### PR TITLE
7511: Integrasjon mot team-fager sin Altinn proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ gradle.beforeProject {
 
 val tokenSupportVersion = "5.0.34"
 val mockOAuth2ServerVersion = "2.2.1"
+val kotlinLoggingVersion = "7.0.3"
 
 repositories {
     mavenCentral()
@@ -41,13 +42,20 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("no.nav.security:token-validation-spring:$tokenSupportVersion")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("no.nav.security:token-validation-spring:${tokenSupportVersion}")
+    implementation("no.nav.security:token-client-spring:${tokenSupportVersion}")
+    implementation("no.nav.security:token-validation-core:${tokenSupportVersion}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11")
+    implementation("io.github.oshai:kotlin-logging-jvm:${kotlinLoggingVersion}")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
     runtimeOnly("org.postgresql:postgresql")
     
@@ -55,7 +63,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOAuth2ServerVersion")
-    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
+    testImplementation("no.nav.security:token-validation-spring-test:${tokenSupportVersion}")
 }
 
 tasks.withType<KotlinCompile> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       POSTGRES_USER: melosys
       POSTGRES_PASSWORD: melosys
     ports:
-      - "5433:5433"
+      - "5433:5432"

--- a/src/main/kotlin/no/nav/melosys/skjema/MelosysSkjemaApiApplication.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/MelosysSkjemaApiApplication.kt
@@ -2,11 +2,9 @@ package no.nav.melosys.skjema
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 
 
 @SpringBootApplication
-@EnableJwtTokenValidation
 class MelosysSkjemaApiApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/no/nav/melosys/skjema/config/AsyncRequestContextConfiguration.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/AsyncRequestContextConfiguration.kt
@@ -1,0 +1,27 @@
+package no.nav.melosys.skjema.config
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.web.filter.RequestContextFilter
+
+@Configuration
+class AsyncRequestContextConfiguration {
+
+    /**
+     * RequestContextListener er allerede registrert av JWT library
+     * Vi trenger bare RequestContextFilter med høy prioritet
+     *
+     * Alternativt kan vi bruke RequestContextFilter med høy prioritet
+     * for å sikre at request context er tilgjengelig i alle tråder
+     */
+    @Bean
+    fun requestContextFilter(): FilterRegistrationBean<RequestContextFilter> {
+        val registration = FilterRegistrationBean<RequestContextFilter>()
+        registration.filter = RequestContextFilter()
+        registration.order = Ordered.HIGHEST_PRECEDENCE
+        registration.setName("requestContextFilter")
+        return registration
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/config/RestControllerInterceptor.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/RestControllerInterceptor.kt
@@ -1,0 +1,41 @@
+package no.nav.melosys.skjema.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import no.nav.melosys.skjema.sikkerhet.context.ThreadLocalAccessInfo
+import org.springframework.web.servlet.HandlerInterceptor
+
+class RestControllerInterceptor : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any
+    ): Boolean {
+        // Skip interceptor for error pages to avoid ThreadLocal conflicts
+        if (request.requestURI == "/error") {
+            return true
+        }
+        
+        ThreadLocalAccessInfo.beforeControllerRequest(
+            request.requestURI,
+        )
+        super.preHandle(request, response, handler)
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?
+    ) {
+        // Skip interceptor for error pages to avoid ThreadLocal conflicts
+        if (request.requestURI == "/error") {
+            return
+        }
+        
+        ThreadLocalAccessInfo.afterControllerRequest(request.requestURI)
+    }
+}
+

--- a/src/main/kotlin/no/nav/melosys/skjema/config/RestControllerInterceptorConfiguration.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/RestControllerInterceptorConfiguration.kt
@@ -1,0 +1,28 @@
+package no.nav.melosys.skjema.config
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+private val logger = KotlinLogging.logger {}
+
+@Configuration
+class RestControllerInterceptorConfiguration : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(restControllerInterceptor())
+    }
+
+    @Bean
+    fun restControllerInterceptor(): RestControllerInterceptor {
+        logger.info { "Registering RestControllerInterceptor" }
+        return RestControllerInterceptor()
+    }
+
+    override fun configurePathMatch(configurer: PathMatchConfigurer) {
+        configurer.setUseTrailingSlashMatch(true)
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/config/TokenSupportConfiguration.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/TokenSupportConfiguration.kt
@@ -1,0 +1,17 @@
+package no.nav.melosys.skjema.config
+
+import no.nav.security.token.support.client.spring.oauth2.ClientConfigurationPropertiesMatcher
+import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
+import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@EnableOAuth2Client(cacheEnabled = true)
+@EnableJwtTokenValidation
+@Configuration
+class TokenSupportConfiguration {
+
+    //TODO: Sjekk om denne er nødvendig.
+    @Bean
+    fun configMatcher() = object : ClientConfigurationPropertiesMatcher {}
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/config/WebMvcAsyncConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/WebMvcAsyncConfig.kt
@@ -1,0 +1,19 @@
+package no.nav.melosys.skjema.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcAsyncConfig : WebMvcConfigurer {
+
+    override fun configureAsyncSupport(configurer: AsyncSupportConfigurer) {
+        // Set timeout for async requests (60 seconds)
+        configurer.setDefaultTimeout(60000)
+        
+        // Register async interceptors if needed
+        // This ensures request context is available in async threads
+        configurer.registerCallableInterceptors()
+        configurer.registerDeferredResultInterceptors()
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/AltinnController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/AltinnController.kt
@@ -1,0 +1,47 @@
+package no.nav.melosys.skjema.controller
+
+import no.nav.melosys.skjema.dto.OrganisasjonDto
+import no.nav.melosys.skjema.service.AltinnService
+import no.nav.security.token.support.core.api.Protected
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+@Protected
+class AltinnController(
+    private val altinnService: AltinnService
+) {
+    
+    companion object {
+        private val log = LoggerFactory.getLogger(AltinnController::class.java)
+    }
+    
+    @GetMapping("/hentTilganger")
+    suspend fun hentTilganger(): ResponseEntity<List<OrganisasjonDto>> {
+        log.info("Henter tilganger for innlogget bruker")
+        
+        val tilganger = altinnService.hentBrukersTilganger()
+        
+        return if (tilganger.isNotEmpty()) {
+            ResponseEntity.ok(tilganger)
+        } else {
+            ResponseEntity.noContent().build()
+        }
+    }
+    
+    @GetMapping("/harTilgang/{orgnr}")
+    suspend fun harTilgang(@PathVariable orgnr: String): ResponseEntity<Boolean> {
+        log.info("Sjekker tilgang til organisasjon: $orgnr")
+        
+        if (!orgnr.matches(Regex("\\d{9}"))) {
+            log.warn("Ugyldig organisasjonsnummer: $orgnr")
+            return ResponseEntity.badRequest().build()
+        }
+        
+        val harTilgang = altinnService.harBrukerTilgang(orgnr)
+        
+        return ResponseEntity.ok(harTilgang)
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/dto/OrganisasjonDto.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/dto/OrganisasjonDto.kt
@@ -1,0 +1,7 @@
+package no.nav.melosys.skjema.dto
+
+data class OrganisasjonDto(
+    val orgnr: String,
+    val navn: String,
+    val organisasjonsform: String
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientProducer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientProducer.kt
@@ -1,0 +1,58 @@
+package no.nav.melosys.skjema.integrasjon.altinn
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.melosys.skjema.integrasjon.felles.TokenXContextExchangeFilter
+import no.nav.melosys.skjema.integrasjon.felles.WebClientConfig
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+private val log = KotlinLogging.logger { }
+
+@Configuration
+class ArbeidsgiverAltinnTilgangerClientProducer(
+    @param:Value("\${arbeidsgiver.altinn.tilganger.url}") private val arbeidsgiverAltinnTilgangerBaseUrl: String,
+) : WebClientConfig {
+
+    companion object {
+        private const val CLIENT_NAME = "arbeidsgiver-altinn-tilganger"
+    }
+
+    @Bean
+    fun arbeidsgiverAltinnTilgangerClient(
+        webClientBuilder: WebClient.Builder,
+        clientConfigurationProperties: ClientConfigurationProperties,
+        oAuth2AccessTokenService: OAuth2AccessTokenService
+    ): WebClient {
+        log.info { "Konfigurerer ArbeidsgiverAltinnTilgangerConsumer med base URL: $arbeidsgiverAltinnTilgangerBaseUrl" }
+
+        val tokenXContextExchangeFilter = TokenXContextExchangeFilter(
+            clientConfigurationProperties,
+            oAuth2AccessTokenService,
+            CLIENT_NAME
+        )
+
+        return webClientBuilder
+            .baseUrl(arbeidsgiverAltinnTilgangerBaseUrl)
+            .filter(tokenXContextExchangeFilter)
+            .filter(errorFilter("Kall mot arbeidsgiver-altinn-tilganger feilet"))
+            .filter(headerFilter())
+            .build()
+    }
+
+    private fun headerFilter(): ExchangeFilterFunction {
+        return ExchangeFilterFunction.ofRequestProcessor { request ->
+            Mono.just(
+                org.springframework.web.reactive.function.client.ClientRequest.from(request)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .build()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerConsumer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerConsumer.kt
@@ -1,0 +1,99 @@
+package no.nav.melosys.skjema.integrasjon.altinn
+
+import kotlinx.coroutines.reactive.awaitSingle
+import no.nav.melosys.skjema.integrasjon.altinn.dto.*
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@Component
+class ArbeidsgiverAltinnTilgangerConsumer(
+    private val arbeidsgiverAltinnTilgangerClient: WebClient,
+    @param:Value("\${altinn.ressurs}") private val altinnRolle: String,
+) {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ArbeidsgiverAltinnTilgangerConsumer::class.java)
+    }
+
+    suspend fun hentTilganger(filter: Filter? = null): List<OrganisasjonMedTilgang> {
+        log.info("Henter Altinn-tilganger med filter: $filter")
+
+        val request = AltinnTilgangerRequest(filter)
+        log.debug("Sender request body: {}", request)
+
+        return try {
+            val response = arbeidsgiverAltinnTilgangerClient.post()
+                .uri("/altinn-tilganger")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(AltinnTilgangerResponse::class.java)
+                .doOnNext { resp ->
+                    log.debug("Mottok response fra Altinn-tilganger: {}", resp)
+                }
+                .awaitSingle()
+
+            if (response.isError) {
+                log.warn("Altinn-tilganger returnerte feil-status")
+                return emptyList()
+            }
+
+            // Finn alle organisasjoner som har den spesifiserte rollen
+            finnOrganisasjonerMedRolle(response, altinnRolle)
+        } catch (e: WebClientResponseException) {
+            log.error("HTTP-feil ved henting av Altinn-tilganger: Status=${e.statusCode}, Body=${e.responseBodyAsString}", e)
+            emptyList()
+        } catch (e: Exception) {
+            log.error("Uventet feil ved henting av Altinn-tilganger: ${e.message}", e)
+            emptyList()
+        }
+    }
+
+    suspend fun harTilgang(orgnr: String): Boolean {
+        log.info("Sjekker tilgang til organisasjon: $orgnr")
+
+        val tilganger = hentTilganger()
+        return tilganger.any { it.orgnr == orgnr }
+    }
+
+    private fun finnOrganisasjonerMedRolle(
+        response: AltinnTilgangerResponse,
+        rolle: String
+    ): List<OrganisasjonMedTilgang> {
+        val organisasjoner = mutableListOf<OrganisasjonMedTilgang>()
+
+        // Sjekk tilgangTilOrgNr-mappingen for å finne organisasjoner med riktig rolle
+        response.tilgangTilOrgNr[rolle]?.forEach { orgnr ->
+            // Finn organisasjonen i hierarkiet
+            finnOrganisasjonIHierarki(response.hierarki, orgnr)?.let { org ->
+                organisasjoner.add(
+                    OrganisasjonMedTilgang(
+                        orgnr = org.orgnr,
+                        navn = org.navn,
+                        organisasjonsform = org.organisasjonsform
+                    )
+                )
+            }
+        }
+
+        return organisasjoner
+    }
+
+    private fun finnOrganisasjonIHierarki(
+        hierarki: List<AltinnTilgang>,
+        orgnr: String
+    ): AltinnTilgang? {
+        for (org in hierarki) {
+            if (org.orgnr == orgnr) {
+                return org
+            }
+            // Søk rekursivt i underenheter
+            finnOrganisasjonIHierarki(org.underenheter, orgnr)?.let {
+                return it
+            }
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgang.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgang.kt
@@ -1,0 +1,14 @@
+package no.nav.melosys.skjema.integrasjon.altinn.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AltinnTilgang(
+    val orgnr: String,
+    val navn: String,
+    val organisasjonsform: String,
+    val altinn2Tilganger: Set<String> = emptySet(),
+    val altinn3Tilganger: Set<String> = emptySet(),
+    val underenheter: List<AltinnTilgang> = emptyList(),
+    val erSlettet: Boolean = false
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgangerRequest.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgangerRequest.kt
@@ -1,0 +1,17 @@
+package no.nav.melosys.skjema.integrasjon.altinn.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AltinnTilgangerRequest(
+    val filter: Filter? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Filter(
+    val altinn2Tilganger: Set<String>? = null,
+    val altinn3Tilganger: Set<String>? = null,
+    val inkluderSlettede: Boolean = false
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgangerResponse.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/AltinnTilgangerResponse.kt
@@ -1,0 +1,11 @@
+package no.nav.melosys.skjema.integrasjon.altinn.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AltinnTilgangerResponse(
+    val isError: Boolean = false,
+    val hierarki: List<AltinnTilgang> = emptyList(),
+    val orgNrTilTilganger: Map<String, Set<String>> = emptyMap(),
+    val tilgangTilOrgNr: Map<String, Set<String>> = emptyMap()
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/OrganisasjonMedTilgang.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/dto/OrganisasjonMedTilgang.kt
@@ -1,0 +1,7 @@
+package no.nav.melosys.skjema.integrasjon.altinn.dto
+
+data class OrganisasjonMedTilgang(
+    val orgnr: String,
+    val navn: String,
+    val organisasjonsform: String
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/GenericContextExchangeFilter.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/GenericContextExchangeFilter.kt
@@ -1,0 +1,50 @@
+package no.nav.melosys.skjema.integrasjon.felles
+
+import no.nav.melosys.skjema.sikkerhet.context.ThreadLocalAccessInfo
+import no.nav.security.token.support.client.core.ClientProperties
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import reactor.core.publisher.Mono
+
+abstract class GenericContextExchangeFilter(
+    protected val clientConfigurationProperties: ClientConfigurationProperties,
+    protected val oAuth2AccessTokenService: OAuth2AccessTokenService,
+    protected val clientName: String
+) : ExchangeFilterFunction {
+    
+    protected val clientProperties: ClientProperties = 
+        clientConfigurationProperties.registration[clientName]
+            ?: throw RuntimeException("Fant ikke OAuth2-config for $clientName")
+    
+    override fun filter(
+        clientRequest: ClientRequest,
+        exchangeFunction: ExchangeFunction
+    ): Mono<ClientResponse> {
+        return exchangeFunction.exchange(
+            withClientRequestBuilder(ClientRequest.from(clientRequest)).build()
+        )
+    }
+    
+    protected fun withClientRequestBuilder(clientRequestBuilder: ClientRequest.Builder): ClientRequest.Builder {
+        return clientRequestBuilder.header(HttpHeaders.AUTHORIZATION, getCorrectToken())
+    }
+    
+    protected fun getCorrectToken(): String {
+        return if (ThreadLocalAccessInfo.shouldUseM2MToken()) {
+            getM2MToken()
+        } else {
+            getUserToken()
+        }
+    }
+    
+    protected abstract fun getM2MToken(): String
+    
+    protected open fun getUserToken(): String {
+        return "Bearer ${oAuth2AccessTokenService.getAccessToken(clientProperties).access_token}"
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/TokenXContextExchangeFilter.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/TokenXContextExchangeFilter.kt
@@ -1,0 +1,26 @@
+package no.nav.melosys.skjema.integrasjon.felles
+
+import com.nimbusds.oauth2.sdk.GrantType
+import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
+import no.nav.security.token.support.client.core.ClientProperties
+import no.nav.security.token.support.client.core.OAuth2GrantType
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+
+class TokenXContextExchangeFilter(
+    clientConfigurationProperties: ClientConfigurationProperties,
+    oAuth2AccessTokenService: OAuth2AccessTokenService,
+    clientName: String) : GenericContextExchangeFilter(clientConfigurationProperties, oAuth2AccessTokenService, clientName) {
+
+    private val clientPropertiesForM2M: ClientProperties = ClientProperties.builder(
+        grantType = GrantType.CLIENT_CREDENTIALS,
+        authentication = clientProperties.authentication
+    )
+        .tokenEndpointUrl(clientProperties.tokenEndpointUrl)
+        .scope(clientProperties.scope)
+        .build()
+
+    override fun getM2MToken(): String {
+        return "Bearer ${oAuth2AccessTokenService.getAccessToken(clientPropertiesForM2M).access_token}"
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.melosys.skjema.integrasjon.felles
+
+import org.springframework.http.HttpStatusCode
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import reactor.core.publisher.Mono
+
+interface WebClientConfig {
+    fun errorFilter(feilmelding: String): ExchangeFilterFunction {
+        return ExchangeFilterFunction.ofResponseProcessor { response ->
+            if (response.statusCode().isError) {
+                response.bodyToMono(String::class.java)
+                    .defaultIfEmpty(response.statusCode().toString())
+                    .flatMap { errorBody ->
+                        Mono.error(lagException(feilmelding, response.statusCode(), errorBody))
+                    }
+            } else {
+                Mono.just(response)
+            }
+        }
+    }
+    
+    fun lagException(feilmelding: String, statusCode: HttpStatusCode, errorBody: String): Exception {
+        return RuntimeException("$feilmelding $statusCode - $errorBody")
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AltinnService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AltinnService.kt
@@ -1,0 +1,46 @@
+package no.nav.melosys.skjema.service
+
+import no.nav.melosys.skjema.dto.OrganisasjonDto
+import no.nav.melosys.skjema.integrasjon.altinn.ArbeidsgiverAltinnTilgangerConsumer
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AltinnService(
+    private val arbeidsgiverAltinnTilgangerConsumer: ArbeidsgiverAltinnTilgangerConsumer
+) {
+    
+    companion object {
+        private val log = LoggerFactory.getLogger(AltinnService::class.java)
+    }
+    
+    suspend fun hentBrukersTilganger(): List<OrganisasjonDto> {
+        log.info("Henter brukers tilganger fra Altinn")
+        
+        return try {
+            val tilganger = arbeidsgiverAltinnTilgangerConsumer.hentTilganger()
+            
+            tilganger.map { org ->
+                OrganisasjonDto(
+                    orgnr = org.orgnr,
+                    navn = org.navn,
+                    organisasjonsform = org.organisasjonsform
+                )
+            }
+        } catch (e: Exception) {
+            log.error("Feil ved henting av tilganger fra Altinn", e)
+            emptyList()
+        }
+    }
+    
+    suspend fun harBrukerTilgang(orgnr: String): Boolean {
+        log.info("Sjekker om bruker har tilgang til organisasjon: $orgnr")
+        
+        return try {
+            arbeidsgiverAltinnTilgangerConsumer.harTilgang(orgnr)
+        } catch (e: Exception) {
+            log.error("Feil ved sjekk av tilgang til organisasjon $orgnr", e)
+            false
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/SpringSubjectHandler.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/SpringSubjectHandler.kt
@@ -1,0 +1,172 @@
+package no.nav.melosys.skjema.sikkerhet.context
+
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+
+@Component
+class SpringSubjectHandler(
+    private val contextHolder: SpringTokenValidationContextHolder
+) : SubjectHandler {
+
+    init {
+        SubjectHandler.set(this)
+    }
+
+    companion object {
+        private const val TOKENX = "tokenx"
+
+        // Standard TokenX claims
+        private const val JWT_TOKEN_CLAIM_PID = "pid"           // Personidentifikator (fødselsnummer)
+        private const val JWT_TOKEN_CLAIM_SUB = "sub"           // Subject - vanligvis samme som pid
+        private const val JWT_TOKEN_CLAIM_CLIENT_ID = "client_id"
+        private const val JWT_TOKEN_CLAIM_ACR = "acr"           // Autentiseringsnivå
+        private const val JWT_TOKEN_CLAIM_IDP = "idp"           // Identity Provider
+
+        // Consumer claims - for organisasjonskontekst
+        private const val JWT_TOKEN_CLAIM_CONSUMER = "consumer"
+        private const val JWT_TOKEN_CLAIM_CONSUMER_AUTHORITY = "authority"
+        private const val JWT_TOKEN_CLAIM_CONSUMER_ID = "ID"
+
+        // Klient-autentiseringsmetode
+        private const val JWT_TOKEN_CLAIM_CLIENT_AMR = "client_amr"
+    }
+
+    override fun getOidcTokenString(): String? {
+        return if (hasValidToken()) tokenXToken()?.tokenAsString else null
+    }
+
+    override fun getUserID(): String? {
+        if (!hasValidToken()) return null
+
+        val token = tokenXToken() ?: return null
+
+        // Sjekk om dette er en maskin-til-maskin token
+        if (isM2MToken(token)) {
+            return getClientId(token)
+        }
+
+        // For person-tokens, bruk pid (personnummer/fødselsnummer)
+        // Fallback til sub hvis pid ikke er tilstede
+        return token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_PID)?.toString()
+            ?: token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_SUB)?.toString()
+    }
+
+    override fun getUserName(): String? {
+        if (!hasValidToken()) return null
+
+        val token = tokenXToken() ?: return null
+
+        // Sjekk om dette er en maskin-til-maskin token
+        if (isM2MToken(token)) {
+            return getClientId(token)
+        }
+
+        // TokenX tokens fra ID-porten har vanligvis ikke en name claim
+        // Returner null eller eventuelt slå opp navnet fra en annen tjeneste ved bruk av pid
+        return null
+    }
+
+    override fun getGroups(): List<String> {
+        // TokenX tokens har vanligvis ikke grupper
+        // Hvis du trenger autorisasjon, kan du slå dette opp fra en annen tjeneste
+        // eller bruke ACR-nivået for grunnleggende autorisasjonsbeslutninger
+        return emptyList()
+    }
+
+    /**
+     * Hent autentiseringsnivået fra tokenet
+     * ID-porten bruker Level3 og Level4 for forskjellige autentiseringsstyrker
+     */
+    override fun getAuthenticationLevel(): String? {
+        if (!hasValidToken()) return null
+        return tokenXToken()?.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_ACR)?.toString()
+    }
+
+    /**
+     * Hent identitetsleverandøren som autentiserte brukeren
+     */
+    override fun getIdentityProvider(): String? {
+        if (!hasValidToken()) return null
+        return tokenXToken()?.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_IDP)?.toString()
+    }
+
+    /**
+     * Hent consumer-organisasjonsinformasjon hvis tilstede
+     * Returnerer et par med (authority, ID) eller null
+     */
+    override fun getConsumerInfo(): Pair<String, String>? {
+        if (!hasValidToken()) return null
+
+        val token = tokenXToken() ?: return null
+        val consumerClaim = token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_CONSUMER) as? Map<*, *>
+            ?: return null
+
+        val authority = consumerClaim[JWT_TOKEN_CLAIM_CONSUMER_AUTHORITY]?.toString()
+        val id = consumerClaim[JWT_TOKEN_CLAIM_CONSUMER_ID]?.toString()
+
+        return if (authority != null && id != null) {
+            Pair(authority, id)
+        } else null
+    }
+
+    /**
+     * Hent organisasjonsnummeret fra consumer info hvis det eksisterer
+     * Formatet er typisk "0192:orgNummer"
+     *
+     * TODO: Sjekk om noe annet enn orgnr til NAV kommer ut her.
+     */
+    override fun getOrganizationNumber(): String? {
+        val consumerInfo = getConsumerInfo() ?: return null
+        val id = consumerInfo.second
+
+        // Ekstraher organisasjonsnummer fra format som "0192:889640782"
+        return if (id.contains(":")) {
+            id.substringAfter(":")
+        } else {
+            id
+        }
+    }
+
+    /**
+     * Sjekk om dette er en maskin-til-maskin token
+     * M2M tokens bruker typisk client credentials flow med private_key_jwt
+     */
+    private fun isM2MToken(token: JwtToken): Boolean {
+        val clientAmr = token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_CLIENT_AMR)?.toString()
+        val pid = token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_PID)
+
+        // M2M tokens har typisk private_key_jwt som client_amr og ingen pid
+        return clientAmr == "private_key_jwt" && pid == null
+    }
+
+    /**
+     * Hent klient-ID fra tokenet
+     */
+    private fun getClientId(token: JwtToken): String? {
+        return token.jwtTokenClaims?.get(JWT_TOKEN_CLAIM_CLIENT_ID)?.toString()
+    }
+
+    private fun hasValidToken(): Boolean {
+        return try {
+            RequestContextHolder.getRequestAttributes() != null &&
+                    getValidationContext().hasTokenFor(TOKENX)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun tokenXToken(): JwtToken? {
+        return try {
+            getValidationContext().getJwtToken(TOKENX)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun getValidationContext(): TokenValidationContext {
+        return contextHolder.getTokenValidationContext()
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/SubjectHandler.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/SubjectHandler.kt
@@ -1,0 +1,56 @@
+package no.nav.melosys.skjema.sikkerhet.context
+
+interface SubjectHandler {
+    fun getOidcTokenString(): String?
+    fun getUserID(): String?
+    fun getUserName(): String?
+    fun getGroups(): List<String>
+
+    // Ekstra metoder for TokenX-spesifikk informasjon
+    fun getAuthenticationLevel(): String? = null
+    fun getIdentityProvider(): String? = null
+    fun getConsumerInfo(): Pair<String, String>? = null
+    fun getOrganizationNumber(): String? = null
+
+    companion object {
+        private var subjectHandler: SubjectHandler? = null
+
+        fun getInstance(): SubjectHandler {
+            return subjectHandler ?: throw IllegalStateException("SubjectHandler ikke initialisert")
+        }
+
+        fun set(handler: SubjectHandler) {
+            subjectHandler = handler
+        }
+
+        /**
+         * Hent brukerens personnummer (fødselsnummer)
+         * Dette er primæridentifikatoren for brukere autentisert via ID-porten/TokenX
+         */
+        fun getSaksbehandlerIdent(): String? {
+            return getInstance().getUserID()
+        }
+
+        /**
+         * Hent autentiseringsnivået (f.eks. Level3, Level4)
+         * Level4 er det høyeste nivået som krever BankID eller tilsvarende
+         */
+        fun getAuthLevel(): String? {
+            val handler = getInstance()
+            return if (handler is SpringSubjectHandler) {
+                handler.getAuthenticationLevel()
+            } else null
+        }
+
+        /**
+         * Hent organisasjonsnummeret hvis det finnes i tokenet
+         * Dette ekstraheres fra consumer claim
+         */
+        fun getOrgNumber(): String? {
+            val handler = getInstance()
+            return if (handler is SpringSubjectHandler) {
+                handler.getOrganizationNumber()
+            } else null
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/ThreadLocalAccessInfo.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/context/ThreadLocalAccessInfo.kt
@@ -1,0 +1,73 @@
+package no.nav.melosys.skjema.sikkerhet.context
+
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+object ThreadLocalAccessInfo {
+    private val log = LoggerFactory.getLogger(ThreadLocalAccessInfo::class.java)
+
+    private val threadLocalStorage = ThreadLocal.withInitial { AccessInfo() }
+
+    data class AccessInfo(
+        var requestUri: String? = null,
+        var processId: UUID? = null,
+        var processName: String? = null,
+        var isAdminRequest: Boolean = false,
+        var saksbehandler: String? = null,
+        var saksbehandlerNavn: String? = null
+    ) {
+        fun isFromWebRequest(): Boolean = requestUri != null
+        fun isFromProcess(): Boolean = processId != null
+        fun isFromAdminRequest(): Boolean = isAdminRequest
+    }
+
+    fun getProcessId(): UUID? {
+        return threadLocalStorage.get().processId
+    }
+
+    //TODO: Implementer admin-request-sjekk senere
+    fun beforeControllerRequest(requestUri: String, isAdminRequest: Boolean = false) {
+        val accessInfo = threadLocalStorage.get()
+        if (accessInfo.requestUri != null) {
+            throw IllegalStateException("Vi skulle ikke ha en thread local requestUri før controller request")
+        }
+        accessInfo.requestUri = requestUri
+        accessInfo.isAdminRequest = isAdminRequest
+    }
+
+    fun afterControllerRequest(requestUri: String) {
+        log.debug("Etter en controller request: {}", threadLocalStorage.get())
+
+        val accessInfo = threadLocalStorage.get()
+        if (accessInfo.requestUri != requestUri) {
+            throw IllegalStateException(
+                "Start og slutt request skal være like\n" +
+                        "${accessInfo.requestUri} != $requestUri"
+            )
+        }
+        threadLocalStorage.remove()
+    }
+
+    fun shouldUseM2MToken(): Boolean {
+        val accessInfo = threadLocalStorage.get()
+
+        // M2M tokens brukes kun når vi eksplisitt har behov for det
+        // For nå returnerer vi false siden vi primært bruker OBO-tokens
+        if (accessInfo.isFromProcess()) {
+            return true
+        }
+
+        if (!accessInfo.isFromWebRequest()) {
+            val stackTrace = Thread.currentThread().stackTrace
+            val stackTraceAsString = stackTrace.joinToString("\n") { it.toString() }
+            log.warn("Kall har ikke blitt registrert fra RestController eller Prosess\n$stackTraceAsString")
+            return false
+        }
+
+        return accessInfo.isFromAdminRequest()
+    }
+
+    fun getInfo(): String {
+        return threadLocalStorage.get().toString()
+    }
+}

--- a/src/main/resources/application-local-q2.yml
+++ b/src/main/resources/application-local-q2.yml
@@ -1,0 +1,11 @@
+# Config for q2 integrasjoner, men lokal database
+
+DB_JDBC_URL: 'jdbc:postgresql://localhost:5433/melosys_skjema?user=melosys&password=melosys'
+TOKEN_X_WELL_KNOWN_URL: https://tokenx.dev-gcp.nav.cloud.nais.io/.well-known/oauth-authorization-server
+TOKEN_X_CLIENT_ID: dev-gcp:teammelosys:melosys-skjema-api
+TOKEN_X_TOKEN_ENDPOINT: https://tokenx.dev-gcp.nav.cloud.nais.io/token
+TOKEN_X_JWKS_URI: https://tokenx.dev-gcp.nav.cloud.nais.io/jwks
+TOKENX_AUDIENCE_ARBEIDSGIVER_ALTINN_TILGANGER: dev-gcp:fager:arbeidsgiver-altinn-tilganger
+ALTINN_RESSURS: test-fager
+ARBEIDSGIVER_ALTINN_TILGANGER_URL: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no
+TOKEN_X_PRIVATE_JWK: Ikke lov å ta med i git. Autohenting av dette fikses i en annen PR.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,25 @@ no.nav.security.jwt:
     tokenx:
       discovery-url: ${TOKEN_X_WELL_KNOWN_URL}
       accepted_audience: ${TOKEN_X_CLIENT_ID}
+  client:
+    registration:
+      arbeidsgiver-altinn-tilganger:
+        token-endpoint-url: ${TOKEN_X_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+        authentication:
+          client-id: ${TOKEN_X_CLIENT_ID}
+          client-jwk: ${TOKEN_X_PRIVATE_JWK}
+          client-auth-method: private_key_jwt
+        token-exchange:
+          audience: ${TOKENX_AUDIENCE_ARBEIDSGIVER_ALTINN_TILGANGER}
+
+arbeidsgiver:
+  altinn:
+    tilganger:
+      url: ${ARBEIDSGIVER_ALTINN_TILGANGER_URL}
+
+altinn:
+  ressurs: ${ALTINN_RESSURS:test-fager}
 
 logging:
   level:


### PR DESCRIPTION
 Implementerer integrasjon mot Team Fager sin arbeidsgiver-altinn-tilganger tjeneste for å hente brukerens Altinn-tilganger. Løsningen bruker TokenX med On-Behalf-Of (OBO) tokens for sikker autentisering og autorisasjon.

  - Legger til støtte for å hente brukerens organisasjonstilganger fra Altinn
  - Implementerer TokenX OBO-token exchange for sikker API-kommunikasjon
  - Eksponerer to nye API-endepunkter for frontend:
    - GET /api/hentTilganger - Returnerer liste over organisasjoner brukeren har tilgang til
    - GET /api/harTilgang/{orgnr} - Sjekker om bruker har tilgang til spesifikk organisasjon

Bruker token-support, men med eget filter som passer til WebClients.