### PR TITLE
8043: Lagre arbeidstakers navn ved innsending

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerMetadata.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerMetadata.kt
@@ -23,7 +23,7 @@ sealed class UtsendtArbeidstakerMetadata : SkjemaMetadata {
     abstract val skjemadel: Skjemadel
     /** Navn på arbeidsgiver-organisasjonen */
     abstract val arbeidsgiverNavn: String
-    /** Fullt navn på arbeidstaker, cachet fra PDL ved opprettelse. */
+    /** Fullt navn på arbeidstaker. */
     abstract val arbeidstakerNavn: String
     /**
      * Juridisk enhet orgnr fra Enhetsregisteret.

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerMetadata.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerMetadata.kt
@@ -23,6 +23,8 @@ sealed class UtsendtArbeidstakerMetadata : SkjemaMetadata {
     abstract val skjemadel: Skjemadel
     /** Navn på arbeidsgiver-organisasjonen */
     abstract val arbeidsgiverNavn: String
+    /** Fullt navn på arbeidstaker, cachet fra PDL ved opprettelse. */
+    abstract val arbeidstakerNavn: String
     /**
      * Juridisk enhet orgnr fra Enhetsregisteret.
      * Brukes for kobling av separate søknader (arbeidsgiver-del og arbeidstaker-del).
@@ -58,6 +60,7 @@ data class DegSelvMetadata(
     override val skjemadel: Skjemadel,
     override val arbeidsgiverNavn: String,
     override val juridiskEnhetOrgnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null
 ) : UtsendtArbeidstakerMetadata() {
@@ -74,6 +77,7 @@ data class ArbeidsgiverMetadata(
     override val skjemadel: Skjemadel,
     override val arbeidsgiverNavn: String,
     override val juridiskEnhetOrgnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null
 ) : UtsendtArbeidstakerMetadata() {
@@ -92,6 +96,7 @@ data class ArbeidsgiverMedFullmaktMetadata(
     override val juridiskEnhetOrgnr: String,
     /** Fødselsnummer til fullmektig (den som fyller ut på vegne av arbeidstaker) */
     val fullmektigFnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null
 ) : UtsendtArbeidstakerMetadata() {
@@ -108,6 +113,7 @@ data class RadgiverMetadata(
     override val skjemadel: Skjemadel,
     override val arbeidsgiverNavn: String,
     override val juridiskEnhetOrgnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null,
     /** Informasjon om rådgiverfirmaet */
@@ -128,6 +134,7 @@ data class RadgiverMedFullmaktMetadata(
     override val juridiskEnhetOrgnr: String,
     /** Fødselsnummer til fullmektig (den som fyller ut på vegne av arbeidstaker) */
     val fullmektigFnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null,
     /** Informasjon om rådgiverfirmaet */
@@ -148,6 +155,7 @@ data class AnnenPersonMetadata(
     override val juridiskEnhetOrgnr: String,
     /** Fødselsnummer til fullmektig (påkrevd for annen person) */
     val fullmektigFnr: String,
+    override val arbeidstakerNavn: String,
     override val kobletSkjemaId: UUID? = null,
     override val erstatterSkjemaId: UUID? = null
 ) : UtsendtArbeidstakerMetadata() {

--- a/melosys-skjema-api-types/src/test/kotlin/no/nav/melosys/skjema/types/MetadatatypeTest.kt
+++ b/melosys-skjema-api-types/src/test/kotlin/no/nav/melosys/skjema/types/MetadatatypeTest.kt
@@ -30,26 +30,30 @@ class MetadatatypeTest {
         mappings[DegSelvMetadata::class.java] shouldBe DegSelvMetadata(
             skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
             arbeidsgiverNavn = "",
-            juridiskEnhetOrgnr = ""
+            juridiskEnhetOrgnr = "",
+            arbeidstakerNavn = ""
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_DEG_SELV"
 
         mappings[ArbeidsgiverMetadata::class.java] shouldBe ArbeidsgiverMetadata(
             skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
             arbeidsgiverNavn = "",
-            juridiskEnhetOrgnr = ""
+            juridiskEnhetOrgnr = "",
+            arbeidstakerNavn = ""
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_ARBEIDSGIVER"
 
         mappings[ArbeidsgiverMedFullmaktMetadata::class.java] shouldBe ArbeidsgiverMedFullmaktMetadata(
             skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
             arbeidsgiverNavn = "",
             juridiskEnhetOrgnr = "",
-            fullmektigFnr = ""
+            fullmektigFnr = "",
+            arbeidstakerNavn = ""
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_ARBEIDSGIVER_MED_FULLMAKT"
 
         mappings[RadgiverMetadata::class.java] shouldBe RadgiverMetadata(
             skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
             arbeidsgiverNavn = "",
             juridiskEnhetOrgnr = "",
+            arbeidstakerNavn = "",
             radgiverfirma = RadgiverfirmaInfo(orgnr = "", navn = "")
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_RADGIVER"
 
@@ -58,6 +62,7 @@ class MetadatatypeTest {
             arbeidsgiverNavn = "",
             juridiskEnhetOrgnr = "",
             fullmektigFnr = "",
+            arbeidstakerNavn = "",
             radgiverfirma = RadgiverfirmaInfo(orgnr = "", navn = "")
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_RADGIVER_MED_FULLMAKT"
 
@@ -65,7 +70,8 @@ class MetadatatypeTest {
             skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
             arbeidsgiverNavn = "",
             juridiskEnhetOrgnr = "",
-            fullmektigFnr = ""
+            fullmektigFnr = "",
+            arbeidstakerNavn = ""
         ).metadatatype shouldBe "UTSENDT_ARBEIDSTAKER_ANNEN_PERSON"
     }
 }

--- a/melosys-skjema-api-types/src/test/kotlin/no/nav/melosys/skjema/types/SkjemaDtoTypeTest.kt
+++ b/melosys-skjema-api-types/src/test/kotlin/no/nav/melosys/skjema/types/SkjemaDtoTypeTest.kt
@@ -41,7 +41,8 @@ class SkjemaDtoTypeTest {
             metadata = DegSelvMetadata(
                 skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
                 arbeidsgiverNavn = "",
-                juridiskEnhetOrgnr = ""
+                juridiskEnhetOrgnr = "",
+                arbeidstakerNavn = ""
             ),
             data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto()
         ).type.name shouldBe "UTSENDT_ARBEIDSTAKER"

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/GlobalExceptionHandler.kt
@@ -26,7 +26,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(RateLimitExceededException::class)
     fun handleRateLimitExceeded(e: RateLimitExceededException): ResponseEntity<Map<String, String>> {
-        log.warn { "Rate limit overskredet: ${e.message}" }
+        log.warn(e) { "Rate limit overskredet: ${e.message}" }
 
         val config = rateLimitConfig.getConfigFor(e.operationType)
         val retryAfterSeconds = config.getTimeWindow().seconds
@@ -67,7 +67,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(OrganisasjonEksistererIkkeException::class)
     fun handleOrganisasjonEksistererIkke(e: OrganisasjonEksistererIkkeException): ResponseEntity<Map<String, String>> {
-        log.warn { "Organisasjon eksisterer ikke: ${e.message}" }
+        log.warn(e) { "Organisasjon eksisterer ikke: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
@@ -76,7 +76,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(SkjemaErIkkeRedigerbartException::class)
     fun handleSkjemaErIkkeRedigerbart(e: SkjemaErIkkeRedigerbartException): ResponseEntity<ErrorResponse> {
-        log.warn { "Skjema er ikke redigerbart: ${e.message}" }
+        log.warn(e) { "Skjema er ikke redigerbart: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
@@ -85,7 +85,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(PersonVerifiseringException::class)
     fun handlePersonVerifiseringFeilet(e: PersonVerifiseringException): ResponseEntity<Map<String, String>> {
-        log.warn { "Verifisering av person feilet: ${e.message}" }
+        log.warn(e) { "Verifisering av person feilet: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -94,7 +94,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(AccessDeniedException::class)
     fun handleAccessDenied(e: AccessDeniedException): ResponseEntity<Map<String, String>> {
-        log.warn { "Tilgang nektet: ${e.message}" }
+        log.warn(e) { "Tilgang nektet: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)
@@ -103,7 +103,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(VedleggVirusFunnetException::class)
     fun handleVedleggVirusFunnet(e: VedleggVirusFunnetException): ResponseEntity<Map<String, String>> {
-        log.warn { "Virus funnet i vedlegg: ${e.message}" }
+        log.warn(e) { "Virus funnet i vedlegg: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -112,7 +112,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(SkjemaTypeMismatchException::class)
     fun handleSkjemaTypeMismatch(e: SkjemaTypeMismatchException): ResponseEntity<ErrorResponse> {
-        log.warn { "Skjematype samsvarer ikke: ${e.message}" }
+        log.warn(e) { "Skjematype samsvarer ikke: ${e.message}" }
 
         return ResponseEntity
             .badRequest()
@@ -121,7 +121,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(e: IllegalArgumentException): ResponseEntity<Map<String, String>> {
-        log.warn { "Ugyldig forespørsel: ${e.message}" }
+        log.warn(e) { "Ugyldig forespørsel: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -130,7 +130,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(NoSuchElementException::class)
     fun handleNotFound(e: NoSuchElementException): ResponseEntity<Map<String, String>> {
-        log.warn { "Ressurs ikke funnet: ${e.message}" }
+        log.warn(e) { "Ressurs ikke funnet: ${e.message}" }
 
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlQuery.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlQuery.kt
@@ -1,26 +1,41 @@
 package no.nav.melosys.skjema.integrasjon.pdl
 
 object PdlQuery {
-    /**
-     * GraphQL query for å hente person med navn og fødselsdato
-     */
+
+    private const val NAVN_FELT = """
+        fornavn
+        mellomnavn
+        etternavn
+        metadata {
+            historisk
+            endringer {
+                type
+                registrert
+            }
+        }
+    """
+
+    private const val FOEDSELSDATO_FELT = """
+        foedselsdato
+        metadata {
+            historisk
+            endringer {
+                type
+                registrert
+            }
+        }
+    """
+
     const val HENT_PERSON_NAVN_FODSELSDATO = """
         query(${'$'}ident: ID!) {
             hentPerson(ident: ${'$'}ident) {
-                navn {
-                    fornavn
-                    mellomnavn
-                    etternavn
-                }
-                foedselsdato {
-                    foedselsdato
-                }
+                navn { $NAVN_FELT }
+                foedselsdato { $FOEDSELSDATO_FELT }
             }
         }
     """
 
     /**
-     * GraphQL query for å hente flere personer samtidig (bulk)
      * Brukes for å hente personer med fullmakt
      */
     const val HENT_PERSON_BOLK = """
@@ -28,14 +43,8 @@ object PdlQuery {
             hentPersonBolk(identer: ${'$'}identer) {
                 ident
                 person {
-                    navn {
-                        fornavn
-                        mellomnavn
-                        etternavn
-                    }
-                    foedselsdato {
-                        foedselsdato
-                    }
+                    navn { $NAVN_FELT }
+                    foedselsdato { $FOEDSELSDATO_FELT }
                 }
                 code
             }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
@@ -41,20 +41,15 @@ class PdlService(
             throw PersonVerifiseringException("Fødselsnummer og etternavn matcher ikke")
         }
 
-        val personEtternavn = person.navn.firstOrNull()?.etternavn
-        if (!personEtternavn.equals(etternavn, ignoreCase = true)) {
+        // PDL kan ha flere parallelle navn (ulik master). Aksepterer match mot enhver aktuell verdi.
+        val matcherEtternavn = person.aktuelleNavn()
+            .any { it.etternavn.equals(etternavn, ignoreCase = true) }
+        if (!matcherEtternavn) {
             log.warn { "Etternavn matcher ikke ved verifisering" }
             throw PersonVerifiseringException("Fødselsnummer og etternavn matcher ikke")
         }
 
-        val navn = person.hentFulltNavn()
-
-        val fodselsdatoString = person.foedselsdato.firstOrNull()?.foedselsdato
-            ?: throw IllegalArgumentException("Person har ingen fødselsdato registrert i PDL")
-
-        val fodselsdato = LocalDate.parse(fodselsdatoString)
-
-        return Pair(navn, fodselsdato)
+        return Pair(person.hentFulltNavn(), person.hentFoedselsdato())
     }
 
     /**
@@ -64,7 +59,21 @@ class PdlService(
     fun hentNavn(fodselsnummer: String): String =
         pdlConsumer.hentPerson(fodselsnummer).hentFulltNavn()
 
+    // PDL kan returnere flere parallelle og historiske verdier per opplysning.
+    // Vi filtrerer bort historiske og velger sist registrerte aktuelle verdi.
+
+    private fun PdlPerson.aktuelleNavn() = navn.filter { it.metadata.erIkkeHistorisk() }
+
     private fun PdlPerson.hentFulltNavn(): String =
-        navn.firstOrNull()?.fulltNavn()
+        aktuelleNavn().maxByOrNull { it.metadata.datoSistRegistrert() }
+            ?.fulltNavn()
             ?: throw IllegalArgumentException("Person har ingen navn registrert i PDL")
+
+    private fun PdlPerson.hentFoedselsdato(): LocalDate {
+        val dato = foedselsdato.filter { it.metadata.erIkkeHistorisk() }
+            .maxByOrNull { it.metadata.datoSistRegistrert() }
+            ?.foedselsdato
+            ?: throw IllegalArgumentException("Person har ingen fødselsdato registrert i PDL")
+        return LocalDate.parse(dato)
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.skjema.integrasjon.pdl
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.LocalDate
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
 import no.nav.melosys.skjema.integrasjon.pdl.exception.PersonVerifiseringException
 import no.nav.melosys.skjema.validators.felles.ErFodselsEllerDNummerValidator
 import org.springframework.beans.factory.annotation.Value
@@ -46,8 +47,7 @@ class PdlService(
             throw PersonVerifiseringException("Fødselsnummer og etternavn matcher ikke")
         }
 
-        val navn = person.navn.firstOrNull()?.fulltNavn()
-            ?: throw IllegalArgumentException("Person har ingen navn registrert i PDL")
+        val navn = person.hentFulltNavn()
 
         val fodselsdatoString = person.foedselsdato.firstOrNull()?.foedselsdato
             ?: throw IllegalArgumentException("Person har ingen fødselsdato registrert i PDL")
@@ -59,11 +59,12 @@ class PdlService(
 
     /**
      * Henter fullt navn fra PDL.
-     * Kaster hvis PDL-oppslag feiler eller person mangler navn — kallere må håndtere det.
+     * @throws IllegalArgumentException hvis person mangler navn registrert i PDL.
      */
-    fun hentNavn(fodselsnummer: String): String {
-        val person = pdlConsumer.hentPerson(fodselsnummer)
-        return person.navn.firstOrNull()?.fulltNavn()
+    fun hentNavn(fodselsnummer: String): String =
+        pdlConsumer.hentPerson(fodselsnummer).hentFulltNavn()
+
+    private fun PdlPerson.hentFulltNavn(): String =
+        navn.firstOrNull()?.fulltNavn()
             ?: throw IllegalArgumentException("Person har ingen navn registrert i PDL")
-    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlService.kt
@@ -56,4 +56,14 @@ class PdlService(
 
         return Pair(navn, fodselsdato)
     }
+
+    /**
+     * Henter fullt navn fra PDL.
+     * Kaster hvis PDL-oppslag feiler eller person mangler navn — kallere må håndtere det.
+     */
+    fun hentNavn(fodselsnummer: String): String {
+        val person = pdlConsumer.hentPerson(fodselsnummer)
+        return person.navn.firstOrNull()?.fulltNavn()
+            ?: throw IllegalArgumentException("Person har ingen navn registrert i PDL")
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlFoedselsdato.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlFoedselsdato.kt
@@ -1,5 +1,6 @@
 package no.nav.melosys.skjema.integrasjon.pdl.dto
 
 data class PdlFoedselsdato(
-    val foedselsdato: String
+    val foedselsdato: String,
+    val metadata: PdlMetadata = PdlMetadata()
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlMetadata.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlMetadata.kt
@@ -1,0 +1,33 @@
+package no.nav.melosys.skjema.integrasjon.pdl.dto
+
+import java.time.LocalDateTime
+
+/**
+ * PDL kan ha flere parallelle verdier (f.eks. ulik master = FREG vs PDL),
+ * og kan også returnere historiske verdier. Konsumenter må selv velge hvilken
+ * de skal bruke. Vi velger siste ikke-historiske registrering.
+ */
+data class PdlMetadata(
+    val historisk: Boolean? = null,
+    val endringer: List<PdlEndring> = emptyList()
+) {
+    fun erIkkeHistorisk(): Boolean = historisk != true
+
+    fun datoSistRegistrert(): LocalDateTime =
+        endringer.filter { it.erIkkeOpphor() }
+            .maxOfOrNull { it.registrert }
+            ?: LocalDateTime.MIN
+}
+
+data class PdlEndring(
+    val type: PdlEndringstype,
+    val registrert: LocalDateTime
+) {
+    fun erIkkeOpphor(): Boolean = type != PdlEndringstype.OPPHOER
+}
+
+enum class PdlEndringstype {
+    OPPRETT,
+    KORRIGER,
+    OPPHOER
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlNavn.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/pdl/dto/PdlNavn.kt
@@ -3,7 +3,8 @@ package no.nav.melosys.skjema.integrasjon.pdl.dto
 data class PdlNavn(
     val fornavn: String,
     val mellomnavn: String?,
-    val etternavn: String
+    val etternavn: String,
+    val metadata: PdlMetadata = PdlMetadata()
 ) {
     fun fulltNavn(): String {
         return if (mellomnavn != null) {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
@@ -217,7 +217,10 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
      * Konverterer Skjema til InnsendtSoknadOversiktDto.
      * Maskerer fnr og henter nødvendige metadata-verdier.
      */
-    private fun konverterTilInnsendtSoknadDto(skjema: Skjema, personerMedAktivFullmakt: Set<String>): InnsendtSoknadOversiktDto {
+    private fun konverterTilInnsendtSoknadDto(
+        skjema: Skjema,
+        personerMedAktivFullmakt: Set<String>
+    ): InnsendtSoknadOversiktDto {
         val metadata = skjema.metadata as UtsendtArbeidstakerMetadata
         val innsending = skjema.id?.let { innsendingRepository.findBySkjemaId(it) }
 
@@ -226,7 +229,7 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
             referanseId = innsending?.referanseId,
             arbeidsgiverNavn = metadata.arbeidsgiverNavn,
             arbeidsgiverOrgnr = skjema.orgnr,
-            arbeidstakerNavn = null, // TODO: Hent fra data-feltet hvis tilgjengelig
+            arbeidstakerNavn = metadata.arbeidstakerNavn,
             arbeidstakerFnrMaskert = maskerFnr(skjema.fnr),
             arbeidstakerFodselsdato = hentFodselsdatoFraFnr(skjema.fnr),
             innsendtDato = skjema.endretDato,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
@@ -24,26 +24,45 @@ class UtsendtArbeidstakerRepresentasjonValidator(
 ) {
 
     /**
-     * Validerer at en opprettelsesforespørsel er gyldig basert på representasjonstype.
+     * Validerer at en opprettelsesforespørsel er gyldig basert på representasjonstype,
+     * og returnerer arbeidstakerens fulle navn fra PDL.
+     *
+     * Navnet caches i metadata slik at listings-endpoints slipper PDL-oppslag.
      *
      * @param request Forespørsel om å opprette søknad
-     * @throws IllegalArgumentException hvis validering feiler
+     * @param innloggetBrukerFnr Fnr til innlogget bruker (brukes for DEG_SELV der bruker er arbeidstaker)
+     * @return Fullt navn på arbeidstaker fra PDL
+     * @throws IllegalArgumentException hvis validering eller PDL-oppslag feiler
      */
     fun validerOpprettelse(
         request: OpprettUtsendtArbeidstakerSoknadRequest,
-    ) {
+        innloggetBrukerFnr: String,
+    ): String {
         log.info { "Validerer opprettelse av søknad for representasjonstype: ${request.representasjonstype}" }
 
-        when (request.representasjonstype) {
-            Representasjonstype.DEG_SELV -> validerDegSelv(request)
+        val arbeidstakerNavn = when (request.representasjonstype) {
+            Representasjonstype.DEG_SELV -> {
+                validerDegSelv(request)
+                pdlService.hentNavn(innloggetBrukerFnr)
+            }
             Representasjonstype.ARBEIDSGIVER -> validerArbeidsgiverUtenFullmakt(request)
-            Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> validerArbeidsgiverMedFullmakt(request)
+            Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> {
+                validerArbeidsgiverMedFullmakt(request)
+                pdlService.hentNavn(request.arbeidstaker.fnr)
+            }
             Representasjonstype.RADGIVER -> validerRadgiverUtenFullmakt(request)
-            Representasjonstype.RADGIVER_MED_FULLMAKT -> validerRadgiverMedFullmakt(request)
-            Representasjonstype.ANNEN_PERSON -> validerAnnenPerson(request)
+            Representasjonstype.RADGIVER_MED_FULLMAKT -> {
+                validerRadgiverMedFullmakt(request)
+                pdlService.hentNavn(request.arbeidstaker.fnr)
+            }
+            Representasjonstype.ANNEN_PERSON -> {
+                validerAnnenPerson(request)
+                pdlService.hentNavn(request.arbeidstaker.fnr)
+            }
         }
 
         log.info { "Validering OK for representasjonstype: ${request.representasjonstype}" }
+        return arbeidstakerNavn
     }
 
     /**
@@ -64,8 +83,10 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Innlogget bruker har Altinn-tilgang til arbeidsgiver
      * - Arbeidsgiver finnes
      * - Arbeidstaker valideres via PDL med etternavn
+     *
+     * @return Fullt navn på arbeidstaker fra PDL
      */
-    private fun validerArbeidsgiverUtenFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerArbeidsgiverUtenFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer ARBEIDSGIVER scenario (uten fullmakt)" }
 
         if (!altinnService.harBrukerTilgang(request.arbeidsgiver.orgnr)) {
@@ -76,7 +97,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
             throw IllegalArgumentException("Arbeidsgiver med organisasjonsnummer ${request.arbeidsgiver.orgnr} finnes ikke")
         }
 
-        validerArbeidstakerViaPdl(request)
+        return validerArbeidstakerViaPdl(request)
     }
 
     /**
@@ -105,8 +126,10 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Innlogget bruker har Altinn-tilgang til arbeidsgiver
      * - Arbeidsgiver finnes
      * - Arbeidstaker valideres via PDL med etternavn
+     *
+     * @return Fullt navn på arbeidstaker fra PDL
      */
-    private fun validerRadgiverUtenFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerRadgiverUtenFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer RADGIVER scenario (uten fullmakt)" }
 
         validerRadgiverfirma(request)
@@ -119,7 +142,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
             throw IllegalArgumentException("Arbeidsgiver med organisasjonsnummer ${request.arbeidsgiver.orgnr} finnes ikke")
         }
 
-        validerArbeidstakerViaPdl(request)
+        return validerArbeidstakerViaPdl(request)
     }
 
     /**
@@ -178,18 +201,18 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         // repr-api validerer også at person finnes i PDL
     }
 
-    private fun validerArbeidstakerViaPdl(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerArbeidstakerViaPdl(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer arbeidstaker via PDL" }
 
         if (request.arbeidstaker.etternavn == null) {
             throw IllegalArgumentException("Etternavn må oppgis for arbeidstaker uten fullmakt")
         }
 
-        try {
+        return try {
             pdlService.verifiserOgHentPerson(
                 request.arbeidstaker.fnr,
                 request.arbeidstaker.etternavn!!
-            )
+            ).first
         } catch (e: Exception) {
             log.warn(e) { "Arbeidstaker kunne ikke verifiseres i PDL" }
             throw IllegalArgumentException(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
@@ -41,24 +41,12 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         log.info { "Validerer opprettelse av søknad for representasjonstype: ${request.representasjonstype}" }
 
         val arbeidstakerNavn = when (request.representasjonstype) {
-            Representasjonstype.DEG_SELV -> {
-                validerDegSelv(request)
-                pdlService.hentNavn(innloggetBrukerFnr)
-            }
+            Representasjonstype.DEG_SELV -> validerDegSelv(request, innloggetBrukerFnr)
             Representasjonstype.ARBEIDSGIVER -> validerArbeidsgiverUtenFullmakt(request)
-            Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> {
-                validerArbeidsgiverMedFullmakt(request)
-                pdlService.hentNavn(request.arbeidstaker.fnr)
-            }
+            Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> validerArbeidsgiverMedFullmakt(request)
             Representasjonstype.RADGIVER -> validerRadgiverUtenFullmakt(request)
-            Representasjonstype.RADGIVER_MED_FULLMAKT -> {
-                validerRadgiverMedFullmakt(request)
-                pdlService.hentNavn(request.arbeidstaker.fnr)
-            }
-            Representasjonstype.ANNEN_PERSON -> {
-                validerAnnenPerson(request)
-                pdlService.hentNavn(request.arbeidstaker.fnr)
-            }
+            Representasjonstype.RADGIVER_MED_FULLMAKT -> validerRadgiverMedFullmakt(request)
+            Representasjonstype.ANNEN_PERSON -> validerAnnenPerson(request)
         }
 
         log.info { "Validering OK for representasjonstype: ${request.representasjonstype}" }
@@ -70,12 +58,14 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Innlogget person er arbeidstaker
      * - Arbeidsgiver finnes
      */
-    private fun validerDegSelv(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerDegSelv(request: OpprettUtsendtArbeidstakerSoknadRequest, innloggetBrukerFnr: String): String {
         log.debug { "Validerer DEG_SELV scenario" }
 
         if (!eregService.organisasjonsnummerEksisterer(request.arbeidsgiver.orgnr)) {
             throw IllegalArgumentException("Arbeidsgiver med organisasjonsnummer ${request.arbeidsgiver.orgnr} finnes ikke")
         }
+
+        return pdlService.hentNavn(innloggetBrukerFnr)
     }
 
     /**
@@ -106,7 +96,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Arbeidsgiver finnes
      * - Innlogget bruker har fullmakt fra arbeidstaker
      */
-    private fun validerArbeidsgiverMedFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerArbeidsgiverMedFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer ARBEIDSGIVER_MED_FULLMAKT scenario" }
 
         if (!altinnService.harBrukerTilgang(request.arbeidsgiver.orgnr)) {
@@ -118,6 +108,8 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         }
 
         validerFullmaktFraArbeidstaker(request)
+
+        return pdlService.hentNavn(request.arbeidstaker.fnr)
     }
 
     /**
@@ -152,7 +144,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Arbeidsgiver finnes
      * - Innlogget bruker har fullmakt fra arbeidstaker
      */
-    private fun validerRadgiverMedFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerRadgiverMedFullmakt(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer RADGIVER_MED_FULLMAKT scenario" }
 
         validerRadgiverfirma(request)
@@ -166,6 +158,8 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         }
 
         validerFullmaktFraArbeidstaker(request)
+
+        return pdlService.hentNavn(request.arbeidstaker.fnr)
     }
 
     /**
@@ -173,7 +167,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
      * - Innlogget bruker må ha fullmakt fra arbeidstaker
      * - Arbeidsgiver finnes
      */
-    private fun validerAnnenPerson(request: OpprettUtsendtArbeidstakerSoknadRequest) {
+    private fun validerAnnenPerson(request: OpprettUtsendtArbeidstakerSoknadRequest): String {
         log.debug { "Validerer ANNEN_PERSON scenario" }
 
         validerFullmaktFraArbeidstaker(request)
@@ -181,6 +175,8 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         if (!eregService.organisasjonsnummerEksisterer(request.arbeidsgiver.orgnr)) {
             throw IllegalArgumentException("Arbeidsgiver med organisasjonsnummer ${request.arbeidsgiver.orgnr} finnes ikke")
         }
+
+        return pdlService.hentNavn(request.arbeidstaker.fnr)
     }
 
     private fun validerRadgiverfirma(request: OpprettUtsendtArbeidstakerSoknadRequest) {
@@ -209,10 +205,11 @@ class UtsendtArbeidstakerRepresentasjonValidator(
         }
 
         return try {
-            pdlService.verifiserOgHentPerson(
+            val (navn, _) = pdlService.verifiserOgHentPerson(
                 request.arbeidstaker.fnr,
                 request.arbeidstaker.etternavn!!
-            ).first
+            )
+            navn
         } catch (e: Exception) {
             log.warn(e) { "Arbeidstaker kunne ikke verifiseres i PDL" }
             throw IllegalArgumentException(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerRepresentasjonValidator.kt
@@ -192,7 +192,7 @@ class UtsendtArbeidstakerRepresentasjonValidator(
     private fun validerFullmaktFraArbeidstaker(request: OpprettUtsendtArbeidstakerSoknadRequest) {
         log.debug { "Validerer fullmakt fra arbeidstaker via repr-api" }
         if (!reprService.harSkriverettigheterForMedlemskap(request.arbeidstaker.fnr)) {
-            throw AccessDeniedException("Innlogget bruker har ikke fullmakt fra arbeidstaker ${request.arbeidstaker.fnr}")
+            throw AccessDeniedException("Innlogget bruker har ikke fullmakt fra arbeidstaker")
         }
         // repr-api validerer også at person finnes i PDL
     }
@@ -204,18 +204,10 @@ class UtsendtArbeidstakerRepresentasjonValidator(
             throw IllegalArgumentException("Etternavn må oppgis for arbeidstaker uten fullmakt")
         }
 
-        return try {
-            val (navn, _) = pdlService.verifiserOgHentPerson(
-                request.arbeidstaker.fnr,
-                request.arbeidstaker.etternavn!!
-            )
-            navn
-        } catch (e: Exception) {
-            log.warn(e) { "Arbeidstaker kunne ikke verifiseres i PDL" }
-            throw IllegalArgumentException(
-                "Arbeidstaker med fødselsnummer ${request.arbeidstaker.fnr} finnes ikke eller etternavn matcher ikke",
-                e
-            )
-        }
+        val (navn, _) = pdlService.verifiserOgHentPerson(
+            request.arbeidstaker.fnr,
+            request.arbeidstaker.etternavn!!
+        )
+        return navn
     }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -65,14 +65,13 @@ class UtsendtArbeidstakerService(
         val innloggetBrukerFnr = subjectHandler.getUserID()
         log.info { "Oppretter Utsendt Arbeidstaker søknad for representasjonstype: ${request.representasjonstype}" }
 
-        // Valider forespørsel
-        representasjonValidator.validerOpprettelse(request)
+        val arbeidstakerNavn = representasjonValidator.validerOpprettelse(request, innloggetBrukerFnr)
 
         // Hent juridisk enhet fra Enhetsregisteret for kobling av separate søknader
         val juridiskEnhetOrgnr = hentJuridiskEnhetOrgnr(request.arbeidsgiver.orgnr)
 
         // Bygg metadata med korrekt fullmektig-logikk og juridisk enhet
-        val metadata = byggMetadata(request, innloggetBrukerFnr, juridiskEnhetOrgnr)
+        val metadata = byggMetadata(request, innloggetBrukerFnr, juridiskEnhetOrgnr, arbeidstakerNavn)
 
         // Opprett skjema med riktig fnr og orgnr basert på representasjonstype
         val skjema = when (request.representasjonstype) {
@@ -460,7 +459,8 @@ class UtsendtArbeidstakerService(
     private fun byggMetadata(
         request: OpprettUtsendtArbeidstakerSoknadRequest,
         innloggetBrukerFnr: String,
-        juridiskEnhetOrgnr: String
+        juridiskEnhetOrgnr: String,
+        arbeidstakerNavn: String
     ): UtsendtArbeidstakerMetadata {
         val skjemadel = request.representasjonstype.tilSkjemadel()
 
@@ -468,18 +468,21 @@ class UtsendtArbeidstakerService(
             Representasjonstype.DEG_SELV -> DegSelvMetadata(
                 skjemadel = skjemadel,
                 arbeidsgiverNavn = request.arbeidsgiver.navn,
-                juridiskEnhetOrgnr = juridiskEnhetOrgnr
+                juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+                arbeidstakerNavn = arbeidstakerNavn
             )
             Representasjonstype.ARBEIDSGIVER -> ArbeidsgiverMetadata(
                 skjemadel = skjemadel,
                 arbeidsgiverNavn = request.arbeidsgiver.navn,
-                juridiskEnhetOrgnr = juridiskEnhetOrgnr
+                juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+                arbeidstakerNavn = arbeidstakerNavn
             )
             Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> ArbeidsgiverMedFullmaktMetadata(
                 skjemadel = skjemadel,
                 arbeidsgiverNavn = request.arbeidsgiver.navn,
                 juridiskEnhetOrgnr = juridiskEnhetOrgnr,
-                fullmektigFnr = innloggetBrukerFnr
+                fullmektigFnr = innloggetBrukerFnr,
+                arbeidstakerNavn = arbeidstakerNavn
             )
             Representasjonstype.RADGIVER -> {
                 val radgiverfirmaInfo = request.radgiverfirma
@@ -488,6 +491,7 @@ class UtsendtArbeidstakerService(
                     skjemadel = skjemadel,
                     arbeidsgiverNavn = request.arbeidsgiver.navn,
                     juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+                    arbeidstakerNavn = arbeidstakerNavn,
                     radgiverfirma = RadgiverfirmaInfo(orgnr = radgiverfirmaInfo.orgnr, navn = radgiverfirmaInfo.navn)
                 )
             }
@@ -499,6 +503,7 @@ class UtsendtArbeidstakerService(
                     arbeidsgiverNavn = request.arbeidsgiver.navn,
                     juridiskEnhetOrgnr = juridiskEnhetOrgnr,
                     fullmektigFnr = innloggetBrukerFnr,
+                    arbeidstakerNavn = arbeidstakerNavn,
                     radgiverfirma = RadgiverfirmaInfo(orgnr = radgiverfirmaInfo.orgnr, navn = radgiverfirmaInfo.navn)
                 )
             }
@@ -506,7 +511,8 @@ class UtsendtArbeidstakerService(
                 skjemadel = skjemadel,
                 arbeidsgiverNavn = request.arbeidsgiver.navn,
                 juridiskEnhetOrgnr = juridiskEnhetOrgnr,
-                fullmektigFnr = innloggetBrukerFnr
+                fullmektigFnr = innloggetBrukerFnr,
+                arbeidstakerNavn = arbeidstakerNavn
             )
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -67,13 +67,10 @@ class UtsendtArbeidstakerService(
 
         val arbeidstakerNavn = representasjonValidator.validerOpprettelse(request, innloggetBrukerFnr)
 
-        // Hent juridisk enhet fra Enhetsregisteret for kobling av separate søknader
         val juridiskEnhetOrgnr = hentJuridiskEnhetOrgnr(request.arbeidsgiver.orgnr)
 
-        // Bygg metadata med korrekt fullmektig-logikk og juridisk enhet
         val metadata = byggMetadata(request, innloggetBrukerFnr, juridiskEnhetOrgnr, arbeidstakerNavn)
 
-        // Opprett skjema med riktig fnr og orgnr basert på representasjonstype
         val skjema = when (request.representasjonstype) {
             Representasjonstype.DEG_SELV -> {
                 // Arbeidstaker fyller ut for seg selv

--- a/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
@@ -271,6 +271,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
     representasjonstype: Representasjonstype = Representasjonstype.DEG_SELV,
     skjemadel: Skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
     arbeidsgiverNavn: String = "Test Arbeidsgiver AS",
+    arbeidstakerNavn: String = "Test Testesen",
     fullmektigFnr: String? = etAnnetKorrektSyntetiskFnr,
     radgiverfirma: RadgiverfirmaInfo? = null,
     juridiskEnhetOrgnr: String = korrektSyntetiskOrgnr,
@@ -282,6 +283,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             skjemadel = skjemadel,
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId
         )
@@ -289,6 +291,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             skjemadel = skjemadel,
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId
         )
@@ -297,6 +300,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
             fullmektigFnr = fullmektigFnr ?: throw IllegalArgumentException("fullmektigFnr er påkrevd for ARBEIDSGIVER_MED_FULLMAKT"),
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId
         )
@@ -304,6 +308,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             skjemadel = skjemadel,
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId,
             radgiverfirma = radgiverfirma ?: radgiverfirmaInfoMedDefaultVerdier()
@@ -313,6 +318,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
             fullmektigFnr = fullmektigFnr ?: throw IllegalArgumentException("fullmektigFnr er påkrevd for RADGIVER_MED_FULLMAKT"),
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId,
             radgiverfirma = radgiverfirma ?: radgiverfirmaInfoMedDefaultVerdier()
@@ -322,6 +328,7 @@ fun utsendtArbeidstakerMetadataMedDefaultVerdier(
             arbeidsgiverNavn = arbeidsgiverNavn,
             juridiskEnhetOrgnr = juridiskEnhetOrgnr,
             fullmektigFnr = fullmektigFnr ?: throw IllegalArgumentException("fullmektigFnr er påkrevd for ANNEN_PERSON"),
+            arbeidstakerNavn = arbeidstakerNavn,
             kobletSkjemaId = kobletSkjemaId,
             erstatterSkjemaId = erstatterSkjemaId
         )

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlServiceTest.kt
@@ -186,4 +186,39 @@ class PdlServiceTest {
 
         assertThat(exception.message).isEqualTo("Person har ingen fødselsdato registrert i PDL")
     }
+
+    @Test
+    fun `hentNavn returnerer fullt navn fra PDL`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        val person = PdlPerson(
+            navn = listOf(PdlNavn(fornavn = "Kurt", mellomnavn = null, etternavn = "Sand")),
+            foedselsdato = listOf(PdlFoedselsdato(foedselsdato = "1968-04-02"))
+        )
+        every { pdlConsumer.hentPerson(fodselsnummer) } returns person
+
+        assertThat(pdlService.hentNavn(fodselsnummer)).isEqualTo("Kurt Sand")
+    }
+
+    @Test
+    fun `hentNavn propagerer feil fra PDL-oppslag`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        every { pdlConsumer.hentPerson(fodselsnummer) } throws RuntimeException("PDL nede")
+
+        assertThrows<RuntimeException> { pdlService.hentNavn(fodselsnummer) }
+    }
+
+    @Test
+    fun `hentNavn kaster IllegalArgumentException når person mangler navn i PDL`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        val person = PdlPerson(
+            navn = emptyList(),
+            foedselsdato = listOf(PdlFoedselsdato(foedselsdato = "1968-04-02"))
+        )
+        every { pdlConsumer.hentPerson(fodselsnummer) } returns person
+
+        val exception = assertThrows<IllegalArgumentException> {
+            pdlService.hentNavn(fodselsnummer)
+        }
+        assertThat(exception.message).isEqualTo("Person har ingen navn registrert i PDL")
+    }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/pdl/PdlServiceTest.kt
@@ -4,7 +4,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.time.LocalDate
+import java.time.LocalDateTime
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlEndring
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlEndringstype
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlFoedselsdato
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlMetadata
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlNavn
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
 import no.nav.melosys.skjema.integrasjon.pdl.exception.PersonVerifiseringException
@@ -221,4 +225,68 @@ class PdlServiceTest {
         }
         assertThat(exception.message).isEqualTo("Person har ingen navn registrert i PDL")
     }
+
+    @Test
+    fun `hentNavn velger sist registrerte navn ved parallelle verdier`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        val person = PdlPerson(
+            navn = listOf(
+                navnMedRegistrert("Ola", "Nordmann", LocalDateTime.of(2020, 1, 1, 0, 0)),
+                navnMedRegistrert("Hans", "Nordmann", LocalDateTime.of(2024, 6, 1, 0, 0))
+            ),
+            foedselsdato = listOf(PdlFoedselsdato(foedselsdato = "1990-01-01"))
+        )
+        every { pdlConsumer.hentPerson(fodselsnummer) } returns person
+
+        assertThat(pdlService.hentNavn(fodselsnummer)).isEqualTo("Hans Nordmann")
+    }
+
+    @Test
+    fun `hentNavn ignorerer historiske navn`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        val person = PdlPerson(
+            navn = listOf(
+                navnMedRegistrert("Hans", "Nordmann", LocalDateTime.of(2024, 6, 1, 0, 0), historisk = true),
+                navnMedRegistrert("Ola", "Nordmann", LocalDateTime.of(2020, 1, 1, 0, 0))
+            ),
+            foedselsdato = listOf(PdlFoedselsdato(foedselsdato = "1990-01-01"))
+        )
+        every { pdlConsumer.hentPerson(fodselsnummer) } returns person
+
+        assertThat(pdlService.hentNavn(fodselsnummer)).isEqualTo("Ola Nordmann")
+    }
+
+    @Test
+    fun `verifiserOgHentPerson aksepterer etternavn-match mot enhver parallell verdi`() {
+        val fodselsnummer = korrektSyntetiskFnr
+        val person = PdlPerson(
+            navn = listOf(
+                navnMedRegistrert("Ola", "Nordmann", LocalDateTime.of(2020, 1, 1, 0, 0)),
+                navnMedRegistrert("Hans", "Hansen", LocalDateTime.of(2024, 6, 1, 0, 0))
+            ),
+            foedselsdato = listOf(PdlFoedselsdato(foedselsdato = "1990-01-01"))
+        )
+        every { pdlConsumer.hentPerson(fodselsnummer) } returns person
+
+        // Bruker oppgir det "gamle" etternavnet (FREG-master), men PDL-master har annet
+        val (navn, _) = pdlService.verifiserOgHentPerson(fodselsnummer, "Nordmann")
+
+        // Returnert navn er sist registrerte
+        assertThat(navn).isEqualTo("Hans Hansen")
+    }
+
+    private fun navnMedRegistrert(
+        fornavn: String,
+        etternavn: String,
+        registrert: LocalDateTime,
+        historisk: Boolean = false
+    ) = PdlNavn(
+        fornavn = fornavn,
+        mellomnavn = null,
+        etternavn = etternavn,
+        metadata = PdlMetadata(
+            historisk = historisk,
+            endringer = listOf(PdlEndring(PdlEndringstype.OPPRETT, registrert))
+        )
+    )
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
@@ -937,4 +937,45 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest : Api
             e.message shouldBe "radgiverfirmaOrgnr er påkrevd for RADGIVER"
         }
     }
+
+    // ========================================
+    // arbeidstakerNavn — lagret i metadata ved opprettelse
+    // ========================================
+
+    @Test
+    @DisplayName("ARBEIDSGIVER: arbeidstakerNavn skal leses fra metadata")
+    fun `arbeidstakerNavn skal leses fra metadata`() {
+        val userFnr = korrektSyntetiskFnr
+        val arbeidstakerFnr = etAnnetKorrektSyntetiskFnr
+        val orgnr = "111222333"
+        every { subjectHandler.getUserID() } returns userFnr
+        every { altinnService.hentBrukersTilganger() } returns listOf(
+            OrganisasjonDto(orgnr, "Bedrift A AS", "AS")
+        )
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                orgnr = orgnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    arbeidsgiverNavn = "Bedrift A AS",
+                    arbeidstakerNavn = "Kurt Sand"
+                ),
+                opprettetAv = userFnr
+            )
+        )
+
+        val request = HentInnsendteSoknaderRequest(
+            side = 1,
+            antall = 10,
+            representasjonstype = Representasjonstype.ARBEIDSGIVER
+        )
+
+        val response = service.hentInnsendteSoknader(request)
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].arbeidstakerNavn shouldBe "Kurt Sand"
+    }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
@@ -105,7 +105,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             response.id shouldNotBe null
             response.status shouldBe SkjemaStatus.UTKAST
 
-            verify { mockValidator.validerOpprettelse(request) }
+            verify { mockValidator.validerOpprettelse(request, any()) }
             verify { mockSkjemaRepository.save(any()) }
         }
 
@@ -134,7 +134,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             response.id shouldNotBe null
             response.status shouldBe SkjemaStatus.UTKAST
 
-            verify { mockValidator.validerOpprettelse(request) }
+            verify { mockValidator.validerOpprettelse(request, any()) }
             verify { mockSkjemaRepository.save(any()) }
         }
 
@@ -164,7 +164,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             response.id shouldNotBe null
             response.status shouldBe SkjemaStatus.UTKAST
 
-            verify { mockValidator.validerOpprettelse(request) }
+            verify { mockValidator.validerOpprettelse(request, any()) }
         }
 
         test("skal opprette skjema for ANNEN_PERSON") {
@@ -192,7 +192,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             response.id shouldNotBe null
             response.status shouldBe SkjemaStatus.UTKAST
 
-            verify { mockValidator.validerOpprettelse(request) }
+            verify { mockValidator.validerOpprettelse(request, any()) }
         }
 
         test("skal feile når validering feiler") {
@@ -204,7 +204,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockValidator.validerOpprettelse(request) } throws IllegalArgumentException("Validering feilet")
+            every { mockValidator.validerOpprettelse(request, any()) } throws IllegalArgumentException("Validering feilet")
 
             val exception = shouldThrow<IllegalArgumentException> {
                 service.opprettUtsendtArbeidstakerSoknad(request)

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerValidatorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerValidatorTest.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.skjema.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
@@ -35,7 +36,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
     val testRadgiverfirma = simpleOrganisasjonDtoMedDefaultVerdier(orgnr = "987654321", navn = "Rådgiver AS")
 
     context("DEG_SELV validering") {
-        test("skal godkjenne gyldig DEG_SELV request") {
+        test("skal godkjenne gyldig DEG_SELV request og returnere navn fra PDL") {
             val request = opprettUtsendtArbeidstakerSoknadRequestMedDefaultVerdier(
                 representasjonstype = Representasjonstype.DEG_SELV,
                 arbeidsgiver = testArbeidsgiver,
@@ -43,9 +44,11 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             )
 
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
+            every { mockPdlService.hentNavn(testArbeidstaker.fnr) } returns "Ola Nordmann"
 
-            validator.validerOpprettelse(request)
+            val navn = validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
+            navn shouldBe "Ola Nordmann"
             verify { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) }
         }
 
@@ -59,7 +62,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns false
 
             val exception = shouldThrow<IllegalArgumentException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "finnes ikke"
@@ -81,7 +84,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
                 java.time.LocalDate.of(1990, 1, 1)
             )
 
-            validator.validerOpprettelse(request)
+            validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
             verify { mockPdlService.verifiserOgHentPerson(testArbeidstakerMedEtternavn.fnr, testArbeidstakerMedEtternavn.etternavn!!) }
         }
@@ -96,7 +99,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "ikke Altinn-tilgang"
@@ -116,7 +119,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             } throws IllegalArgumentException("Person ikke funnet")
 
             val exception = shouldThrow<IllegalArgumentException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "finnes ikke eller etternavn matcher ikke"
@@ -124,7 +127,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
     }
 
     context("ARBEIDSGIVER_MED_FULLMAKT validering") {
-        test("skal godkjenne gyldig ARBEIDSGIVER_MED_FULLMAKT request") {
+        test("skal godkjenne gyldig ARBEIDSGIVER_MED_FULLMAKT request og returnere navn fra PDL") {
             val request = opprettUtsendtArbeidstakerSoknadRequestMedDefaultVerdier(
                 representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
                 arbeidsgiver = testArbeidsgiver,
@@ -134,11 +137,30 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns true
+            every { mockPdlService.hentNavn(testArbeidstaker.fnr) } returns "Ola Nordmann"
 
-            validator.validerOpprettelse(request)
+            val navn = validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
+            navn shouldBe "Ola Nordmann"
             verify { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) }
             verify { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) }
+        }
+
+        test("skal propagere PDL-feil i fullmakt-flow") {
+            val request = opprettUtsendtArbeidstakerSoknadRequestMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
+                arbeidsgiver = testArbeidsgiver,
+                arbeidstaker = testArbeidstaker
+            )
+
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+            every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
+            every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns true
+            every { mockPdlService.hentNavn(testArbeidstaker.fnr) } throws IllegalArgumentException("Person ikke funnet")
+
+            shouldThrow<IllegalArgumentException> {
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
+            }
         }
 
         test("skal feile når fullmakt mangler") {
@@ -153,7 +175,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "ikke fullmakt"
@@ -177,7 +199,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
                 java.time.LocalDate.of(1990, 1, 1)
             )
 
-            validator.validerOpprettelse(request)
+            validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
             verify { mockEregService.organisasjonsnummerEksisterer(testRadgiverfirma.orgnr) }
             verify { mockPdlService.verifiserOgHentPerson(testArbeidstakerMedEtternavn.fnr, testArbeidstakerMedEtternavn.etternavn!!) }
@@ -192,7 +214,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             )
 
             val exception = shouldThrow<IllegalArgumentException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "Rådgiverfirma må oppgis"
@@ -209,7 +231,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockEregService.organisasjonsnummerEksisterer(testRadgiverfirma.orgnr) } returns false
 
             val exception = shouldThrow<IllegalArgumentException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "Rådgiverfirma"
@@ -230,8 +252,9 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns true
+            every { mockPdlService.hentNavn(testArbeidstaker.fnr) } returns "Ola Nordmann"
 
-            validator.validerOpprettelse(request)
+            validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
             verify { mockEregService.organisasjonsnummerEksisterer(testRadgiverfirma.orgnr) }
             verify { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) }
@@ -251,7 +274,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "ikke fullmakt"
@@ -268,8 +291,9 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
 
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns true
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
+            every { mockPdlService.hentNavn(testArbeidstaker.fnr) } returns "Ola Nordmann"
 
-            validator.validerOpprettelse(request)
+            validator.validerOpprettelse(request, testArbeidstaker.fnr)
 
             verify { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) }
         }
@@ -284,7 +308,7 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockReprService.harSkriverettigheterForMedlemskap(testArbeidstaker.fnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
-                validator.validerOpprettelse(request)
+                validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
 
             exception.message shouldContain "ikke fullmakt"

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerValidatorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerValidatorTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import no.nav.melosys.skjema.exception.AccessDeniedException
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
 import no.nav.melosys.skjema.integrasjon.pdl.PdlService
+import no.nav.melosys.skjema.integrasjon.pdl.exception.PersonVerifiseringException
 import no.nav.melosys.skjema.integrasjon.repr.ReprService
 import no.nav.melosys.skjema.opprettUtsendtArbeidstakerSoknadRequestMedDefaultVerdier
 import no.nav.melosys.skjema.personDtoMedDefaultVerdier
@@ -116,13 +117,11 @@ class UtsendtArbeidstakerValidatorTest : FunSpec({
             every { mockEregService.organisasjonsnummerEksisterer(testArbeidsgiver.orgnr) } returns true
             every {
                 mockPdlService.verifiserOgHentPerson(testArbeidstakerMedEtternavn.fnr, testArbeidstakerMedEtternavn.etternavn!!)
-            } throws IllegalArgumentException("Person ikke funnet")
+            } throws PersonVerifiseringException("Fødselsnummer og etternavn matcher ikke")
 
-            val exception = shouldThrow<IllegalArgumentException> {
+            shouldThrow<PersonVerifiseringException> {
                 validator.validerOpprettelse(request, testArbeidstaker.fnr)
             }
-
-            exception.message shouldContain "finnes ikke eller etternavn matcher ikke"
         }
     }
 


### PR DESCRIPTION
På flyt for arbeidstaker/rådgiver så kan det være flere hundre ulike personer etterhvert, og vil derfor føre til en del kall til PDL hvis vi skal gjøre kallene on-demand. Vi gjør allerede en del kall mot tilgangsstyring/fullmakt, og dette ville gjort at det ytet enda dårligere.

Lagrer arbeidstakers navn i databasen. Vi lagrer allerede fnr, og dette vil ikke medføre unødvendig økt lagring av personopplysninger. 