### PR TITLE
8060 7978 8079: Endre diverse tekst i søknadsskjema

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
@@ -71,7 +71,7 @@ object HtmlDokumentGenerator {
 
     private fun byggHeader(referanseId: String, innsendtDato: Instant, språk: Språk): String {
         val tittel = when (språk) {
-            Språk.NORSK_BOKMAL -> "Søknad om A1 for utsendte arbeidstakere i EØS/Sveits"
+            Språk.NORSK_BOKMAL -> "Søknad om A1 for utsendte arbeidstakere i EØS eller Sveits"
             Språk.ENGELSK -> "Application for posted worker within EU/EEA and Switzerland"
         }
 

--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -11,8 +11,8 @@
         "utsendelseLand": {
           "type": "COUNTRY_SELECT",
           "label": {
-            "nb": "I hvilket land skal du utføre arbeid?",
-            "en": "In which country will you be working?"
+            "nb": "I hvilket land skal arbeidet utføres?",
+            "en": "In which country will the work be performed?"
           },
           "pakrevd": true
         },

--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -429,8 +429,8 @@
         "tilleggsopplysningerTilSoknad": {
           "type": "TEXTAREA",
           "label": {
-            "nb": "Beskriv de flere opplysningene du har til søknaden",
-            "en": "Describe the additional information you have for the application"
+            "nb": "Beskriv disse her",
+            "en": "Describe them here"
           },
           "maxLength": 2000,
           "pakrevd": false
@@ -1148,8 +1148,8 @@
         "tilleggsopplysningerTilSoknad": {
           "type": "TEXTAREA",
           "label": {
-            "nb": "Beskriv de flere opplysningene du har til søknaden",
-            "en": "Describe the additional information you have for the application"
+            "nb": "Beskriv disse her",
+            "en": "Describe them here"
           },
           "maxLength": 2000,
           "pakrevd": false

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -564,7 +564,7 @@ class PdfGeneratorTest : FunSpec({
             html shouldContain "Arbeidsgivers del"
             html shouldContain "Arbeidsgiverens virksomhet i Norge"
 
-            html shouldContain "I hvilket land skal du utføre arbeid?"
+            html shouldContain "I hvilket land skal arbeidet utføres?"
             html shouldContain "Sverige"
             html shouldContain "Fra dato"
             html shouldContain "Til dato"


### PR DESCRIPTION
Endrer label på land-spørsmålet i første steg fra «I hvilket land skal du utføre arbeid?» til «I hvilket land skal arbeidet utføres?», slik at teksten passer både når arbeidstaker, arbeidsgiver eller rådgiver fyller ut skjemaet.

Endrer også 
- tilleggsopplysningerhjelpetekst
- feil tittel i PDF

Sync: https://github.com/navikt/melosys-skjema-web/pull/448