### PR TITLE
8075 Legg til page-break-regler i PDF

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/PdfStyles.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/PdfStyles.kt
@@ -49,6 +49,7 @@ object PdfStyles {
             margin: 32px 0 16px 0;
             padding-bottom: 8px;
             border-bottom: 2px solid #C6C2BF;
+            page-break-after: avoid;
         }
 
         /* FormSummary-stil seksjon */
@@ -56,17 +57,20 @@ object PdfStyles {
             background: #FFFFFF;
             border: 1px solid #C6C2BF;
             margin-bottom: 24px;
+            page-break-inside: avoid;
         }
         .form-summary-header {
             background: #F7F7F7;
             padding: 12px 16px;
             border-bottom: 1px solid #C6C2BF;
+            page-break-after: avoid;
         }
         .form-summary-heading {
             font-size: 12pt;
             font-weight: bold;
             color: #262626;
             margin: 0;
+            page-break-after: avoid;
         }
         .form-summary-answers {
             padding: 0;

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -215,6 +215,19 @@ class PdfGeneratorTest : FunSpec({
             html shouldContain "Fra dato"
             html shouldContain "Til dato"
         }
+
+        test("CSS forhindrer linjeskift mellom overskrift og innhold") {
+            val skjema = lagSkjemaPdfData(
+                referanseId = "LSKIFT",
+                arbeidstakerData = lagKomplettArbeidstakerData(),
+                arbeidsgiverData = lagKomplettArbeidsgiverData()
+            )
+
+            val html = HtmlDokumentGenerator.byggHtml(skjema)
+
+            html shouldContain "page-break-after: avoid"
+            html shouldContain "page-break-inside: avoid"
+        }
     }
 
     context("HTML-innhold - Engelsk") {


### PR DESCRIPTION
Legger til CSS page-break-regler i PDF-genereringen slik at overskrifter ikke havner alene nederst på en side.

I dagens søknad/PDF kan overskrifter havne på én side mens innholdet starter på neste side. Dette gir dårlig lesbarhet. Løst ved å legge til `page-break-after: avoid` på overskrifter og `page-break-inside: avoid` på seksjoner.
[MELOSYS-8075](https://jira.adeo.no/browse/MELOSYS-8075)

- `page-break-after: avoid` på `.part-heading`, `.form-summary-header` og `.form-summary-heading`
- `page-break-inside: avoid` på `.form-summary`
- Ny test som verifiserer at page-break CSS-regler er med i generert HTML

### Testing
- [x] Enhetstester (PdfGeneratorTest)
- [x] Manuell testing lokalt (visuell inspeksjon av generert PDF)
