### PR TITLE
MELOSYS-8030 Mock-storage for vedlegg i local-profil

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/storage/GcpStorageClient.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/storage/GcpStorageClient.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service
 private val log = KotlinLogging.logger { }
 
 @Service
-@Profile("!local-q1")
+@Profile("!local-q1 & !local")
 class GcpStorageClient(
     @param:Value("\${vedlegg.bucket-name}") private val bucketName: String
 ) : VedleggStorageClient {

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/storage/MockStorageClient.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/storage/MockStorageClient.kt
@@ -1,0 +1,52 @@
+package no.nav.melosys.skjema.integrasjon.storage
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+private val log = KotlinLogging.logger { }
+
+/**
+ * Storage-klient som lagrer vedlegg via melosys-mock (lokal utvikling).
+ * Brukes i `local`-profil — sender ingen trafikk ut av PC-en.
+ */
+@Service
+@Profile("local")
+class MockStorageClient(
+    @param:Value("\${vedlegg.mock-storage-url}") private val baseUrl: String
+) : VedleggStorageClient {
+
+    private val webClient: WebClient = WebClient.builder().baseUrl(baseUrl).build()
+
+    override fun lastOpp(storageReferanse: String, data: ByteArray, contentType: String) {
+        log.info { "Mock-storage: laster opp '$storageReferanse' (${data.size} bytes)" }
+        webClient.put()
+            .uri { it.queryParam("ref", storageReferanse).build() }
+            .contentType(MediaType.parseMediaType(contentType))
+            .bodyValue(data)
+            .retrieve()
+            .toBodilessEntity()
+            .block()
+    }
+
+    override fun slett(storageReferanse: String) {
+        log.info { "Mock-storage: sletter '$storageReferanse'" }
+        webClient.delete()
+            .uri { it.queryParam("ref", storageReferanse).build() }
+            .retrieve()
+            .toBodilessEntity()
+            .block()
+    }
+
+    override fun hent(storageReferanse: String): ByteArray {
+        log.info { "Mock-storage: henter '$storageReferanse'" }
+        return webClient.get()
+            .uri { it.queryParam("ref", storageReferanse).build() }
+            .retrieve()
+            .bodyToMono(ByteArray::class.java)
+            .block() ?: error("Vedlegg '$storageReferanse' ikke funnet i mock-storage")
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,6 +36,7 @@ REPR_URL: http://localhost:8083/repr
 AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: dev-fss:teammelosys:melosys
 VEDLEGG_BUCKET_NAME: melosys-skjema-vedlegg-local
+VEDLEGG_MOCK_STORAGE_URL: http://localhost:8083/vedlegg-storage
 CLAMAV_URL: http://localhost:8083/clamav
 
 # Override token exchange clients to use client_secret_basic locally

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,6 +151,7 @@ varsling:
 
 vedlegg:
   bucket-name: ${VEDLEGG_BUCKET_NAME}
+  mock-storage-url: ${VEDLEGG_MOCK_STORAGE_URL:http://localhost:8083/vedlegg-storage}
 
 clamav:
   url: ${CLAMAV_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,7 +151,7 @@ varsling:
 
 vedlegg:
   bucket-name: ${VEDLEGG_BUCKET_NAME}
-  mock-storage-url: ${VEDLEGG_MOCK_STORAGE_URL:http://localhost:8083/vedlegg-storage}
+  mock-storage-url: ${VEDLEGG_MOCK_STORAGE_URL}
 
 clamav:
   url: ${CLAMAV_URL}


### PR DESCRIPTION
MockStorageClient kaller melosys-mock i `local`-profil. GcpStorageClient ekskluderer `local` så ingen utgående trafikk skjer lokalt.

https://github.com/navikt/melosys-docker-compose/pull/139