### PR TITLE
8061: Vis land og søknadsperiode i PDF for kun AG-del

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
@@ -212,6 +212,12 @@ class SeksjonRenderer(
     ): String {
         val builder = StringBuilder()
 
+        data.utsendingsperiodeOgLand?.let { dto ->
+            definisjon.seksjoner["utsendingsperiodeOgLand"]?.let { seksjon ->
+                builder.append(byggUtsendingsperiodeOgLand(dto, seksjon))
+            }
+        }
+
         data.arbeidsgiverensVirksomhetINorge?.let { dto ->
             definisjon.seksjoner["arbeidsgiverensVirksomhetINorge"]?.let { seksjon ->
                 builder.append(byggArbeidsgiverensVirksomhetINorge(dto, seksjon))

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -649,6 +649,11 @@ class PdfGeneratorTest : FunSpec({
             html shouldContain "Arbeidsgivers del"
             html shouldContain "Arbeidsgiverens virksomhet i Norge"
 
+            html shouldContain "I hvilket land skal du utføre arbeid?"
+            html shouldContain "Sverige"
+            html shouldContain "Fra dato"
+            html shouldContain "Til dato"
+
             // Sjekk at arbeidstaker-overskrift IKKE er med (nøyaktig match)
             html shouldNotContain """<h2 class="part-heading">Arbeidstakers del</h2>"""
         }
@@ -670,6 +675,7 @@ private fun lagKomplettArbeidstakerData(): UtsendtArbeidstakerArbeidstakersSkjem
 
 private fun lagKomplettArbeidsgiverData(): UtsendtArbeidstakerArbeidsgiversSkjemaDataDto {
     return UtsendtArbeidstakerArbeidsgiversSkjemaDataDto(
+        utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier(),
         arbeidsgiverensVirksomhetINorge = arbeidsgiverensVirksomhetINorgeDtoMedDefaultVerdier(),
         utenlandsoppdraget = utenlandsoppdragetDtoMedDefaultVerdier(),
         arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier(),


### PR DESCRIPTION
## Sammendrag
Når kun arbeidsgiverdel (uten fullmakt) sendes inn manglet `utsendingsperiodeOgLand` i PDF-en. `byggArbeidsgiverSeksjoner` i `SeksjonRenderer` rendrer den nå på samme måte som de to andre variantene (arbeidstaker-bare og kombinert).

Eksisterende test `genererer PDF for kun arbeidsgivers del` er utvidet til å verifisere at land og periode kommer med.

[MELOSYS-8061](https://jira.adeo.no/browse/MELOSYS-8061)
