### PR TITLE
8030: Fjern retention policy fra vedlegg-buckets

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -53,9 +53,8 @@ spec:
         cascadingDelete: false
     buckets:
       - name: melosys-skjema-vedlegg-dev
-        retentionPeriodDays: 30
         lifecycleCondition:
-          age: 30
+          age: 365
           withState: ANY
   tokenx:
     enabled: true

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -53,9 +53,8 @@ spec:
         cascadingDelete: false
     buckets:
       - name: melosys-skjema-vedlegg-prod
-        retentionPeriodDays: 30
         lifecycleCondition:
-          age: 30
+          age: 365
           withState: ANY
   tokenx:
     enabled: true

--- a/src/main/kotlin/no/nav/melosys/skjema/service/VedleggService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/VedleggService.kt
@@ -3,6 +3,7 @@ package no.nav.melosys.skjema.service
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.UUID
 import no.nav.melosys.skjema.entity.Vedlegg
+import no.nav.melosys.skjema.exception.SkjemaErIkkeRedigerbartException
 import no.nav.melosys.skjema.extensions.toVedleggDto
 import no.nav.melosys.skjema.integrasjon.clamav.ClamAvClient
 import no.nav.melosys.skjema.types.vedlegg.VedleggFiltype
@@ -33,8 +34,8 @@ class VedleggService(
     fun lastOpp(skjemaId: UUID, fil: MultipartFile): VedleggDto {
         val skjema = utsendtArbeidstakerService.hentSkjemaMedLesetilgang(skjemaId)
 
-        require(skjema.status == SkjemaStatus.UTKAST) {
-            "Kan kun laste opp vedlegg til skjemaer med status UTKAST"
+        if (skjema.status != SkjemaStatus.UTKAST) {
+            throw SkjemaErIkkeRedigerbartException()
         }
 
         val antallEksisterende = vedleggRepository.countBySkjemaId(skjemaId)
@@ -100,8 +101,8 @@ class VedleggService(
     fun slett(skjemaId: UUID, vedleggId: UUID) {
         val skjema = utsendtArbeidstakerService.hentSkjemaMedLesetilgang(skjemaId)
 
-        require(skjema.status == SkjemaStatus.UTKAST) {
-            "Kan kun slette vedlegg fra skjemaer med status UTKAST"
+        if (skjema.status != SkjemaStatus.UTKAST) {
+            throw SkjemaErIkkeRedigerbartException()
         }
 
         val vedlegg = vedleggRepository.findByIdAndSkjemaId(vedleggId, skjemaId)

--- a/src/test/kotlin/no/nav/melosys/skjema/service/VedleggServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/VedleggServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.verify
 import java.util.UUID
 import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.entity.Vedlegg
+import no.nav.melosys.skjema.exception.SkjemaErIkkeRedigerbartException
 import no.nav.melosys.skjema.exception.VedleggVirusFunnetException
 import no.nav.melosys.skjema.integrasjon.clamav.ClamAvClient
 import no.nav.melosys.skjema.integrasjon.storage.VedleggStorageClient
@@ -90,9 +91,9 @@ class VedleggServiceTest : FunSpec({
 
             every { mockUtsendtArbeidstakerService.hentSkjemaMedLesetilgang(skjemaId) } returns skjema
 
-            shouldThrow<IllegalArgumentException> {
+            shouldThrow<SkjemaErIkkeRedigerbartException> {
                 vedleggService.lastOpp(skjemaId, fil)
-            }.message shouldBe "Kan kun laste opp vedlegg til skjemaer med status UTKAST"
+            }
         }
 
         test("feiler når maks antall vedlegg er nådd") {
@@ -174,7 +175,7 @@ class VedleggServiceTest : FunSpec({
 
             every { mockUtsendtArbeidstakerService.hentSkjemaMedLesetilgang(skjemaId) } returns skjema
 
-            shouldThrow<IllegalArgumentException> {
+            shouldThrow<SkjemaErIkkeRedigerbartException> {
                 vedleggService.slett(skjemaId, vedleggId)
             }
         }


### PR DESCRIPTION
`retentionPeriodDays: 30` på vedlegg-bucketene gjorde at brukere ikke fikk slettet vedlegg fra utkast — GCS returnerte 403 `retentionPolicyNotMet`. Fjernet retention policy og økte `lifecycleCondition.age` fra 30 til 365 dager, slik at vedlegg ryddes opp automatisk etter ett år, men kan slettes manuelt før det.

Eksisterende objekter i dev-bucketen som allerede har `retentionExpirationTime` satt vil fortsatt være låst til utløpsdato — endringen påvirker kun nye opplastinger.