### PR TITLE
8058: Vis alle felter fra utfylte skjemaer i PDF og oppsummering

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/felles/NorskeOgUtenlandskeVirksomheter.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/felles/NorskeOgUtenlandskeVirksomheter.kt
@@ -3,6 +3,16 @@ package no.nav.melosys.skjema.types.felles
 import com.fasterxml.jackson.annotation.JsonInclude
 import jakarta.validation.Valid
 
+/**
+ * Diskriminator-nøkler for virksomheter i blandede norsk/utenlandsk-lister.
+ * Brukes både som nøkler i [no.nav.melosys.skjema.types.skjemadefinisjon.ListeFeltDefinisjon.itemTypeLabels]
+ * og som type-tag mot frontend.
+ */
+object VirksomhetTypeKey {
+    const val NORSK = "norsk"
+    const val UTENLANDSK = "utenlandsk"
+}
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class NorskeOgUtenlandskeVirksomheter(
     @field:Valid

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/FeltDefinisjonDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/FeltDefinisjonDto.kt
@@ -124,6 +124,8 @@ data class CountrySelectFeltDefinisjon(
  * @property fjernLabel Label for "Fjern"-knappen
  * @property tomListeMelding Melding som vises når listen er tom
  * @property elementDefinisjon Definisjon av feltene i hvert liste-element
+ * @property itemTypeLabels Tittel per element-type for diskriminerte lister (f.eks. norsk/utenlandsk
+ * virksomhet). Nøklene mappes mot et type-felt på hvert element i UI-flyten. Null for ikke-diskriminerte lister.
  */
 data class ListeFeltDefinisjon(
     override val label: String,

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/FeltDefinisjonDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/FeltDefinisjonDto.kt
@@ -132,7 +132,8 @@ data class ListeFeltDefinisjon(
     val leggTilLabel: String,
     val fjernLabel: String,
     val tomListeMelding: String? = null,
-    val elementDefinisjon: Map<String, FeltDefinisjonDto>
+    val elementDefinisjon: Map<String, FeltDefinisjonDto>,
+    val itemTypeLabels: Map<String, String>? = null
 ) : FeltDefinisjonDto()
 
 /**

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/flerspraklig/FlersprakligFeltModel.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/skjemadefinisjon/flerspraklig/FlersprakligFeltModel.kt
@@ -164,7 +164,8 @@ data class FlersprakligListeFeltDto(
     val leggTilLabel: FlersprakligTekst,
     val fjernLabel: FlersprakligTekst,
     val tomListeMelding: FlersprakligTekst? = null,
-    val elementDefinisjon: Map<String, FlersprakligFeltModel>
+    val elementDefinisjon: Map<String, FlersprakligFeltModel>,
+    val itemTypeLabels: Map<String, FlersprakligTekst>? = null
 ) : FlersprakligFeltModel() {
     override fun tilFeltDto(språk: Språk) = ListeFeltDefinisjon(
         label = label.hent(språk),
@@ -173,7 +174,8 @@ data class FlersprakligListeFeltDto(
         leggTilLabel = leggTilLabel.hent(språk),
         fjernLabel = fjernLabel.hent(språk),
         tomListeMelding = tomListeMelding?.hent(språk),
-        elementDefinisjon = elementDefinisjon.mapValues { it.value.tilFeltDto(språk) }
+        elementDefinisjon = elementDefinisjon.mapValues { it.value.tilFeltDto(språk) },
+        itemTypeLabels = itemTypeLabels?.mapValues { it.value.hent(språk) }
     )
 }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
@@ -152,6 +152,7 @@ class FeltRenderer(
         }
 
         val ed = felt.elementDefinisjon
+        val itemTypeLabels = felt.itemTypeLabels.orEmpty()
         val builder = StringBuilder()
         builder.append("""<div class="list-container">""")
         builder.append("""<div class="list-label">${escapeHtml(felt.label)}</div>""")
@@ -160,14 +161,14 @@ class FeltRenderer(
 
         norske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
-            builder.append("""<div class="list-item-title">${index++}. virksomhet (norsk)</div>""")
+            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue("norsk"))}</div>""")
             builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
             builder.append("</div>")
         }
 
         utenlandske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
-            builder.append("""<div class="list-item-title">${index++}. virksomhet (utenlandsk)</div>""")
+            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue("utenlandsk"))}</div>""")
             builder.append(renderListeFelt(ed.getValue("navn"), virksomhet.navn))
             builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
             builder.append(renderListeFelt(ed.getValue("vegnavnOgHusnummer"), virksomhet.vegnavnOgHusnummer))

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
@@ -56,14 +56,8 @@ class FeltRenderer(
         """.trimIndent()
     }
 
-    private fun renderBoolean(felt: BooleanFeltDefinisjon, verdi: Any): String {
-        val boolVerdi = when (verdi) {
-            is Boolean -> verdi
-            else -> return ""
-        }
-        val visningsverdi = if (boolVerdi) felt.jaLabel else felt.neiLabel
-        return renderEnkeltFelt(felt.label, visningsverdi)
-    }
+    private fun renderBoolean(felt: BooleanFeltDefinisjon, verdi: Any): String =
+        formaterVerdi(felt, verdi)?.let { renderEnkeltFelt(felt.label, it) } ?: ""
 
     private fun renderText(felt: TextFeltDefinisjon, verdi: Any): String {
         val tekst = verdi.toString()
@@ -94,22 +88,11 @@ class FeltRenderer(
                 renderEnkeltFelt(felt.tilDatoLabel, tilDato)
     }
 
-    private fun renderSelect(felt: SelectFeltDefinisjon, verdi: Any): String {
-        val verdiStr = when (verdi) {
-            is Enum<*> -> verdi.name
-            else -> verdi.toString()
-        }
-        val visningsverdi = felt.alternativer.find { it.verdi == verdiStr }?.label ?: verdiStr
-        return renderEnkeltFelt(felt.label, visningsverdi)
-    }
+    private fun renderSelect(felt: SelectFeltDefinisjon, verdi: Any): String =
+        formaterVerdi(felt, verdi)?.let { renderEnkeltFelt(felt.label, it) } ?: ""
 
-    private fun renderCountry(felt: CountrySelectFeltDefinisjon, verdi: Any): String {
-        val landnavn = when (verdi) {
-            is LandKode -> verdi.hentNavn(språk)
-            else -> verdi.toString()
-        }
-        return renderEnkeltFelt(felt.label, landnavn)
-    }
+    private fun renderCountry(felt: CountrySelectFeltDefinisjon, verdi: Any): String =
+        formaterVerdi(felt, verdi)?.let { renderEnkeltFelt(felt.label, it) } ?: ""
 
     private fun renderCheckboxGruppe(felt: CheckboxGruppeFeltDefinisjon, verdi: Any): String {
         val valgteVerdier: Set<String> = when (verdi) {
@@ -206,20 +189,22 @@ class FeltRenderer(
 
     private fun renderListeFelt(feltDef: FeltDefinisjonDto, verdi: Any?): String {
         if (verdi == null) return ""
-        val visningsverdi = when (feltDef) {
-            is BooleanFeltDefinisjon -> if (verdi as Boolean) feltDef.jaLabel else feltDef.neiLabel
-            is SelectFeltDefinisjon -> {
-                val verdiStr = if (verdi is Enum<*>) verdi.name else verdi.toString()
-                feltDef.alternativer.find { it.verdi == verdiStr }?.label ?: verdiStr
-            }
-            is CountrySelectFeltDefinisjon -> when (verdi) {
-                is LandKode -> verdi.hentNavn(språk)
-                is String -> LandKode.hentLandnavn(verdi, språk)
-                else -> verdi.toString()
-            }
+        val visningsverdi = formaterVerdi(feltDef, verdi) ?: return ""
+        return renderListeElement(feltDef.label, visningsverdi)
+    }
+
+    private fun formaterVerdi(feltDef: FeltDefinisjonDto, verdi: Any): String? = when (feltDef) {
+        is BooleanFeltDefinisjon -> (verdi as? Boolean)?.let { if (it) feltDef.jaLabel else feltDef.neiLabel }
+        is SelectFeltDefinisjon -> {
+            val verdiStr = if (verdi is Enum<*>) verdi.name else verdi.toString()
+            feltDef.alternativer.find { it.verdi == verdiStr }?.label ?: verdiStr
+        }
+        is CountrySelectFeltDefinisjon -> when (verdi) {
+            is LandKode -> verdi.hentNavn(språk)
+            is String -> LandKode.hentLandnavn(verdi, språk)
             else -> verdi.toString()
         }
-        return renderListeElement(feltDef.label, visningsverdi)
+        else -> verdi.toString()
     }
 
     private fun renderGeneriskListe(felt: ListeFeltDefinisjon, liste: List<*>): String {

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
@@ -10,6 +10,7 @@ import no.nav.melosys.skjema.types.felles.NorskeOgUtenlandskeVirksomheterMedAnse
 import no.nav.melosys.skjema.types.felles.PeriodeDto
 import no.nav.melosys.skjema.types.felles.UtenlandskVirksomhetBase
 import no.nav.melosys.skjema.types.felles.UtenlandskVirksomhetMedAnsettelsesform
+import no.nav.melosys.skjema.types.felles.VirksomhetTypeKey
 import no.nav.melosys.skjema.types.skjemadefinisjon.BooleanFeltDefinisjon
 import no.nav.melosys.skjema.types.skjemadefinisjon.CheckboxGruppeFeltDefinisjon
 import no.nav.melosys.skjema.types.skjemadefinisjon.CountrySelectFeltDefinisjon
@@ -163,14 +164,14 @@ class FeltRenderer(
 
         norske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
-            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue("norsk"))}</div>""")
+            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue(VirksomhetTypeKey.NORSK))}</div>""")
             builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
             builder.append("</div>")
         }
 
         utenlandske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
-            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue("utenlandsk"))}</div>""")
+            builder.append("""<div class="list-item-title">${index++}. ${escapeHtml(itemTypeLabels.getValue(VirksomhetTypeKey.UTENLANDSK))}</div>""")
             builder.append(renderListeFelt(ed.getValue("navn"), virksomhet.navn))
             builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
             builder.append(renderListeFelt(ed.getValue("vegnavnOgHusnummer"), virksomhet.vegnavnOgHusnummer))

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
@@ -152,7 +152,9 @@ class FeltRenderer(
         }
 
         val ed = felt.elementDefinisjon
-        val itemTypeLabels = felt.itemTypeLabels.orEmpty()
+        val itemTypeLabels = requireNotNull(felt.itemTypeLabels) {
+            "Mangler itemTypeLabels i definisjonen for virksomhetsliste '${felt.label}'"
+        }
         val builder = StringBuilder()
         builder.append("""<div class="list-container">""")
         builder.append("""<div class="list-label">${escapeHtml(felt.label)}</div>""")

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/FeltRenderer.kt
@@ -4,8 +4,12 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.felles.LandKode
+import no.nav.melosys.skjema.types.felles.NorskVirksomhet
 import no.nav.melosys.skjema.types.felles.NorskeOgUtenlandskeVirksomheter
+import no.nav.melosys.skjema.types.felles.NorskeOgUtenlandskeVirksomheterMedAnsettelsesform
 import no.nav.melosys.skjema.types.felles.PeriodeDto
+import no.nav.melosys.skjema.types.felles.UtenlandskVirksomhetBase
+import no.nav.melosys.skjema.types.felles.UtenlandskVirksomhetMedAnsettelsesform
 import no.nav.melosys.skjema.types.skjemadefinisjon.BooleanFeltDefinisjon
 import no.nav.melosys.skjema.types.skjemadefinisjon.CheckboxGruppeFeltDefinisjon
 import no.nav.melosys.skjema.types.skjemadefinisjon.CountrySelectFeltDefinisjon
@@ -143,20 +147,28 @@ class FeltRenderer(
                 }
             }
 
-            is NorskeOgUtenlandskeVirksomheter -> renderVirksomheter(felt, verdi)
+            is NorskeOgUtenlandskeVirksomheter ->
+                renderVirksomheter(felt, verdi.norskeVirksomheter, verdi.utenlandskeVirksomheter)
+            is NorskeOgUtenlandskeVirksomheterMedAnsettelsesform ->
+                renderVirksomheter(felt, verdi.norskeVirksomheter, verdi.utenlandskeVirksomheter)
             else -> ""
         }
     }
 
 
-    private fun renderVirksomheter(felt: ListeFeltDefinisjon, virksomheter: NorskeOgUtenlandskeVirksomheter): String {
-        val norske = virksomheter.norskeVirksomheter ?: emptyList()
-        val utenlandske = virksomheter.utenlandskeVirksomheter ?: emptyList()
+    private fun renderVirksomheter(
+        felt: ListeFeltDefinisjon,
+        norskeVirksomheter: List<NorskVirksomhet>?,
+        utenlandskeVirksomheter: List<UtenlandskVirksomhetBase>?
+    ): String {
+        val norske = norskeVirksomheter ?: emptyList()
+        val utenlandske = utenlandskeVirksomheter ?: emptyList()
 
         if (norske.isEmpty() && utenlandske.isEmpty()) {
             return felt.tomListeMelding?.let { renderEnkeltFelt(felt.label, it) } ?: ""
         }
 
+        val ed = felt.elementDefinisjon
         val builder = StringBuilder()
         builder.append("""<div class="list-container">""")
         builder.append("""<div class="list-label">${escapeHtml(felt.label)}</div>""")
@@ -166,23 +178,48 @@ class FeltRenderer(
         norske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
             builder.append("""<div class="list-item-title">${index++}. virksomhet (norsk)</div>""")
-            builder.append(renderListeElement("Organisasjonsnummer", virksomhet.organisasjonsnummer))
+            builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
             builder.append("</div>")
         }
 
         utenlandske.forEach { virksomhet ->
             builder.append("""<div class="list-item">""")
             builder.append("""<div class="list-item-title">${index++}. virksomhet (utenlandsk)</div>""")
-            builder.append(renderListeElement("Navn", virksomhet.navn))
-            virksomhet.organisasjonsnummer?.let { builder.append(renderListeElement("Organisasjonsnummer", it)) }
-            // land er en String landkode, konverter til landnavn
-            val landnavn = LandKode.hentLandnavn(virksomhet.land, språk)
-            builder.append(renderListeElement("Land", landnavn))
+            builder.append(renderListeFelt(ed.getValue("navn"), virksomhet.navn))
+            builder.append(renderListeFelt(ed.getValue("organisasjonsnummer"), virksomhet.organisasjonsnummer))
+            builder.append(renderListeFelt(ed.getValue("vegnavnOgHusnummer"), virksomhet.vegnavnOgHusnummer))
+            builder.append(renderListeFelt(ed.getValue("bygning"), virksomhet.bygning))
+            builder.append(renderListeFelt(ed.getValue("postkode"), virksomhet.postkode))
+            builder.append(renderListeFelt(ed.getValue("byStedsnavn"), virksomhet.byStedsnavn))
+            builder.append(renderListeFelt(ed.getValue("region"), virksomhet.region))
+            builder.append(renderListeFelt(ed.getValue("land"), virksomhet.land))
+            builder.append(renderListeFelt(ed.getValue("tilhorerSammeKonsern"), virksomhet.tilhorerSammeKonsern))
+            if (virksomhet is UtenlandskVirksomhetMedAnsettelsesform) {
+                builder.append(renderListeFelt(ed.getValue("ansettelsesform"), virksomhet.ansettelsesform))
+            }
             builder.append("</div>")
         }
 
         builder.append("</div>")
         return builder.toString()
+    }
+
+    private fun renderListeFelt(feltDef: FeltDefinisjonDto, verdi: Any?): String {
+        if (verdi == null) return ""
+        val visningsverdi = when (feltDef) {
+            is BooleanFeltDefinisjon -> if (verdi as Boolean) feltDef.jaLabel else feltDef.neiLabel
+            is SelectFeltDefinisjon -> {
+                val verdiStr = if (verdi is Enum<*>) verdi.name else verdi.toString()
+                feltDef.alternativer.find { it.verdi == verdiStr }?.label ?: verdiStr
+            }
+            is CountrySelectFeltDefinisjon -> when (verdi) {
+                is LandKode -> verdi.hentNavn(språk)
+                is String -> LandKode.hentLandnavn(verdi, språk)
+                else -> verdi.toString()
+            }
+            else -> verdi.toString()
+        }
+        return renderListeElement(feltDef.label, visningsverdi)
     }
 
     private fun renderGeneriskListe(felt: ListeFeltDefinisjon, liste: List<*>): String {

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
@@ -199,7 +199,7 @@ class SeksjonRenderer(
         }
 
         data.tilleggsopplysninger?.let { dto ->
-            definisjon.seksjoner["tilleggsopplysninger"]?.let { seksjon ->
+            definisjon.seksjoner["tilleggsopplysningerArbeidstaker"]?.let { seksjon ->
                 builder.append(byggTilleggsopplysninger(dto, seksjon))
             }
         }

--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -154,6 +154,70 @@
                   }
                 }
               ]
+            },
+            "vegnavnOgHusnummer": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Vegnavn og husnummer",
+                "en": "Street name and number"
+              },
+              "pakrevd": true
+            },
+            "bygning": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Bygning",
+                "en": "Building"
+              },
+              "pakrevd": false
+            },
+            "postkode": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Postkode",
+                "en": "Postal code"
+              },
+              "pakrevd": false
+            },
+            "byStedsnavn": {
+              "type": "TEXT",
+              "label": {
+                "nb": "By/stedsnavn",
+                "en": "City/place name"
+              },
+              "pakrevd": false
+            },
+            "region": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Region",
+                "en": "Region"
+              },
+              "pakrevd": false
+            },
+            "land": {
+              "type": "COUNTRY_SELECT",
+              "label": {
+                "nb": "Land",
+                "en": "Country"
+              },
+              "pakrevd": true
+            },
+            "tilhorerSammeKonsern": {
+              "type": "BOOLEAN",
+              "label": {
+                "nb": "Tilhører samme konsern som norsk arbeidsgiver?",
+                "en": "Belongs to the same group as the Norwegian employer?"
+              },
+              "jaLabel": {
+                "nb": "Ja",
+                "en": "Yes"
+              },
+              "neiLabel": {
+                "nb": "Nei",
+                "en": "No"
+              },
+              "pakrevd": true
             }
           }
         }
@@ -970,6 +1034,70 @@
                 "en": "Company name"
               },
               "pakrevd": false
+            },
+            "vegnavnOgHusnummer": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Vegnavn og husnummer",
+                "en": "Street name and number"
+              },
+              "pakrevd": true
+            },
+            "bygning": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Bygning",
+                "en": "Building"
+              },
+              "pakrevd": false
+            },
+            "postkode": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Postkode",
+                "en": "Postal code"
+              },
+              "pakrevd": false
+            },
+            "byStedsnavn": {
+              "type": "TEXT",
+              "label": {
+                "nb": "By/stedsnavn",
+                "en": "City/place name"
+              },
+              "pakrevd": false
+            },
+            "region": {
+              "type": "TEXT",
+              "label": {
+                "nb": "Region",
+                "en": "Region"
+              },
+              "pakrevd": false
+            },
+            "land": {
+              "type": "COUNTRY_SELECT",
+              "label": {
+                "nb": "Land",
+                "en": "Country"
+              },
+              "pakrevd": true
+            },
+            "tilhorerSammeKonsern": {
+              "type": "BOOLEAN",
+              "label": {
+                "nb": "Tilhører samme konsern som norsk arbeidsgiver?",
+                "en": "Belongs to the same group as the Norwegian employer?"
+              },
+              "jaLabel": {
+                "nb": "Ja",
+                "en": "Yes"
+              },
+              "neiLabel": {
+                "nb": "Nei",
+                "en": "No"
+              },
+              "pakrevd": true
             }
           }
         }

--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -107,6 +107,16 @@
             "en": "Remove"
           },
           "pakrevd": false,
+          "itemTypeLabels": {
+            "norsk": {
+              "nb": "Norsk virksomhet",
+              "en": "Norwegian company"
+            },
+            "utenlandsk": {
+              "nb": "Utenlandsk virksomhet",
+              "en": "Foreign company"
+            }
+          },
           "elementDefinisjon": {
             "organisasjonsnummer": {
               "type": "TEXT",
@@ -1018,6 +1028,16 @@
             "en": "Remove"
           },
           "pakrevd": false,
+          "itemTypeLabels": {
+            "norsk": {
+              "nb": "Norsk virksomhet",
+              "en": "Norwegian company"
+            },
+            "utenlandsk": {
+              "nb": "Utenlandsk virksomhet",
+              "en": "Foreign company"
+            }
+          },
           "elementDefinisjon": {
             "organisasjonsnummer": {
               "type": "TEXT",

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -33,10 +33,12 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedType
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.common.Språk
+import no.nav.melosys.skjema.types.felles.NorskeOgUtenlandskeVirksomheter
 import no.nav.melosys.skjema.types.felles.TilleggsopplysningerDto
 import no.nav.melosys.skjema.arbeidsgiverOgArbeidstakerSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.norskeOgUtenlandskeVirksomheterMedAnsettelsesformMedDefaultVerdier
 import no.nav.melosys.skjema.norskeOgUtenlandskeVirksomheterMedDefaultVerdier
+import no.nav.melosys.skjema.utenlandskVirksomhetMedDefaultVerdier
 import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
 import no.nav.melosys.skjema.utenlandsoppdragetDtoMedDefaultVerdier
 import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider
@@ -595,7 +597,31 @@ class PdfGeneratorTest : FunSpec({
             html shouldContain "12345"
             html shouldContain "Stockholm County"
             html shouldContain "Sverige"
-            html shouldContain "Tilhører samme konsern som norsk arbeidsgiver?"
+            val tilhorerKonsernVerdi = verdiEtterLabel(html, "Tilhører samme konsern som norsk arbeidsgiver?")
+            tilhorerKonsernVerdi shouldBe "Ja"
+        }
+
+        test("rendrer tilhorerSammeKonsern=false som Nei") {
+            val utenlandsk = utenlandskVirksomhetMedDefaultVerdier().copy(tilhorerSammeKonsern = false)
+            val arbeidsgiverData = lagKomplettArbeidsgiverData().copy(
+                arbeidstakerensLonn = ArbeidstakerensLonnDto(
+                    arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden = false,
+                    virksomheterSomUtbetalerLonnOgNaturalytelser = NorskeOgUtenlandskeVirksomheter(
+                        norskeVirksomheter = null,
+                        utenlandskeVirksomheter = listOf(utenlandsk)
+                    )
+                )
+            )
+
+            val skjema = lagSkjemaPdfData(
+                referanseId = "UTLAGN",
+                arbeidsgiverData = arbeidsgiverData
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            val tilhorerKonsernVerdi = verdiEtterLabel(html, "Tilhører samme konsern som norsk arbeidsgiver?")
+            tilhorerKonsernVerdi shouldBe "Nei"
         }
 
         test("viser alle felter inkludert ansettelsesform når arbeidstaker jobber for flere virksomheter") {
@@ -654,6 +680,18 @@ class PdfGeneratorTest : FunSpec({
         }
     }
 })
+
+/**
+ * Plukker ut verdien som rendreres rett etter en gitt label i den genererte HTML-en.
+ * Brukes for å verifisere felt-verdier uten å være avhengig av label-uavhengige strenger som
+ * "Ja"/"Nei", som finnes mange steder i en typisk PDF.
+ */
+private fun verdiEtterLabel(html: String, label: String): String? {
+    val regex = Regex(
+        """<span class="list-item-label">${Regex.escape(label)}</span>\s*<span class="list-item-value">([^<]*)</span>"""
+    )
+    return regex.find(html)?.groupValues?.get(1)
+}
 
 private fun lagKomplettArbeidstakerData(): UtsendtArbeidstakerArbeidstakersSkjemaDataDto {
     return UtsendtArbeidstakerArbeidstakersSkjemaDataDto(

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -636,7 +636,12 @@ class PdfGeneratorTest : FunSpec({
                 referanseId = "FULLMK",
                 innsendtDato = Instant.now(),
                 innsendtSprak = Språk.NORSK_BOKMAL,
-                aktørInfo = AktørInfo("Bedrift AS", "123456789", "Ola Nordmann", "12345678901"),
+                aktørInfo = AktørInfo(
+                    arbeidsgiverNavn = "Bedrift AS",
+                    orgnr = "123456789",
+                    arbeidstakerNavn = "Ola Nordmann",
+                    arbeidstakerFnr = "12345678901"
+                ),
                 skjemaData = data,
                 kobletSkjemaData = null,
                 definisjon = definisjon

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -27,12 +27,16 @@ import no.nav.melosys.skjema.service.skjemadefinisjon.SkjemaDefinisjonService
 import no.nav.melosys.skjema.skatteforholdOgInntektDtoMedDefaultVerdier
 import no.nav.melosys.skjema.tilleggsopplysningerDtoMedDefaultVerdier
 import no.nav.melosys.skjema.types.SkjemaType
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidstakerensLonnDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedType
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.felles.TilleggsopplysningerDto
+import no.nav.melosys.skjema.arbeidsgiverOgArbeidstakerSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.norskeOgUtenlandskeVirksomheterMedAnsettelsesformMedDefaultVerdier
+import no.nav.melosys.skjema.norskeOgUtenlandskeVirksomheterMedDefaultVerdier
 import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
 import no.nav.melosys.skjema.utenlandsoppdragetDtoMedDefaultVerdier
 import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider
@@ -565,6 +569,83 @@ class PdfGeneratorTest : FunSpec({
 
             // Sjekk at arbeidstaker-overskrift IKKE er med (nøyaktig match)
             html shouldNotContain """<h2 class="part-heading">Arbeidstakers del</h2>"""
+        }
+    }
+
+    context("Utenlandsk virksomhet") {
+        test("viser alle adressefelter for utenlandsk lønnsutbetaler i arbeidsgivers del") {
+            val arbeidsgiverData = lagKomplettArbeidsgiverData().copy(
+                arbeidstakerensLonn = ArbeidstakerensLonnDto(
+                    arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden = false,
+                    virksomheterSomUtbetalerLonnOgNaturalytelser = norskeOgUtenlandskeVirksomheterMedDefaultVerdier()
+                )
+            )
+
+            val skjema = lagSkjemaPdfData(
+                referanseId = "UTLAGV",
+                arbeidsgiverData = arbeidsgiverData
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Foreign Company Ltd"
+            html shouldContain "ABC123"
+            html shouldContain "Main Street 123"
+            html shouldContain "Building A"
+            html shouldContain "12345"
+            html shouldContain "Stockholm County"
+            html shouldContain "Sverige"
+            html shouldContain "Tilhører samme konsern som norsk arbeidsgiver?"
+        }
+
+        test("viser alle felter inkludert ansettelsesform når arbeidstaker jobber for flere virksomheter") {
+            val arbeidstakerData = lagKomplettArbeidstakerData().copy(
+                arbeidssituasjon = arbeidssituasjonDtoMedDefaultVerdier().copy(
+                    skalJobbeForFlereVirksomheter = true,
+                    virksomheterArbeidstakerJobberForIutsendelsesPeriode =
+                        norskeOgUtenlandskeVirksomheterMedAnsettelsesformMedDefaultVerdier()
+                )
+            )
+
+            val skjema = lagSkjemaPdfData(
+                referanseId = "UTLAT1",
+                arbeidstakerData = arbeidstakerData
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Foreign Company Ltd"
+            html shouldContain "Main Street 123"
+            html shouldContain "Building A"
+            html shouldContain "Hva jobber du som i denne virksomheten?"
+            html shouldContain "Arbeidstaker eller frilanser"
+        }
+    }
+
+    context("Kombinert skjema (fullmakt)") {
+        test("viser tilleggsopplysninger fra toppnivå i kombinert PDF") {
+            val data = arbeidsgiverOgArbeidstakerSkjemaDataDtoMedDefaultVerdier().copy(
+                tilleggsopplysninger = TilleggsopplysningerDto(
+                    harFlereOpplysningerTilSoknaden = true,
+                    tilleggsopplysningerTilSoknad = "Tillegg via fullmektig"
+                )
+            )
+            val definisjon = skjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, null, Språk.NORSK_BOKMAL)
+            val skjema = SkjemaPdfData(
+                skjemaId = UUID.randomUUID(),
+                referanseId = "FULLMK",
+                innsendtDato = Instant.now(),
+                innsendtSprak = Språk.NORSK_BOKMAL,
+                aktørInfo = AktørInfo("Bedrift AS", "123456789", "Ola Nordmann", "12345678901"),
+                skjemaData = data,
+                kobletSkjemaData = null,
+                definisjon = definisjon
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Tilleggsopplysninger"
+            html shouldContain "Tillegg via fullmektig"
         }
     }
 })


### PR DESCRIPTION
## Sammendrag
Tre relaterte mangler i PDF og oppsummeringsside som alle handler om at brukerutfylte data ikke kommer ut:

- **Adresse til utenlandsk virksomhet** vises ikke (hovedscope). Skyldtes både ufullstendig `elementDefinisjon` i definisjonen (oppsummering) og hardkodet renderer (PDF). Definisjonen utvides med adressefelter (`vegnavnOgHusnummer`, `bygning`, `postkode`, `byStedsnavn`, `region`, `land`, `tilhorerSammeKonsern`) for begge virksomhetslister.
- **`NorskeOgUtenlandskeVirksomheterMedAnsettelsesform` (i arbeidssituasjon) renderes ikke** – hele lista falt bort i `renderListe` siden bare basisvarianten var håndtert.
- **Tilleggsopplysninger forsvant i fullmakt-PDF** – `byggKombinertArbeidstakersSeksjoner` slo opp seksjonsnavnet `tilleggsopplysninger` som ikke finnes i definisjonen.

`renderVirksomheter` bruker nå definisjonen som kilde via `elementDefinisjon.getValue("X")` – fail-fast hvis et felt mangler i definisjonen, ingen fallback.

[MELOSYS-8058](https://jira.adeo.no/browse/MELOSYS-8058)