### PR TITLE
Øk WebClient buffer-grense til 16 MB

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,9 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+  codec:
+    max-in-memory-size: 16MB
+
 server:
   port: ${SERVER_PORT:8080}
 


### PR DESCRIPTION
Øker WebClient buffer-grense fra 256 KB (default) til 16 MB for å fikse DataBufferLimitException.
Altinn-responser for organisasjoner med mange tilganger overskrider standard buffer-grensen på 256 KB, noe som gir feil i produksjon.
- Lagt til spring.codec.max-in-memory-size: 16MB i application.yml
## Testing
- [ ] Manuell testing lokalt
