### PR TITLE
8055: Ikke serialiser null over wire og gjør arbeidstakerNavn non-null

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSoknadOversiktDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSoknadOversiktDto.kt
@@ -14,7 +14,7 @@ data class InnsendtSoknadOversiktDto(
     val referanseId: String?,
     val arbeidsgiverNavn: String?,
     val arbeidsgiverOrgnr: String,
-    val arbeidstakerNavn: String?,
+    val arbeidstakerNavn: String,
     val arbeidstakerFnrMaskert: String?, // Maskert fnr (f.eks. "010190*****")
     val arbeidstakerFodselsdato: LocalDate,
     val innsendtDato: Instant,

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/UtkastOversiktDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/UtkastOversiktDto.kt
@@ -12,7 +12,7 @@ data class UtkastOversiktDto(
     val id: UUID,
     val arbeidsgiverNavn: String?,
     val arbeidsgiverOrgnr: String?,
-    val arbeidstakerNavn: String?,
+    val arbeidstakerNavn: String,
     val arbeidstakerFnrMaskert: String?, // Maskert fnr (f.eks. "01019*****")
     val opprettetDato: Instant,
     val sistEndretDato: Instant,

--- a/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
@@ -4,8 +4,10 @@ import io.swagger.v3.core.jackson.ModelResolver
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -31,4 +33,37 @@ class SwaggerConfig {
                     .description("Bearer token"),
             ),
         ).addSecurityItem(SecurityRequirement().addList("bearer-jwt"))
+
+    /**
+     * Fjerner "null" fra OpenAPI 3.1 `type`-arrays (f.eks. `["string", "null"]` -> `["string"]`).
+     *
+     * Springdoc utleder nullability fra Kotlin sin nullable-markering (`String?`),
+     * men i kombinasjon med Jackson `default-property-inclusion: non_null` serialiseres
+     * aldri null over nettet. Vi vil dermed at OpenAPI-spec'en skal reflektere
+     * faktisk wire-kontrakt (felt er fraværende, ikke null), slik at genererte
+     * TypeScript-typer blir `T | undefined` i stedet for `T | null | undefined`.
+     */
+    @Bean
+    fun stripNullFromSchemaTypes(): OpenApiCustomizer = OpenApiCustomizer { openApi ->
+        openApi.components?.schemas?.values?.forEach { stripNullFromSchema(it) }
+    }
+
+    private fun stripNullFromSchema(schema: Schema<*>) {
+        schema.types?.remove("null")
+        if (schema.types?.isEmpty() == true) {
+            schema.types = null
+        }
+        // Springdoc genererer `oneOf: [{$ref}, {types: ["null"]}]` for nullable
+        // $ref-felter. Vi vil bare beholde $ref-grenen.
+        schema.oneOf = schema.oneOf?.filterNot { it.types?.singleOrNull() == "null" }
+
+        schema.properties?.values?.forEach { stripNullFromSchema(it) }
+        schema.items?.let { stripNullFromSchema(it) }
+        schema.additionalProperties?.let {
+            if (it is Schema<*>) stripNullFromSchema(it)
+        }
+        schema.allOf?.forEach { stripNullFromSchema(it) }
+        schema.anyOf?.forEach { stripNullFromSchema(it) }
+        schema.oneOf?.forEach { stripNullFromSchema(it) }
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/HentUtkastUtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/HentUtkastUtsendtArbeidstakerService.kt
@@ -130,7 +130,7 @@ class HentUtkastUtsendtArbeidstakerService(
             id = skjema.id ?: throw IllegalStateException("Skjema ID er null"),
             arbeidsgiverNavn = metadata.arbeidsgiverNavn,
             arbeidsgiverOrgnr = skjema.orgnr,
-            arbeidstakerNavn = null,
+            arbeidstakerNavn = metadata.arbeidstakerNavn,
             arbeidstakerFnrMaskert = maskerFnr(skjema.fnr),
             opprettetDato = skjema.opprettetDato,
             sistEndretDato = skjema.endretDato,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       minimum-idle: 1
 
   jackson:
+    default-property-inclusion: non_null
     deserialization:
       fail-on-unknown-properties: false
       fail-on-missing-creator-properties: true

--- a/src/test/kotlin/no/nav/melosys/skjema/config/SwaggerConfigIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/config/SwaggerConfigIntegrationTest.kt
@@ -1,0 +1,38 @@
+package no.nav.melosys.skjema.config
+
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
+import no.nav.melosys.skjema.ApiTestBase
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
+
+class SwaggerConfigIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Test
+    fun `api-docs inneholder ikke null i type-arrays`() {
+        val apiDocs = webTestClient.get()
+            .uri("/v3/api-docs")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        // Lagre til disk for å kunne generere TypeScript-typer offline (uten
+        // dev-deploy). Frontend kan peke `pnpm generate-types --path` til denne.
+        Path.of("build/api-docs.json").apply {
+            createParentDirectories()
+            writeText(apiDocs)
+        }
+
+        // OpenAPI 3.1 ville representert nullable felter som "type":["string","null"].
+        // OpenApiCustomizer i SwaggerConfig fjerner "null" fra alle slike type-arrays.
+        apiDocs shouldNotContain "\"null\""
+    }
+}


### PR DESCRIPTION

Springdoc utleder nullability fra Kotlin sin `?`-markering. Kombinert med Jackson `non_null` blir wire-kontrakten "felt fraværende, aldri null", men OpenAPI-spec'en sa fortsatt `nullable: true`, så TypeScript-typene fikk `T | null | undefined`. Det forurenset form-resolvers og andre konsumenter på frontend uten å reflektere reell oppførsel.