### PR TITLE
Vis arbeidsgiver- og arbeidstakerinfo øverst i PDF

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
@@ -30,6 +30,7 @@ object HtmlDokumentGenerator {
         return buildString {
             append(byggHtmlStart())
             append(byggHeader(skjema.referanseId, skjema.innsendtDato, språk))
+            append(byggAktørInfoSeksjon(skjema.aktørInfo, språk))
             appendSkjemaData(skjema.skjemaData, skjema.definisjon, seksjonRenderer, språk)
             skjema.kobletSkjemaData?.let { appendSkjemaData(it, skjema.definisjon, seksjonRenderer, språk) }
             append(byggHtmlSlutt())
@@ -134,6 +135,73 @@ object HtmlDokumentGenerator {
             append(seksjonRenderer.byggKombinertArbeidsgiversSeksjoner(data, definisjon))
             append("""<h2 class="part-heading">${escapeHtml(arbeidstakerOverskrift(språk))}</h2>""")
             append(seksjonRenderer.byggKombinertArbeidstakersSeksjoner(data, definisjon))
+        }
+    }
+
+    private fun byggAktørInfoSeksjon(aktørInfo: AktørInfo, språk: Språk): String {
+        val arbeidstakerRolle = when (språk) {
+            Språk.NORSK_BOKMAL -> "Arbeidstaker"
+            Språk.ENGELSK -> "Employee"
+        }
+        val arbeidsgiverRolle = when (språk) {
+            Språk.NORSK_BOKMAL -> "Arbeidsgiver"
+            Språk.ENGELSK -> "Employer"
+        }
+        val orgnrTekst = when (språk) {
+            Språk.NORSK_BOKMAL -> "Organisasjonsnummer"
+            Språk.ENGELSK -> "Organisation number"
+        }
+        val identTekst = personidentifikatorLabel(aktørInfo.arbeidstakerFnr, språk)
+        val navnTekst = when (språk) {
+            Språk.NORSK_BOKMAL -> "Navn"
+            Språk.ENGELSK -> "Name"
+        }
+
+        return """
+            <div class="form-summary">
+                <div class="form-summary-header">
+                    <h3 class="form-summary-heading">${escapeHtml(arbeidstakerRolle)}</h3>
+                </div>
+                <div class="form-summary-answers">
+                    <div class="form-summary-answer">
+                        <p class="form-summary-label">${escapeHtml(navnTekst)}</p>
+                        <p class="form-summary-value">${escapeHtml(aktørInfo.arbeidstakerNavn)}</p>
+                    </div>
+                    <div class="form-summary-answer">
+                        <p class="form-summary-label">${escapeHtml(identTekst)}</p>
+                        <p class="form-summary-value">${escapeHtml(aktørInfo.arbeidstakerFnr)}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="form-summary">
+                <div class="form-summary-header">
+                    <h3 class="form-summary-heading">${escapeHtml(arbeidsgiverRolle)}</h3>
+                </div>
+                <div class="form-summary-answers">
+                    <div class="form-summary-answer">
+                        <p class="form-summary-label">${escapeHtml(navnTekst)}</p>
+                        <p class="form-summary-value">${escapeHtml(aktørInfo.arbeidsgiverNavn)}</p>
+                    </div>
+                    <div class="form-summary-answer">
+                        <p class="form-summary-label">${escapeHtml(orgnrTekst)}</p>
+                        <p class="form-summary-value">${escapeHtml(aktørInfo.orgnr)}</p>
+                    </div>
+                </div>
+            </div>
+        """.trimIndent()
+    }
+
+    /**
+     * Utleder riktig label for personidentifikator basert på om det er et D-nummer eller fødselsnummer.
+     * D-nummer gjenkjennes ved at første siffer er 4–7 (dag-delen er økt med 4).
+     */
+    private fun personidentifikatorLabel(ident: String, språk: Språk): String {
+        val erDnummer = ident.length == 11 && ident[0].digitToInt() in 4..7
+        return when {
+            erDnummer && språk == Språk.NORSK_BOKMAL -> "D-nummer"
+            erDnummer && språk == Språk.ENGELSK -> "D number"
+            språk == Språk.NORSK_BOKMAL -> "Fødselsnummer"
+            else -> "National identity number"
         }
     }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SkjemaPdfData.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SkjemaPdfData.kt
@@ -7,6 +7,17 @@ import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.skjemadefinisjon.SkjemaDefinisjonDto
 
 /**
+ * Informasjon om arbeidsgiver og arbeidstaker for visning øverst i PDF.
+ * Hentes fra skjema-metadata og PDL — ikke fra selve skjemadataen.
+ */
+data class AktørInfo(
+    val arbeidsgiverNavn: String,
+    val orgnr: String,
+    val arbeidstakerNavn: String,
+    val arbeidstakerFnr: String
+)
+
+/**
  * Intern dataklasse for PDF-generering.
  * Inneholder all data som trengs for å generere PDF av et innsendt skjema.
  */
@@ -15,6 +26,7 @@ data class SkjemaPdfData(
     val referanseId: String,
     val innsendtDato: Instant,
     val innsendtSprak: Språk,
+    val aktørInfo: AktørInfo,
     val skjemaData: UtsendtArbeidstakerSkjemaData,
     val kobletSkjemaData: UtsendtArbeidstakerSkjemaData?,
     val definisjon: SkjemaDefinisjonDto

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -6,6 +6,8 @@ import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.extensions.toOsloLocalDateTime
 import no.nav.melosys.skjema.extensions.toUtsendtArbeidstakerDto
+import no.nav.melosys.skjema.integrasjon.pdl.PdlConsumer
+import no.nav.melosys.skjema.pdf.AktørInfo
 import no.nav.melosys.skjema.pdf.SkjemaPdfData
 import no.nav.melosys.skjema.pdf.genererPdf
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -26,7 +28,8 @@ class M2MSkjemaService(
     private val skjemaRepository: SkjemaRepository,
     private val innsendingRepository: InnsendingRepository,
     private val vedleggService: VedleggService,
-    private val skjemaDefinisjonService: SkjemaDefinisjonService
+    private val skjemaDefinisjonService: SkjemaDefinisjonService,
+    private val pdlConsumer: PdlConsumer
 ) {
 
     fun hentUtsendtArbeidstakerSkjemaData(id: UUID): UtsendtArbeidstakerSkjemaM2MDto {
@@ -129,11 +132,22 @@ class M2MSkjemaService(
             språk = innsending.innsendtSprak
         )
 
+        val arbeidstakerNavn = pdlConsumer.hentPerson(skjema.fnr)
+            .navn.first().fulltNavn()
+
+        val aktørInfo = AktørInfo(
+            arbeidsgiverNavn = metadata.arbeidsgiverNavn,
+            orgnr = skjema.orgnr,
+            arbeidstakerNavn = arbeidstakerNavn,
+            arbeidstakerFnr = skjema.fnr
+        )
+
         return SkjemaPdfData(
             skjemaId = skjema.id!!,
             referanseId = innsending.referanseId,
             innsendtDato = innsending.opprettetDato,
             innsendtSprak = innsending.innsendtSprak,
+            aktørInfo = aktørInfo,
             skjemaData = skjema.data as UtsendtArbeidstakerSkjemaData,
             kobletSkjemaData = kobletSkjemaData,
             definisjon = definisjon

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -1,9 +1,11 @@
 package no.nav.melosys.skjema.controller
 
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
+import io.mockk.every
 import java.time.Instant
 import java.util.UUID
 import no.nav.melosys.skjema.ApiTestBase
@@ -12,6 +14,11 @@ import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.extensions.toOsloLocalDateTime
 import no.nav.melosys.skjema.getToken
 import no.nav.melosys.skjema.innsendingMedDefaultVerdier
+import no.nav.melosys.skjema.integrasjon.pdl.PdlConsumer
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlFoedselsdato
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlNavn
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
+import no.nav.melosys.skjema.korrektSyntetiskFnr
 import no.nav.melosys.skjema.m2mTokenWithReadSkjemaDataAccess
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -43,10 +50,18 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
     @Autowired
     private lateinit var innsendingRepository: InnsendingRepository
 
+    @MockkBean
+    private lateinit var pdlConsumer: PdlConsumer
+
     @BeforeEach
     fun setUp() {
         skjemaRepository.deleteAll()
         innsendingRepository.deleteAll()
+
+        every { pdlConsumer.hentPerson(any()) } returns PdlPerson(
+            navn = listOf(PdlNavn("Hans", null, "Hansen")),
+            foedselsdato = listOf(PdlFoedselsdato("1980-01-01"))
+        )
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -65,7 +65,13 @@ class PdfGeneratorTest : FunSpec({
         referanseId: String,
         språk: Språk = Språk.NORSK_BOKMAL,
         arbeidstakerData: UtsendtArbeidstakerArbeidstakersSkjemaDataDto? = null,
-        arbeidsgiverData: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto? = null
+        arbeidsgiverData: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto? = null,
+        aktørInfo: AktørInfo = AktørInfo(
+            arbeidsgiverNavn = "Test Bedrift AS",
+            orgnr = "123456789",
+            arbeidstakerNavn = "Ola Nordmann",
+            arbeidstakerFnr = "12345678901"
+        )
     ): SkjemaPdfData {
         val definisjon = skjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, null, språk)
         val skjemaData: UtsendtArbeidstakerSkjemaData = arbeidstakerData ?: arbeidsgiverData
@@ -76,6 +82,7 @@ class PdfGeneratorTest : FunSpec({
             referanseId = referanseId,
             innsendtDato = Instant.now(),
             innsendtSprak = språk,
+            aktørInfo = aktørInfo,
             skjemaData = skjemaData,
             kobletSkjemaData = kobletSkjemaData,
             definisjon = definisjon
@@ -246,6 +253,125 @@ class PdfGeneratorTest : FunSpec({
 
             html shouldContain ">Yes<"
             html shouldContain ">No<"
+        }
+    }
+
+    context("Aktør-info seksjon") {
+        test("viser arbeidsgiver-navn og orgnr på norsk") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_NO",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Nav Kontaktsenter AS",
+                    orgnr = "987654321",
+                    arbeidstakerNavn = "Kari Nordmann",
+                    arbeidstakerFnr = "11223344556"
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Nav Kontaktsenter AS"
+            html shouldContain "987654321"
+            html shouldContain "Arbeidsgiver"
+            html shouldContain "Organisasjonsnummer"
+        }
+
+        test("viser arbeidstaker-navn og fnr på norsk") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_AT",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Nav Kontaktsenter AS",
+                    orgnr = "987654321",
+                    arbeidstakerNavn = "Kari Nordmann",
+                    arbeidstakerFnr = "11223344556"
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Kari Nordmann"
+            html shouldContain "11223344556"
+            html shouldContain "Arbeidstaker"
+            html shouldContain "Fødselsnummer"
+        }
+
+        test("viser engelske ledetekster") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_EN",
+                språk = Språk.ENGELSK,
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Test Corp Ltd",
+                    orgnr = "111222333",
+                    arbeidstakerNavn = "John Doe",
+                    arbeidstakerFnr = "99887766554"
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Employer"
+            html shouldContain "Organisation number"
+            html shouldContain "Employee"
+            html shouldContain "National identity number"
+            html shouldContain "Test Corp Ltd"
+            html shouldContain "John Doe"
+        }
+
+        test("viser 'D-nummer' som label når identifikator er d-nummer") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_DN",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Nav Kontaktsenter AS",
+                    orgnr = "987654321",
+                    arbeidstakerNavn = "Kari Nordmann",
+                    arbeidstakerFnr = "41015678901" // Starter med 4 → D-nummer
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "D-nummer"
+            html shouldNotContain "Fødselsnummer"
+        }
+
+        test("viser 'Fødselsnummer' som label når identifikator er fødselsnummer") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_FN",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Nav Kontaktsenter AS",
+                    orgnr = "987654321",
+                    arbeidstakerNavn = "Kari Nordmann",
+                    arbeidstakerFnr = "11223344556" // Starter med 1 → fødselsnummer
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Fødselsnummer"
+            html shouldNotContain "D-nummer"
+        }
+
+        test("escaper HTML-spesialtegn i aktør-info") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "AKT_XS",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Tom & Jerry AS",
+                    orgnr = "123456789",
+                    arbeidstakerNavn = "O'Brien",
+                    arbeidstakerFnr = "12345678901"
+                )
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Tom &amp; Jerry AS"
+            html shouldContain "O&#39;Brien"
         }
     }
 


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-8050

PDF-søknaden som genereres inneholdt ingen informasjon om hvilken arbeidsgiver eller arbeidstaker søknaden gjelder. Personer som ser søknaden kun via PDF (f.eks. Kontaktsenteret i Gosys) manglet denne konteksten.

Løsningen legger til en ny seksjon øverst i PDF-en (etter header, før skjemadata) som viser:
- **Arbeidstaker:** Navn + fødselsnummer/D-nummer
- **Arbeidsgiver:** Navn + organisasjonsnummer

Dataen hentes fra skjema-metadata (`arbeidsgiverNavn`, `orgnr`) og PDL (arbeidstakernavn via fnr-oppslag). Label for personidentifikator utledes dynamisk — viser "D-nummer" når første siffer er 4–7, ellers "Fødselsnummer".

Seksjonen bruker samme `form-summary`-stilsett som resten av PDF-en for konsistens, og støtter norsk/engelsk basert på `innsendtSprak`.

## Akseptansekriterier

Alle tre scenarioer fra oppgaven dekkes med én felles renderingsvei, siden backend normaliserer dataen uavhengig av representasjonstype:
- ✅ Arbeidsgiver/rådgiver fyller ut → arbeidsgiver + arbeidstaker vises
- ✅ Annen person fyller ut → arbeidsgiver + arbeidstaker vises
- ✅ "Deg selv" fyller ut → arbeidsgiver + arbeidstaker (=innlogget bruker) vises

## Endrede filer

- `SkjemaPdfData.kt` — Ny `AktørInfo` dataklasse + felt på `SkjemaPdfData`
- `HtmlDokumentGenerator.kt` — Ny `byggAktørInfoSeksjon()` + `personidentifikatorLabel()` for dynamisk fnr/d-nr label
- `M2MSkjemaService.kt` — Injiserer `PdlConsumer`, henter arbeidstakernavn fra PDL, bygger `AktørInfo`
- `PdfGeneratorTest.kt` — 6 nye tester (norsk AG, norsk AT, engelsk, D-nummer, fødselsnummer, XSS-escaping)

## Testing

Kan verifiseres lokalt ved å generere en PDF via M2M-endepunktet:
```
GET /api/m2m/skjema/{skjemaId}/pdf
```