### PR TITLE
8067 Vis land for fast arbeidssted i PDF

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
@@ -15,6 +15,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeid
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidssituasjonDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.FamiliemedlemmerDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.SkatteforholdOgInntektDto
+import no.nav.melosys.skjema.types.felles.LandKode
 import no.nav.melosys.skjema.types.felles.TilleggsopplysningerDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendingsperiodeOgLandDto
 import no.nav.melosys.skjema.types.skjemadefinisjon.SeksjonDefinisjonDto
@@ -167,7 +168,7 @@ class SeksjonRenderer(
         }
 
         ag.arbeidsstedIUtlandet?.let { dto ->
-            builder.append(byggArbeidsstedIUtlandet(dto, definisjon))
+            builder.append(byggArbeidsstedIUtlandet(dto, definisjon, data.utsendingsperiodeOgLand?.utsendelseLand))
         }
 
         return builder.toString()
@@ -246,7 +247,7 @@ class SeksjonRenderer(
         }
 
         data.arbeidsstedIUtlandet?.let { dto ->
-            builder.append(byggArbeidsstedIUtlandet(dto, definisjon))
+            builder.append(byggArbeidsstedIUtlandet(dto, definisjon, data.utsendingsperiodeOgLand?.utsendelseLand))
         }
 
         return builder.toString()
@@ -297,7 +298,8 @@ class SeksjonRenderer(
 
     private fun byggArbeidsstedIUtlandet(
         data: ArbeidsstedIUtlandetDto,
-        definisjon: SkjemaDefinisjonDto
+        definisjon: SkjemaDefinisjonDto,
+        utsendelseLand: LandKode? = null
     ): String {
         val builder = StringBuilder()
 
@@ -312,7 +314,7 @@ class SeksjonRenderer(
         when (data.arbeidsstedType) {
             ArbeidsstedType.PA_LAND -> data.paLand?.let { dto ->
                 definisjon.seksjoner["arbeidsstedPaLand"]?.let { seksjon ->
-                    builder.append(byggArbeidsstedPaLand(dto, seksjon))
+                    builder.append(byggArbeidsstedPaLand(dto, seksjon, utsendelseLand))
                 }
             }
 
@@ -340,7 +342,8 @@ class SeksjonRenderer(
 
     private fun byggArbeidsstedPaLand(
         data: PaLandDto,
-        seksjon: SeksjonDefinisjonDto
+        seksjon: SeksjonDefinisjonDto,
+        utsendelseLand: LandKode? = null
     ): String {
         return byggSeksjon(seksjon) {
             felt("navnPaVirksomhet", data.navnPaVirksomhet)
@@ -351,6 +354,7 @@ class SeksjonRenderer(
                 felt("nummer", adresse.nummer)
                 felt("postkode", adresse.postkode)
                 felt("bySted", adresse.bySted)
+                felt("land", utsendelseLand)
             }
             felt("erHjemmekontor", data.erHjemmekontor)
         }

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
@@ -350,15 +350,15 @@ class SeksjonRenderer(
             felt("navnPaVirksomhet", data.navnPaVirksomhet)
             felt("fastEllerVekslendeArbeidssted", data.fastEllerVekslendeArbeidssted)
             // Adressefelter fra fastArbeidssted
-            data.fastArbeidssted
-                ?.takeIf { data.fastEllerVekslendeArbeidssted == FastEllerVekslendeArbeidssted.FAST }
-                ?.let { adresse ->
+            if (data.fastEllerVekslendeArbeidssted == FastEllerVekslendeArbeidssted.FAST) {
+                data.fastArbeidssted?.let { adresse ->
                     felt("vegadresse", adresse.vegadresse)
                     felt("nummer", adresse.nummer)
                     felt("postkode", adresse.postkode)
                     felt("bySted", adresse.bySted)
-                    felt("land", utsendelseLand)
                 }
+                felt("land", utsendelseLand)
+            }
             felt("erHjemmekontor", data.erHjemmekontor)
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SeksjonRenderer.kt
@@ -4,6 +4,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeid
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsgiverensVirksomhetINorgeDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedIUtlandetDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedType
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.FastEllerVekslendeArbeidssted
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.OffshoreDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.OmBordPaFlyDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.PaLandDto
@@ -349,13 +350,15 @@ class SeksjonRenderer(
             felt("navnPaVirksomhet", data.navnPaVirksomhet)
             felt("fastEllerVekslendeArbeidssted", data.fastEllerVekslendeArbeidssted)
             // Adressefelter fra fastArbeidssted
-            data.fastArbeidssted?.let { adresse ->
-                felt("vegadresse", adresse.vegadresse)
-                felt("nummer", adresse.nummer)
-                felt("postkode", adresse.postkode)
-                felt("bySted", adresse.bySted)
-                felt("land", utsendelseLand)
-            }
+            data.fastArbeidssted
+                ?.takeIf { data.fastEllerVekslendeArbeidssted == FastEllerVekslendeArbeidssted.FAST }
+                ?.let { adresse ->
+                    felt("vegadresse", adresse.vegadresse)
+                    felt("nummer", adresse.nummer)
+                    felt("postkode", adresse.postkode)
+                    felt("bySted", adresse.bySted)
+                    felt("land", utsendelseLand)
+                }
             felt("erHjemmekontor", data.erHjemmekontor)
         }
     }
@@ -421,7 +424,7 @@ class SeksjonRenderer(
     /**
      * Builder for å bygge en seksjon med felter.
      */
-    inner class SeksjonBuilder(
+    class SeksjonBuilder(
         private val seksjon: SeksjonDefinisjonDto,
         private val feltRenderer: FeltRenderer
     ) {

--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -695,6 +695,14 @@
           },
           "pakrevd": false
         },
+        "land": {
+          "type": "COUNTRY_SELECT",
+          "label": {
+            "nb": "Land",
+            "en": "Country"
+          },
+          "pakrevd": false
+        },
         "erHjemmekontor": {
           "type": "BOOLEAN",
           "label": {

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import java.io.File
 import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 import kotlin.io.path.createTempFile
 import kotlin.io.path.writeBytes
@@ -394,6 +393,8 @@ class PdfGeneratorTest : FunSpec({
             val html = HtmlDokumentGenerator.byggHtml(skjema)
 
             html shouldContain "På land"
+            html shouldContain "Land"
+            html shouldContain "Sverige"
             lagrePdfForInspeksjon("arbeidssted-pa-land.pdf", genererPdf(skjema))
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -28,6 +28,7 @@ import no.nav.melosys.skjema.tilleggsopplysningerDtoMedDefaultVerdier
 import no.nav.melosys.skjema.types.SkjemaType
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedType
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.FastEllerVekslendeArbeidssted
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.common.Språk
@@ -396,6 +397,31 @@ class PdfGeneratorTest : FunSpec({
             html shouldContain "Land"
             html shouldContain "Sverige"
             lagrePdfForInspeksjon("arbeidssted-pa-land.pdf", genererPdf(skjema))
+        }
+
+        test("viser ikke fast adresse for vekslende arbeidssted på land") {
+            val arbeidsgiverData = lagKomplettArbeidsgiverData().copy(
+                arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier().copy(
+                    arbeidsstedType = ArbeidsstedType.PA_LAND,
+                    paLand = paLandDtoMedDefaultVerdier().copy(
+                        fastEllerVekslendeArbeidssted = FastEllerVekslendeArbeidssted.VEKSLENDE
+                    ),
+                    offshore = null,
+                    paSkip = null,
+                    omBordPaFly = null
+                )
+            )
+
+            val skjema = lagSkjemaPdfData(
+                referanseId = "VEKSL",
+                arbeidsgiverData = arbeidsgiverData
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Veksler ofte"
+            html shouldNotContain "Test Street"
+            html shouldNotContain "Stockholm"
         }
 
         test("viser arbeidssted offshore") {

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -399,6 +399,28 @@ class PdfGeneratorTest : FunSpec({
             lagrePdfForInspeksjon("arbeidssted-pa-land.pdf", genererPdf(skjema))
         }
 
+        test("viser land for fast arbeidssted uten adresse") {
+            val arbeidsgiverData = lagKomplettArbeidsgiverData().copy(
+                arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier().copy(
+                    arbeidsstedType = ArbeidsstedType.PA_LAND,
+                    paLand = paLandDtoMedDefaultVerdier().copy(fastArbeidssted = null),
+                    offshore = null,
+                    paSkip = null,
+                    omBordPaFly = null
+                )
+            )
+
+            val skjema = lagSkjemaPdfData(
+                referanseId = "LANDNA",
+                arbeidsgiverData = arbeidsgiverData
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "Land"
+            html shouldContain "Sverige"
+        }
+
         test("viser ikke fast adresse for vekslende arbeidssted på land") {
             val arbeidsgiverData = lagKomplettArbeidsgiverData().copy(
                 arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier().copy(


### PR DESCRIPTION
Inkluderer utsendelseslandet i PDF-genereringen for faste arbeidssteder slik at journalført søknad viser land under arbeidssted.

Utsendelseslandet var allerede tilgjengelig i skjemadataene, men ble ikke piped ned til `byggArbeidsstedPaLand()`. Adressefelter og land vises nå kun for faste arbeidssteder — ikke vekslende.
[MELOSYS-8067](https://jira.adeo.no/browse/MELOSYS-8067)

- Piper `utsendelseLand` fra `SeksjonRenderer` ned til `byggArbeidsstedPaLand()`
- Legger til `land`-felt i `definisjon.json` (`COUNTRY_SELECT`)
- Adressefelter (vegadresse, nummer, postkode, bySted) vises kun ved fast arbeidssted
- `SeksjonBuilder` endret fra `inner class` til `class` (ingen funksjonell endring)

## Testing
- [x] Enhetstester (`PdfGeneratorTest`) — land for fast, uten adresse, og vekslende
- [x] Manuell testing lokalt
