### PR TITLE
8065: Tilgang til innsendt søknad etter tapt fullmakt

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -121,8 +121,26 @@ class UtsendtArbeidstakerService(
         )
     }
 
-    fun hentSkjema(skjemaId: UUID): UtsendtArbeidstakerSkjemaDto =
-        hentSkjemaMedLesetilgang(skjemaId).toUtsendtArbeidstakerDto()
+    /**
+     * Henter et skjema for visning.
+     *
+     * For UTKAST: krever skrivetilgang og at innlogget bruker er den som starta utkastet.
+     * For SENDT: lenient kontroll via [validerLesetilgangForSendtSkjema] — fullmektig som har mistet
+     * fullmakten men fortsatt har Altinn-tilgang får se skjemaet med arbeidstakers data strippet.
+     */
+    fun hentSkjema(skjemaId: UUID): UtsendtArbeidstakerSkjemaDto {
+        val skjema = findAktivByIdOrThrow(skjemaId)
+        if (skjema.status != SkjemaStatus.SENDT) {
+            return krevSkrivetilgang(skjema).toUtsendtArbeidstakerDto()
+        }
+
+        val dto = skjema.toUtsendtArbeidstakerDto()
+        return if (validerLesetilgangForSendtSkjema(skjema) == false) {
+            dto.copy(data = stripArbeidstakersData(dto.data))
+        } else {
+            dto
+        }
+    }
 
     /**
      * Soft-sletter et skjema med status UTKAST.
@@ -285,9 +303,13 @@ class UtsendtArbeidstakerService(
 
     }
 
-    fun getSkjemaMetadata(skjemaId: UUID): UtsendtArbeidstakerMetadata{
-        val skjema = hentSkjemaMedLesetilgang(skjemaId)
-
+    fun getSkjemaMetadata(skjemaId: UUID): UtsendtArbeidstakerMetadata {
+        val skjema = findAktivByIdOrThrow(skjemaId)
+        if (skjema.status == SkjemaStatus.SENDT) {
+            validerLesetilgangForSendtSkjema(skjema)
+        } else {
+            krevSkrivetilgang(skjema)
+        }
         return skjema.utsendtArbeidstakerMetadataOrThrow()
     }
 
@@ -300,14 +322,13 @@ class UtsendtArbeidstakerService(
      * @throws IllegalStateException hvis skjema ikke er innsendt
      */
     fun hentInnsendtSkjema(skjemaId: UUID, sprak: Språk?): InnsendtSkjemaResponse {
-        val skjema = skjemaRepository.findAktivById(skjemaId)
-            ?: throw NoSuchElementException("Skjema with id $skjemaId not found")
+        val skjema = findAktivByIdOrThrow(skjemaId)
 
         if (skjema.status != SkjemaStatus.SENDT) {
             throw IllegalStateException("Skjema $skjemaId er ikke innsendt (status: ${skjema.status})")
         }
 
-        val fullmaktAktiv = harAktivFullmaktForInnsendtSkjema(skjema)
+        val fullmaktAktiv = validerLesetilgangForSendtSkjema(skjema)
 
         if (fullmaktAktiv == false) {
             log.warn { "Fullmakt tapt for innsendt skjema ${skjema.id}, arbeidstaker-data strippet" }
@@ -350,13 +371,16 @@ class UtsendtArbeidstakerService(
      * @throws NoSuchElementException hvis skjema ikke finnes
      * @throws AccessDeniedException hvis tilgang nektes
      */
-    fun hentSkjemaMedLesetilgang(skjemaId: UUID): Skjema {
-        val skjema = skjemaRepository.findAktivById(skjemaId)
-            ?: throw NoSuchElementException("Skjema with id $skjemaId not found")
+    fun hentSkjemaMedLesetilgang(skjemaId: UUID): Skjema =
+        krevLesetilgang(findAktivByIdOrThrow(skjemaId))
 
-        return skjema.takeIf { harInnloggetBrukerLesetilgangTilSkjema(it) }
+    private fun krevLesetilgang(skjema: Skjema): Skjema =
+        skjema.takeIf { harInnloggetBrukerLesetilgangTilSkjema(it) }
             ?: throw AccessDeniedException("Innlogget bruker har ikke tilgang til skjema")
-    }
+
+    private fun findAktivByIdOrThrow(skjemaId: UUID): Skjema =
+        skjemaRepository.findAktivById(skjemaId)
+            ?: throw NoSuchElementException("Skjema med id $skjemaId finnes ikke")
 
     fun saveUtsendingsperiodeOgLand(skjemaId: UUID, request: UtsendingsperiodeOgLandDto): UtsendtArbeidstakerSkjemaDto {
         log.info { "Saving utsendingsperiode og land info for skjema: $skjemaId" }
@@ -533,11 +557,15 @@ class UtsendtArbeidstakerService(
     /**
      * Sjekker tilgang og om fullmakt er aktiv for innsendte skjemaer.
      *
+     * Returverdien styrer om arbeidstakers data skal strippes hos kalleren:
+     * - `null` = strippes ikke (ikke _MED_FULLMAKT, eller bruker er arbeidstakeren selv)
+     * - `true` = strippes ikke (aktiv fullmakt)
+     * - `false` = strippes (fullmakt tapt, men Altinn-fallback ga tilgang)
+     *
      * Kaster AccessDeniedException hvis bruker ikke har tilgang i det hele tatt.
-     * For _MED_FULLMAKT-typer der fullmakt er tapt men bruker har Altinn-tilgang: returnerer false.
      * For ANNEN_PERSON uten fullmakt: kaster AccessDeniedException (ingen fallback).
      */
-    private fun harAktivFullmaktForInnsendtSkjema(skjema: Skjema): Boolean? {
+    private fun validerLesetilgangForSendtSkjema(skjema: Skjema): Boolean? {
         val currentUser = subjectHandler.getUserID()
 
         if (skjema.fnr == currentUser) {
@@ -593,18 +621,22 @@ class UtsendtArbeidstakerService(
     /**
      * Validerer at innlogget bruker har tilgang til skjemaet.
      *
-     * Sjekker følgende i prioritert rekkefølge:
-     * 1. Er bruker arbeidstaker? (fnr match)
-     * 2. Er bruker fullmektig? (fullmektigFnr match + aktiv fullmakt via repr-api)
-     * 3. Har bruker Altinn-tilgang til arbeidsgiver? (orgnr match)
+     * For UTKAST: kun den som starta utkastet (opprettetAv-match) i tillegg til rollesjekk —
+     * utkast er personlig og deles ikke mellom brukere med samme rolle.
+     *
+     * For andre statuser: arbeidstaker selv (fnr-match) eller rollesjekk
+     * (fullmektig med aktiv fullmakt, eller Altinn-tilgang til arbeidsgiver).
      *
      * VIKTIG: Fullmakt verifiseres ALLTID mot repr-api for å sikre at den fortsatt er aktiv.
-     *
-     * @param skjema Skjemaet som skal sjekkes
-     * @throws IllegalArgumentException hvis bruker ikke har tilgang
      */
     private fun harInnloggetBrukerLesetilgangTilSkjema(skjema: Skjema): Boolean {
-        if (skjema.fnr == subjectHandler.getUserID()) {
+        val currentUser = subjectHandler.getUserID()
+
+        if (skjema.status == SkjemaStatus.UTKAST && skjema.opprettetAv != currentUser) {
+            return false
+        }
+
+        if (skjema.fnr == currentUser) {
             return true
         }
 
@@ -620,17 +652,17 @@ class UtsendtArbeidstakerService(
 
             Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT -> {
                 val metadata = skjemaMetadata as ArbeidsgiverMedFullmaktMetadata
-                metadata.fullmektigFnr == subjectHandler.getUserID() && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
+                metadata.fullmektigFnr == currentUser && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
             }
 
             Representasjonstype.RADGIVER_MED_FULLMAKT -> {
                 val metadata = skjemaMetadata as RadgiverMedFullmaktMetadata
-                metadata.fullmektigFnr == subjectHandler.getUserID() && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
+                metadata.fullmektigFnr == currentUser && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
             }
 
             Representasjonstype.ANNEN_PERSON -> {
                 val annenPersonMetadata = skjemaMetadata as AnnenPersonMetadata
-                annenPersonMetadata.fullmektigFnr == subjectHandler.getUserID() && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
+                annenPersonMetadata.fullmektigFnr == currentUser && reprService.harSkriverettigheterForMedlemskap(skjema.fnr)
             }
         }
     }
@@ -648,20 +680,26 @@ class UtsendtArbeidstakerService(
     /**
      * Henter skjema og verifiserer at innlogget bruker har skrivetilgang.
      *
-     * Til forskjell fra [hentSkjemaMedLesetilgang] (som også gir lesetilgang basert på fnr-match)
-     * krever denne at brukeren har riktig rolle for å kunne skrive:
+     * Krever at brukeren har riktig rolle:
      * - DEG_SELV: Kun arbeidstaker selv (fnr-match)
      * - ARBEIDSGIVER/RADGIVER: Kun via Altinn-tilgang til organisasjonen
      * - *_MED_FULLMAKT/ANNEN_PERSON: Kun fullmektig med aktiv fullmakt
+     *
+     * I tillegg for UTKAST: kun den som starta utkastet kan redigere — utkast er personlig
+     * og kan ikke overtas av andre brukere selv om de har samme rolle.
      */
-    private fun hentSkjemaMedSkrivetilgang(skjemaId: UUID): Skjema {
-        val skjema = skjemaRepository.findAktivById(skjemaId)
-            ?: throw NoSuchElementException("Skjema with id $skjemaId not found")
+    private fun hentSkjemaMedSkrivetilgang(skjemaId: UUID): Skjema =
+        krevSkrivetilgang(findAktivByIdOrThrow(skjemaId))
 
-        val skjemaMetadata = skjema.utsendtArbeidstakerMetadataOrThrow()
+    private fun krevSkrivetilgang(skjema: Skjema): Skjema {
         val currentUser = subjectHandler.getUserID()
 
-        val harTilgang = when (skjemaMetadata.representasjonstype) {
+        if (skjema.status == SkjemaStatus.UTKAST && skjema.opprettetAv != currentUser) {
+            throw AccessDeniedException("Innlogget bruker har ikke skrivetilgang til skjema")
+        }
+
+        val skjemaMetadata = skjema.utsendtArbeidstakerMetadataOrThrow()
+        val harRolle = when (skjemaMetadata.representasjonstype) {
             Representasjonstype.DEG_SELV -> skjema.fnr == currentUser
 
             Representasjonstype.ARBEIDSGIVER,
@@ -683,7 +721,7 @@ class UtsendtArbeidstakerService(
             }
         }
 
-        if (!harTilgang) {
+        if (!harRolle) {
             throw AccessDeniedException("Innlogget bruker har ikke skrivetilgang til skjema")
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerControllerIntegrationTest.kt
@@ -537,6 +537,8 @@ class UtsendtArbeidstakerControllerIntegrationTest : ApiTestBase() {
                 representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
                 fullmektigFnr = korrektSyntetiskFnr,
             ),
+            opprettetAv = korrektSyntetiskFnr,
+            endretAv = korrektSyntetiskFnr,
         )
 
         fun arbeidstakerSkjema(data: SkjemaData = atBaseData) = skjemaMedDefaultVerdier(
@@ -555,6 +557,8 @@ class UtsendtArbeidstakerControllerIntegrationTest : ApiTestBase() {
                 fullmektigFnr = korrektSyntetiskFnr,
                 skjemadel = Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
             ),
+            opprettetAv = korrektSyntetiskFnr,
+            endretAv = korrektSyntetiskFnr,
         )
 
         return listOf(

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
@@ -27,6 +27,11 @@ import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.SkjemaType
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.arbeidsgiverOgArbeidstakerSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
 import no.nav.melosys.skjema.validators.UtsendtArbeidstakerSkjemaDataValidator
 import org.springframework.context.ApplicationEventPublisher
@@ -386,6 +391,162 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             shouldThrow<SkjemaErIkkeRedigerbartException> {
                 service.sendInnSkjema(alleredeSendtSkjema.id!!)
             }
+        }
+    }
+
+    context("MELOSYS-8065: SENDT RADGIVER_MED_FULLMAKT-skjema med tapt fullmakt") {
+        val fullmektigFnr = "99999999999"
+        val arbeidstakerFnr = "12345678910"
+
+        fun radgiverMedFullmaktSendtSkjema(skjemaId: UUID, medData: Boolean = true) = skjemaMedDefaultVerdier(
+            id = skjemaId,
+            status = SkjemaStatus.SENDT,
+            fnr = arbeidstakerFnr,
+            orgnr = testArbeidsgiver.orgnr,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.RADGIVER_MED_FULLMAKT,
+                skjemadel = Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+                fullmektigFnr = fullmektigFnr
+            ),
+            data = if (medData) arbeidsgiverOgArbeidstakerSkjemaDataDtoMedDefaultVerdier() else null
+        )
+
+        test("hentSkjema: tapt fullmakt + Altinn-tilgang → returnerer skjema med strippet AT-data") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId)
+            every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+
+            val data = service.hentSkjema(skjemaId).data as UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
+
+            data.arbeidsgiversData.arbeidsgiverensVirksomhetINorge shouldNotBe null
+            data.arbeidstakersData.arbeidssituasjon shouldBe null
+            data.arbeidstakersData.skatteforholdOgInntekt shouldBe null
+            data.arbeidstakersData.familiemedlemmer shouldBe null
+        }
+
+        test("hentSkjema: aktiv fullmakt → returnerer full data") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId)
+            every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns true
+
+            val data = service.hentSkjema(skjemaId).data as UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
+
+            data.arbeidstakersData.arbeidssituasjon shouldNotBe null
+        }
+
+        test("hentSkjema: tapt fullmakt + ingen Altinn-tilgang → AccessDeniedException") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
+
+            shouldThrow<AccessDeniedException> { service.hentSkjema(skjemaId) }
+        }
+
+        test("getSkjemaMetadata: tapt fullmakt + Altinn-tilgang → returnerer metadata") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+
+            service.getSkjemaMetadata(skjemaId).representasjonstype shouldBe Representasjonstype.RADGIVER_MED_FULLMAKT
+        }
+
+        test("getSkjemaMetadata: tapt fullmakt + ingen Altinn-tilgang → AccessDeniedException") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
+
+            shouldThrow<AccessDeniedException> { service.getSkjemaMetadata(skjemaId) }
+        }
+
+        test("hentSkjema: ARBEIDSGIVER (uten _MED_FULLMAKT) med Altinn-tilgang skal returnere full data uten stripping") {
+            val skjemaId = UUID.randomUUID()
+            val skjema = skjemaMedDefaultVerdier(
+                id = skjemaId,
+                status = SkjemaStatus.SENDT,
+                fnr = arbeidstakerFnr,
+                orgnr = testArbeidsgiver.orgnr,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                ),
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+            )
+
+            every { mockSubjectHandler.getUserID() } returns korrektSyntetiskFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+
+            val data = service.hentSkjema(skjemaId).data as UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
+
+            data.arbeidsgiverensVirksomhetINorge shouldNotBe null
+        }
+
+        test("hentSkjema: UTKAST med _MED_FULLMAKT uten fullmakt skal kaste AccessDenied (streng kontroll bevart for utkast)") {
+            val skjemaId = UUID.randomUUID()
+            val skjema = skjemaMedDefaultVerdier(
+                id = skjemaId,
+                status = SkjemaStatus.UTKAST,
+                fnr = arbeidstakerFnr,
+                orgnr = testArbeidsgiver.orgnr,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.RADGIVER_MED_FULLMAKT,
+                    fullmektigFnr = fullmektigFnr
+                ),
+                opprettetAv = fullmektigFnr,
+                endretAv = fullmektigFnr
+            )
+
+            every { mockSubjectHandler.getUserID() } returns fullmektigFnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockReprService.harSkriverettigheterForMedlemskap(arbeidstakerFnr) } returns false
+
+            shouldThrow<AccessDeniedException> { service.hentSkjema(skjemaId) }
+        }
+    }
+
+    context("UTKAST: kun den som starta utkastet har tilgang (personlig eierskap)") {
+        val hrPersonA = "11111111111"
+        val hrPersonB = "22222222222"
+        val arbeidstakerFnr = "12345678910"
+
+        fun arbeidsgiverUtkastStartetAv(creatorFnr: String, skjemaId: UUID) = skjemaMedDefaultVerdier(
+            id = skjemaId,
+            status = SkjemaStatus.UTKAST,
+            fnr = arbeidstakerFnr,
+            orgnr = testArbeidsgiver.orgnr,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+            ),
+            opprettetAv = creatorFnr,
+            endretAv = creatorFnr
+        )
+
+        test("hentSkjema: opprinnelig creator med Altinn-tilgang får tilgang til eget utkast") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns hrPersonA
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId)
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+
+            service.hentSkjema(skjemaId).id shouldBe skjemaId
+        }
+
+        test("hentSkjema: annen kollega med Altinn-tilgang får IKKE lese andres utkast") {
+            val skjemaId = UUID.randomUUID()
+            every { mockSubjectHandler.getUserID() } returns hrPersonB
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId)
+            every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
+
+            shouldThrow<AccessDeniedException> { service.hentSkjema(skjemaId) }
         }
     }
 })


### PR DESCRIPTION
**SENDT:** Fullmektig som har mistet fullmakten men fortsatt har Altinn-tilgang får nå se arbeidsgivers del av søknaden istedenfor 403. Arbeidstakers data strippes fra responsen.

**UTKAST:** Krever nå at innlogget bruker er den som starta utkastet. Utkast er personlig og deles ikke mellom brukere med samme rolle.