### PR TITLE
8039 Endre feltlabel fra Vegadresse til Gate/vei

### DIFF
--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -661,7 +661,7 @@
         "vegadresse": {
           "type": "TEXT",
           "label": {
-            "nb": "Vegadresse",
+            "nb": "Gate/vei",
             "en": "Street address"
           },
           "pakrevd": false


### PR DESCRIPTION
Endrer feltlabel fra "Vegadresse" til "Gate/vei" på steget _Arbeidssted i utlandet_ i skjemadefinisjonen for utsendt arbeidstaker.

Faglig justering — feltet skal hete "Gate/vei" i tråd med ønsket fra saksbehandlerne.
[MELOSYS-8039](https://jira.adeo.no/browse/MELOSYS-8039)

- Oppdatert `nb`-label i `definisjon.json` for `vegadresse`-feltet

## Testing
- [x] Manuell verifisering av JSON-syntaks
- [x] Frontend-sync (`sync-skjema-definisjon`) verifisert

