### PR TITLE
Oppgrader dependencies til siste stabile versjoner

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm")
     kotlin("plugin.spring")
@@ -26,7 +26,7 @@ gradle.beforeProject {
     }
 }
 
-val tokenSupportVersion = "6.0.5"
+val tokenSupportVersion = "6.0.6"
 val mockOAuth2ServerVersion = "3.0.1"
 val kotlinLoggingVersion = "8.0.01"
 val kotestVersion = "6.1.11"
@@ -78,7 +78,7 @@ dependencies {
     implementation("io.github.openhtmltopdf:openhtmltopdf-pdfbox:1.1.37")
 
     // GCP Cloud Storage for vedlegg
-    implementation("com.google.cloud:google-cloud-storage:2.66.0")
+    implementation("com.google.cloud:google-cloud-storage:2.67.0")
 
     runtimeOnly("org.postgresql:postgresql")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
 
-kotlinVersion=2.3.20
+kotlinVersion=2.3.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/melosys-skjema-api-types/build.gradle.kts
+++ b/melosys-skjema-api-types/build.gradle.kts
@@ -7,7 +7,7 @@ group = "no.nav.melosys"
 
 val jacksonVersion = "2.21"
 val jakartaValidationVersion = "3.1.1"
-val swaggerVersion = "2.2.47"
+val swaggerVersion = "2.2.49"
 val junitVersion = "6.0.3"
 val kotestVersion = "6.1.11"
 


### PR DESCRIPTION
## Endringer

- Spring Boot 4.0.5 → 4.0.6
- Kotlin 2.3.20 → 2.3.21
- token-support 6.0.5 → 6.0.6
- google-cloud-storage 2.66.0 → 2.67.0
- swagger-annotations-jakarta 2.2.47 → 2.2.49
- Gradle wrapper 9.4.1 → 9.5.0

Kun patch/minor bumps på stabile versjoner. Holder oss unna pre-release (Spring Boot 4.1, Kotlin 2.4, Wiremock 4 osv.).

## Test plan

- [x] `./gradlew build` grønn (554 tester, 0 feil)