### PR TITLE
Endre svartekst for vedlegg til bare Ja/Nei

### DIFF
--- a/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
+++ b/src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json
@@ -450,12 +450,12 @@
             "en": "Do you have any other documentation you wish to attach?"
           },
           "jaLabel": {
-            "nb": "Ja, jeg legger dem ved denne søknaden",
-            "en": "Yes, I am attaching them with this application"
+            "nb": "Ja",
+            "en": "Yes"
           },
           "neiLabel": {
-            "nb": "Nei, jeg har ingen ekstra dokumentasjon jeg vil legge ved",
-            "en": "No, I have no extra documentation I want to attach"
+            "nb": "Nei",
+            "en": "No"
           },
           "pakrevd": true
         }
@@ -1201,12 +1201,12 @@
             "en": "Do you have any other documentation you wish to attach?"
           },
           "jaLabel": {
-            "nb": "Ja, jeg legger dem ved denne søknaden",
-            "en": "Yes, I am attaching them with this application"
+            "nb": "Ja",
+            "en": "Yes"
           },
           "neiLabel": {
-            "nb": "Nei, jeg har ingen ekstra dokumentasjon jeg vil legge ved",
-            "en": "No, I have no extra documentation I want to attach"
+            "nb": "Nei",
+            "en": "No"
           },
           "pakrevd": true
         }


### PR DESCRIPTION
## MELOSYS-8104: Endre svartekst til vedleggspørsmål til bare Ja/Nei

### Hva er endret?
Endret svartekst for spørsmålet "Har du noen annen dokumentasjon du ønsker å legge ved?" fra lange beskrivende svar til enkle Ja/Nei-svar, for både arbeidstaker- og arbeidsgiver-delen av skjemaet.

### Hvorfor?
Svartekstene var inkonsistente med resten av skjemaet der alle andre ja/nei-spørsmål bruker bare "Ja"/"Nei".

### Endrede filer
- `src/main/resources/skjema-definisjoner/UTSENDT_ARBEIDSTAKER/v1/definisjon.json`
  - `vedleggArbeidstaker.harAnnenDokumentasjon`: jaLabel/neiLabel forenklet (nb + en)
  - `vedleggArbeidsgiver.harAnnenDokumentasjon`: jaLabel/neiLabel forenklet (nb + en)
