### PR TITLE
NOJIRA: Publish types lokalt

### DIFF
--- a/Publisere biblioteker til Github Package Registry.md
+++ b/Publisere biblioteker til Github Package Registry.md
@@ -10,6 +10,35 @@ nav_order: 5
 Å laste opp pakker til Github Package Registry er et enklere alternativ
 for å publisere Maven-artifakter enn å bruke Maven Central.
 
+# Lokal publisering for utvikling (`scripts/publish-types-local.sh`)
+
+For å teste endringer i `melosys-skjema-api-types` mot konsumenter (typisk
+[melosys-api](https://github.com/navikt/melosys-api)) uten å måtte merge til
+`main` og vente på at `publish-types.yml` kjører, finnes scriptet
+`scripts/publish-types-local.sh`. Det kan kjøres direkte eller via
+gradle-wrapperen `publishTypesLocal`:
+
+```bash
+./gradlew publishTypesLocal       # idiomatisk via Gradle
+./scripts/publish-types-local.sh  # direkte (raskere, ingen gradle-daemon i tillegg)
+```
+
+Det publiserer artifaktet til lokal Maven-cache (`~/.m2/repository`) med en
+versjon på formen `<dato>-<sha12>[.dirty]-LOCAL`. `-LOCAL`-suffikset gjør
+versjonen lett å gjenkjenne, og `.dirty` settes automatisk hvis working tree
+har ucommittede endringer.
+
+Output: progresjon og gradle-output går til stderr, mens versjonsstrengen
+skrives som siste linje på stdout. Det gjør det lett for en konsument å
+capture versjonen i et wrapper-script:
+
+```bash
+VERSION=$(./scripts/publish-types-local.sh)
+```
+
+I melosys-api finnes en slik wrapper (`make local-skjema-types`) som kaller
+dette scriptet og oppdaterer `pom.xml` automatisk.
+
 Den enkleste måten å publisere artifakter dit, er å sette opp en CI-pipeline
 via Github Actions.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,3 +119,12 @@ tasks.withType<Test> {
         showStackTraces = true
     }
 }
+
+tasks.register<Exec>("publishTypesLocal") {
+    group = "publishing"
+    description = "Bygger og publiserer melosys-skjema-api-types til ~/.m2/repository for lokal utvikling mot konsumenter (f.eks. melosys-api). Wrapper rundt scripts/publish-types-local.sh."
+    workingDir = rootDir
+    commandLine("./scripts/publish-types-local.sh")
+    standardOutput = System.out
+    errorOutput = System.err
+}

--- a/scripts/publish-types-local.sh
+++ b/scripts/publish-types-local.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Bygger melosys-skjema-api-types og publiserer til lokal Maven cache (~/.m2/repository).
+# Brukes av konsumenter (f.eks. melosys-api) for å teste types-endringer uten å merge til main.
+#
+# Bruk:
+#   ./scripts/publish-types-local.sh
+#
+# Output:
+#   - Progresjon og gradle-output: stderr
+#   - Versjons-streng: siste linje på stdout (slik at konsumenter kan capture den)
+
+set -euo pipefail
+
+# Alt utenom selve versjon-strengen skal til stderr, slik at konsumenter
+# kan kjøre VERSION=$(./scripts/publish-types-local.sh) og kun få versjonen.
+log() { echo "$@" >&2; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+START_TIME=$SECONDS
+
+log "==> melosys-skjema-api-types: lokal publish"
+log "    repo: $REPO_ROOT"
+
+log ""
+log "[1/3] Beregner versjon..."
+SHA="$(git rev-parse --short=12 HEAD)"
+DIRTY=""
+if ! git diff --quiet HEAD 2>/dev/null; then
+    DIRTY=".dirty"
+fi
+DATE="$(date +%Y.%m.%d)"
+VERSION="${DATE}-${SHA}${DIRTY}-LOCAL"
+log "      versjon: $VERSION"
+
+log ""
+log "[2/3] Kjører gradle publishToMavenLocal..."
+log "      (første kjøring kan ta 30-60s pga. daemon-oppstart og dependency resolution)"
+log ""
+
+# --console=plain sikrer at output flushes linjevis selv når stdout ikke er en TTY.
+# Sender alt til stderr så stdout holdes rent for selve versjons-strengen.
+./gradlew \
+    :melosys-skjema-api-types:clean \
+    :melosys-skjema-api-types:publishToMavenLocal \
+    -Pversion="$VERSION" \
+    --console=plain \
+    --no-build-cache \
+    1>&2
+
+ELAPSED=$((SECONDS - START_TIME))
+
+log ""
+log "[3/3] Publisert til ~/.m2/repository på ${ELAPSED}s:"
+log "      no.nav.melosys:melosys-skjema-api-types:$VERSION"
+log ""
+
+# Stdout: bare versjonen, slik at konsumenter kan capture den enkelt
+echo "$VERSION"


### PR DESCRIPTION
Legger til mulighet for å bygge og publishe skjema-types lokalt og legger det inn i ~/.m2-mappa