### PR TITLE
Separate endepunkt for arbeidstaker og arbeidsgiver opprettelse og ruteendringer

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/SkjemaController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/SkjemaController.kt
@@ -16,7 +16,7 @@ import java.util.*
 private val log = KotlinLogging.logger { }
 
 @RestController
-@RequestMapping("/api/skjema")
+@RequestMapping("/api/skjema/utsendt-arbeidstaker")
 @Tag(name = "Skjema", description = "placeholder")
 @Protected
 class SkjemaController(
@@ -32,11 +32,11 @@ class SkjemaController(
         return ResponseEntity.ok(skjemaer)
     }
 
-    @PostMapping
+    @PostMapping("/arbeidsgiver")
     @Operation(summary = "Create new skjema")
     @ApiResponse(responseCode = "201", description = "Skjema created")
-    fun createSkjema(@RequestBody request: CreateSkjemaRequest): ResponseEntity<Any> {
-        val skjema = skjemaService.createSkjema(request)
+    fun createSkjemaArbeidsgiverDel(@RequestBody request: CreateArbeidsgiverSkjemaRequest): ResponseEntity<Any> {
+        val skjema = skjemaService.createSkjemaArbeidsgiverDel(request)
         return ResponseEntity.status(201).body(skjema)
     }
 
@@ -79,7 +79,7 @@ class SkjemaController(
     }
 
     // Arbeidsgiver Flow Endpoints
-    @PostMapping("/{skjemaId}/arbeidsgiver/arbeidsgiveren")
+    @PostMapping("/arbeidsgiver/{skjemaId}/arbeidsgiveren")
     @Operation(summary = "Register arbeidsgiver information")
     @ApiResponse(responseCode = "200", description = "Arbeidsgiver information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
@@ -89,7 +89,7 @@ class SkjemaController(
         return ResponseEntity.ok(skjema)
     }
 
-    @PostMapping("/{skjemaId}/arbeidsgiver/virksomhet-i-norge")
+    @PostMapping("/arbeidsgiver/{skjemaId}/virksomhet-i-norge")
     @Operation(summary = "Register virksomhet information")
     @ApiResponse(responseCode = "200", description = "Virksomhet information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
@@ -99,7 +99,7 @@ class SkjemaController(
         return ResponseEntity.ok(skjema)
     }
 
-    @PostMapping("/{skjemaId}/arbeidsgiver/utenlandsoppdraget")
+    @PostMapping("/arbeidsgiver/{skjemaId}/utenlandsoppdraget")
     @Operation(summary = "Register utenlandsoppdrag information")
     @ApiResponse(responseCode = "200", description = "Utenlandsoppdrag information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
@@ -109,7 +109,7 @@ class SkjemaController(
         return ResponseEntity.ok(skjema)
     }
 
-    @PostMapping("/{skjemaId}/arbeidsgiver/arbeidstakerens-lonn")
+    @PostMapping("/arbeidsgiver/{skjemaId}/arbeidstakerens-lonn")
     @Operation(summary = "Register arbeidstaker lønn information")
     @ApiResponse(responseCode = "200", description = "Arbeidstaker lønn information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
@@ -119,9 +119,9 @@ class SkjemaController(
         return ResponseEntity.ok(skjema)
     }
 
-    @PostMapping("/{skjemaId}/arbeidsgiver/oppsummering")
-    @Operation(summary = "Submit arbeidsgiver oppsummering")
-    @ApiResponse(responseCode = "200", description = "Oppsummering submitted")
+    @PostMapping("/arbeidsgiver/{skjemaId}/submit")
+    @Operation(summary = "Submit arbeidsgiver skjema")
+    @ApiResponse(responseCode = "200", description = "Skjema submitted")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
     fun submitArbeidsgiverRequest(@PathVariable skjemaId: UUID, @RequestBody request: SubmitSkjemaRequest): ResponseEntity<Any> {
         log.info { "Submitting arbeidsgiver oppsummering at ${request.submittedAt}" }
@@ -130,7 +130,15 @@ class SkjemaController(
     }
 
     // Arbeidstaker Flow Endpoints
-    @PostMapping("/{skjemaId}/arbeidstaker/arbeidstakeren")
+    @PostMapping("/arbeidstaker")
+    @Operation(summary = "Create new skjema")
+    @ApiResponse(responseCode = "201", description = "Skjema created")
+    fun createSkjemaArbeidstakerDel(@RequestBody request: CreateArbeidstakerSkjemaRequest): ResponseEntity<Any> {
+        val skjema = skjemaService.createSkjemaArbeidstakerDel(request)
+        return ResponseEntity.status(201).body(skjema)
+    }
+
+    @PostMapping("/arbeidstaker/{skjemaId}/arbeidstakeren")
     @Operation(summary = "Register arbeidstaker information")
     @ApiResponse(responseCode = "200", description = "Arbeidstaker information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")
@@ -139,7 +147,7 @@ class SkjemaController(
         return ResponseEntity.ok(skjema)
     }
 
-    @PostMapping("/{skjemaId}/arbeidstaker/skatteforhold-og-inntekt")
+    @PostMapping("/arbeidstaker/{skjemaId}/skatteforhold-og-inntekt")
     @Operation(summary = "Register skatteforhold og inntekt information")
     @ApiResponse(responseCode = "200", description = "Skatteforhold og inntekt information registered")
     @ApiResponse(responseCode = "404", description = "Skjema not found")

--- a/src/main/kotlin/no/nav/melosys/skjema/dto/CreateArbeidsgiverSkjemaRequest.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/dto/CreateArbeidsgiverSkjemaRequest.kt
@@ -1,6 +1,5 @@
 package no.nav.melosys.skjema.dto
 
-data class CreateSkjemaRequest(
-    val fnr: String,
+data class CreateArbeidsgiverSkjemaRequest(
     val orgnr: String
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/dto/CreateArbeidstakerSkjemaRequest.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/dto/CreateArbeidstakerSkjemaRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.melosys.skjema.dto
+
+data class CreateArbeidstakerSkjemaRequest(
+    val fnr: String
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
@@ -22,11 +22,11 @@ class Skjema(
     @Column(name = "type", nullable = false)
     val type: String = "A1",
 
-    @Column(name = "fnr", nullable = false, length = 11)
-    val fnr: String,
+    @Column(name = "fnr", length = 11)
+    val fnr: String? = null,
 
-    @Column(name = "orgnr", nullable = false, length = 9)
-    val orgnr: String,
+    @Column(name = "orgnr", length = 9)
+    val orgnr: String? = null,
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "data")

--- a/src/main/kotlin/no/nav/melosys/skjema/service/SkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/SkjemaService.kt
@@ -26,12 +26,22 @@ class SkjemaService(
     private val subjectHandler: SubjectHandler
 ) {
 
-    fun createSkjema(request: CreateSkjemaRequest): Skjema {
+    fun createSkjemaArbeidsgiverDel(request: CreateArbeidsgiverSkjemaRequest): Skjema {
+        val currentUser = subjectHandler.getUserID()
+        val skjema = Skjema(
+            status = SkjemaStatus.UTKAST,
+            orgnr = request.orgnr,
+            opprettetAv = currentUser,
+            endretAv = currentUser
+        )
+        return skjemaRepository.save(skjema)
+    }
+
+    fun createSkjemaArbeidstakerDel(request: CreateArbeidstakerSkjemaRequest): Skjema {
         val currentUser = subjectHandler.getUserID()
         val skjema = Skjema(
             status = SkjemaStatus.UTKAST,
             fnr = request.fnr,
-            orgnr = request.orgnr,
             opprettetAv = currentUser,
             endretAv = currentUser
         )

--- a/src/main/resources/db/migration/V3__Make_fnr_orgnr_nullable.sql
+++ b/src/main/resources/db/migration/V3__Make_fnr_orgnr_nullable.sql
@@ -1,0 +1,7 @@
+-- Make fnr and orgnr columns nullable
+ALTER TABLE skjema ALTER COLUMN fnr DROP NOT NULL;
+ALTER TABLE skjema ALTER COLUMN orgnr DROP NOT NULL;
+
+-- Add constraint to ensure at least one of fnr or orgnr is set
+ALTER TABLE skjema ADD CONSTRAINT check_fnr_or_orgnr_not_null 
+    CHECK (fnr IS NOT NULL OR orgnr IS NOT NULL);

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/ProtectedEndpointsApiTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/ProtectedEndpointsApiTest.kt
@@ -39,11 +39,19 @@ class ProtectedEndpointsApiTes: ApiTestBase() {
         Arguments.of(HttpMethod.GET, "/api/auth/representasjoner"),
 
         // SkjemaController
-        Arguments.of(HttpMethod.GET, "/api/skjema"),
-        Arguments.of(HttpMethod.POST, "/api/skjema"),
-        Arguments.of(HttpMethod.GET, "/api/skjema/123"),
-        Arguments.of(HttpMethod.POST, "/api/skjema/123/submit"),
-        Arguments.of(HttpMethod.GET, "/api/skjema/123/pdf"),
+        Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidstaker"),
+        Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker/123"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/123/submit"),
+        Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker/123/pdf"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver/123/arbeidsgiveren"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver/123/virksomhet-i-norge"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver/123/utenlandsoppdraget"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver/123/arbeidstakerens-lonn"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidsgiver/123/submit"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidstaker/123/arbeidstakeren"),
+        Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/arbeidstaker/123/skatteforhold-og-inntekt"),
 
         // PrefillController
         Arguments.of(HttpMethod.POST, "/api/preutfyll/person"),

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/SkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/SkjemaControllerIntegrationTest.kt
@@ -50,7 +50,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("GET /api/skjema skal returnere liste over brukerens skjemaer")
+    @DisplayName("GET /api/skjema/utsendt-arbeidstaker skal returnere liste over brukerens skjemaer")
     fun `GET skjema skal returnere liste over brukerens skjemaer`() {
         val skjema1 = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val skjema2 = createTestSkjema(testPid, "987654321", SkjemaStatus.SENDT)
@@ -60,7 +60,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         
         val token = createTokenForUser(testPid)
         webTestClient.get()
-            .uri("/api/skjema")
+            .uri("/api/skjema/utsendt-arbeidstaker")
             .header("Authorization", "Bearer $token")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
@@ -77,7 +77,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("POST /api/skjema skal opprette nytt skjema")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/arbeidsgiver skal opprette nytt skjema")
     fun `POST skjema skal opprette nytt skjema`() {
         val token = createTokenForUser(testPid)
         val createRequest = mapOf(
@@ -86,7 +86,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         )
         
         webTestClient.post()
-            .uri("/api/skjema")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidsgiver")
             .header("Authorization", "Bearer $token")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(createRequest)
@@ -97,7 +97,6 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
             .consumeWith { response ->
                 val responseBody = response.responseBody
                 responseBody.shouldNotBeNull()
-                responseBody["fnr"] shouldBe testPid
                 responseBody["orgnr"] shouldBe testOrgnr
                 responseBody["status"] shouldBe "UTKAST"
                 responseBody["id"].toString().shouldNotBeBlank()
@@ -105,7 +104,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("GET /api/skjema/{id} skal returnere spesifikt skjema")
+    @DisplayName("GET /api/skjema/utsendt-arbeidstaker/{id} skal returnere spesifikt skjema")
     fun `GET skjema by id skal returnere spesifikt skjema`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -113,7 +112,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         val token = createTokenForUser(testPid)
         
         webTestClient.get()
-            .uri("/api/skjema/${savedSkjema.id}")
+            .uri("/api/skjema/utsendt-arbeidstaker/${savedSkjema.id}")
             .header("Authorization", "Bearer $token")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
@@ -131,13 +130,13 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("GET /api/skjema/{id} skal returnere 404 for ikke-eksisterende skjema")
+    @DisplayName("GET /api/skjema/utsendt-arbeidstaker/{id} skal returnere 404 for ikke-eksisterende skjema")
     fun `GET skjema by id skal returnere 404 for ikke-eksisterende skjema`() {
         val token = createTokenForUser(testPid)
         val nonExistentId = UUID.randomUUID()
         
         webTestClient.get()
-            .uri("/api/skjema/$nonExistentId")
+            .uri("/api/skjema/utsendt-arbeidstaker/$nonExistentId")
             .header("Authorization", "Bearer $token")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
@@ -146,7 +145,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     
     
     @Test
-    @DisplayName("POST /api/skjema/{id}/submit skal sende skjema og trigge notifikasjoner")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/{id}/submit skal sende skjema og trigge notifikasjoner")
     fun `POST submit skjema skal sende skjema og trigge notifikasjoner`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -154,7 +153,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         val token = createTokenForUser(testPid)
         
         webTestClient.post()
-            .uri("/api/skjema/${savedSkjema.id}/submit")
+            .uri("/api/skjema/utsendt-arbeidstaker/${savedSkjema.id}/submit")
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
@@ -163,7 +162,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("GET /api/skjema/{id}/pdf skal returnere PDF response")
+    @DisplayName("GET /api/skjema/utsendt-arbeidstaker/{id}/pdf skal returnere PDF response")
     fun `GET pdf skal returnere PDF response`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.SENDT)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -171,14 +170,14 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         val token = createTokenForUser(testPid)
         
         webTestClient.get()
-            .uri("/api/skjema/${savedSkjema.id}/pdf")
+            .uri("/api/skjema/utsendt-arbeidstaker/${savedSkjema.id}/pdf")
             .header("Authorization", "Bearer $token")
             .exchange()
             .expectStatus().isOk
     }
     
     @Test
-    @DisplayName("POST /api/skjema/{id}/arbeidsgiver/arbeidsgiveren skal lagre arbeidsgiver info")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/arbeidsgiver/{id}/arbeidsgiveren skal lagre arbeidsgiver info")
     fun `POST arbeidsgiver info skal lagre arbeidsgiver info`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -190,7 +189,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         )
         
         webTestClient.post()
-            .uri("/api/skjema/${savedSkjema.id}/arbeidsgiver/arbeidsgiveren")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidsgiver/${savedSkjema.id}/arbeidsgiveren")
             .header("Authorization", "Bearer $token")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(arbeidsgiverRequest)
@@ -207,7 +206,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("POST /api/skjema/{id}/arbeidsgiver/virksomhet-i-norge skal lagre virksomhet info")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/arbeidsgiver/{id}/virksomhet-i-norge skal lagre virksomhet info")
     fun `POST virksomhet info skal lagre virksomhet info`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -220,7 +219,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         )
         
         webTestClient.post()
-            .uri("/api/skjema/${savedSkjema.id}/arbeidsgiver/virksomhet-i-norge")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidsgiver/${savedSkjema.id}/virksomhet-i-norge")
             .header("Authorization", "Bearer $token")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(virksomhetRequest)
@@ -230,7 +229,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("POST /api/skjema/{id}/arbeidsgiver/oppsummering skal sende inn skjema")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/arbeidsgiver/{id}/submit skal sende inn skjema")
     fun `POST oppsummering skal sende inn skjema`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -242,7 +241,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         )
         
         webTestClient.post()
-            .uri("/api/skjema/${savedSkjema.id}/arbeidsgiver/oppsummering")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidsgiver/${savedSkjema.id}/submit")
             .header("Authorization", "Bearer $token")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(oppsummeringRequest)
@@ -258,7 +257,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
     }
     
     @Test
-    @DisplayName("POST /api/skjema/{id}/arbeidstaker/arbeidstakeren skal lagre arbeidstaker info")
+    @DisplayName("POST /api/skjema/utsendt-arbeidstaker/arbeidstaker/{id}/arbeidstakeren skal lagre arbeidstaker info")
     fun `POST arbeidstaker info skal lagre arbeidstaker info`() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
@@ -275,7 +274,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         )
         
         webTestClient.post()
-            .uri("/api/skjema/${savedSkjema.id}/arbeidstaker/arbeidstakeren")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidstaker/${savedSkjema.id}/arbeidstakeren")
             .header("Authorization", "Bearer $token")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(arbeidstakerRequest)
@@ -292,7 +291,7 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         
         val token = createTokenForUser(testPid)
         webTestClient.get()
-            .uri("/api/skjema/${savedSkjema.id}")
+            .uri("/api/skjema/utsendt-arbeidstaker/${savedSkjema.id}")
             .header("Authorization", "Bearer $token")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
@@ -305,18 +304,18 @@ class SkjemaControllerIntegrationTest : ApiTestBase() {
         val skjema = createTestSkjema(testPid, testOrgnr, SkjemaStatus.UTKAST)
         val savedSkjema = skjemaRepository.save(skjema)
         webTestClient.get()
-            .uri("/api/skjema")
+            .uri("/api/skjema/utsendt-arbeidstaker")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isUnauthorized
         webTestClient.post()
-            .uri("/api/skjema")
+            .uri("/api/skjema/utsendt-arbeidstaker/arbeidsgiver")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(mapOf("fnr" to testPid, "orgnr" to testOrgnr))
             .exchange()
             .expectStatus().isUnauthorized
         webTestClient.get()
-            .uri("/api/skjema/${savedSkjema.id}")
+            .uri("/api/skjema/utsendt-arbeidstaker/${savedSkjema.id}")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isUnauthorized


### PR DESCRIPTION
- Endret ruter til å ha prefiks `/api/skjema/utsendt-arbeidstaker/arbeidsgiver` og `/api/skjema/utsendt-arbeidstaker/arbeidstaker`
- Laget separate endepunkter og request-objekter for opprettelse av arbeidstaker og arbeidsgivers del
- Gjort fnr og orgnr kolonnene nullable siden man kun har en av de av gangen (slik vi gjør det per nå)