### PR TITLE
NOJIRA Retry forbindelsesfeil i WebClient

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
@@ -39,10 +39,7 @@ object WebClientConfig {
             .jitter(0.75)
             .filter { throwable: Throwable? ->
                 when (throwable) {
-                    // HTTP-svar mottatt: kun 5xx regnes som forbigående
                     is WebClientResponseException -> throwable.statusCode.is5xxServerError
-                    // Forbindelsesfeil (timeout, reset, DNS) — kom aldri frem til et svar,
-                    // typisk forbigående og trygt å forsøke på nytt
                     is WebClientRequestException -> true
                     else -> false
                 }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
@@ -3,6 +3,7 @@ package no.nav.melosys.skjema.integrasjon.felles
 import java.time.Duration
 import org.springframework.http.HttpStatusCode
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import reactor.util.retry.Retry
@@ -37,18 +38,20 @@ object WebClientConfig {
             .backoff(maxAttempts.toLong(), Duration.ofMillis(backoffDurationMillis.toLong()))
             .jitter(0.75)
             .filter { throwable: Throwable? ->
-                if (throwable is WebClientResponseException) {
-                    throwable.statusCode.is5xxServerError
-                } else {
-                    false
+                when (throwable) {
+                    // HTTP-svar fra tjenesten: kun 5xx er forbigående og verdt et nytt forsøk
+                    is WebClientResponseException -> throwable.statusCode.is5xxServerError
+                    // Forbindelsesfeil (connection timeout, reset, DNS) nådde aldri frem til et svar
+                    // og er typisk forbigående nettverkshikke mot prod-fss-pub. Skal forsøkes på nytt.
+                    is WebClientRequestException -> true
+                    else -> false
                 }
             }
-            .onRetryExhaustedThrow { retryBackoffSpec: RetryBackoffSpec?, retrySignal: RetrySignal ->
-                val throwable = retrySignal.failure()
-                if (throwable is WebClientResponseException) {
-                    throw throwable
+            .onRetryExhaustedThrow { _: RetryBackoffSpec?, retrySignal: RetrySignal ->
+                when (val throwable = retrySignal.failure()) {
+                    is WebClientResponseException, is WebClientRequestException -> throw throwable
+                    else -> throw RuntimeException(throwable)
                 }
-                throw RuntimeException(throwable)
             }
     }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfig.kt
@@ -39,10 +39,10 @@ object WebClientConfig {
             .jitter(0.75)
             .filter { throwable: Throwable? ->
                 when (throwable) {
-                    // HTTP-svar fra tjenesten: kun 5xx er forbigående og verdt et nytt forsøk
+                    // HTTP-svar mottatt: kun 5xx regnes som forbigående
                     is WebClientResponseException -> throwable.statusCode.is5xxServerError
-                    // Forbindelsesfeil (connection timeout, reset, DNS) nådde aldri frem til et svar
-                    // og er typisk forbigående nettverkshikke mot prod-fss-pub. Skal forsøkes på nytt.
+                    // Forbindelsesfeil (timeout, reset, DNS) — kom aldri frem til et svar,
+                    // typisk forbigående og trygt å forsøke på nytt
                     is WebClientRequestException -> true
                     else -> false
                 }

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfigTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfigTest.kt
@@ -1,0 +1,67 @@
+package no.nav.melosys.skjema.integrasjon.felles
+
+import java.net.URI
+import java.util.concurrent.atomic.AtomicInteger
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+
+class WebClientConfigTest {
+
+    private fun connectionTimeout() = WebClientRequestException(
+        java.net.SocketTimeoutException("Connection timed out"),
+        HttpMethod.POST,
+        URI.create("https://pdl-api.example.no/graphql"),
+        HttpHeaders.EMPTY
+    )
+
+    @Test
+    fun `retryer forbigående forbindelsesfeil og lykkes til slutt`() {
+        val forsoek = AtomicInteger(0)
+
+        val resultat = Mono.defer {
+            if (forsoek.incrementAndGet() < 3) Mono.error(connectionTimeout()) else Mono.just("ok")
+        }
+            .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
+            .block()
+
+        assertThat(resultat).isEqualTo("ok")
+        assertThat(forsoek.get()).isEqualTo(3)
+    }
+
+    @Test
+    fun `retryer ikke HTTP 4xx-svar`() {
+        val forsoek = AtomicInteger(0)
+        val badRequest = WebClientResponseException.create(
+            HttpStatus.BAD_REQUEST.value(), "Bad Request", HttpHeaders.EMPTY, ByteArray(0), null
+        )
+
+        assertThatThrownBy {
+            Mono.defer { forsoek.incrementAndGet(); Mono.error<String>(badRequest) }
+                .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
+                .block()
+        }.isInstanceOf(WebClientResponseException::class.java)
+
+        assertThat(forsoek.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `retryer ikke vilkårlige feil`() {
+        val forsoek = AtomicInteger(0)
+
+        assertThatThrownBy {
+            Mono.defer { forsoek.incrementAndGet(); Mono.error<String>(IllegalArgumentException("nei")) }
+                .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
+                .block()
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(forsoek.get()).isEqualTo(1)
+    }
+}
+

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfigTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/felles/WebClientConfigTest.kt
@@ -23,45 +23,44 @@ class WebClientConfigTest {
 
     @Test
     fun `retryer forbigående forbindelsesfeil og lykkes til slutt`() {
-        val forsoek = AtomicInteger(0)
+        val attempts = AtomicInteger(0)
 
         val resultat = Mono.defer {
-            if (forsoek.incrementAndGet() < 3) Mono.error(connectionTimeout()) else Mono.just("ok")
+            if (attempts.incrementAndGet() < 3) Mono.error(connectionTimeout()) else Mono.just("ok")
         }
             .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
             .block()
 
         assertThat(resultat).isEqualTo("ok")
-        assertThat(forsoek.get()).isEqualTo(3)
+        assertThat(attempts.get()).isEqualTo(3)
     }
 
     @Test
     fun `retryer ikke HTTP 4xx-svar`() {
-        val forsoek = AtomicInteger(0)
+        val attempts = AtomicInteger(0)
         val badRequest = WebClientResponseException.create(
             HttpStatus.BAD_REQUEST.value(), "Bad Request", HttpHeaders.EMPTY, ByteArray(0), null
         )
 
         assertThatThrownBy {
-            Mono.defer { forsoek.incrementAndGet(); Mono.error<String>(badRequest) }
+            Mono.defer { attempts.incrementAndGet(); Mono.error<String>(badRequest) }
                 .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
                 .block()
         }.isInstanceOf(WebClientResponseException::class.java)
 
-        assertThat(forsoek.get()).isEqualTo(1)
+        assertThat(attempts.get()).isEqualTo(1)
     }
 
     @Test
     fun `retryer ikke vilkårlige feil`() {
-        val forsoek = AtomicInteger(0)
+        val attempts = AtomicInteger(0)
 
         assertThatThrownBy {
-            Mono.defer { forsoek.incrementAndGet(); Mono.error<String>(IllegalArgumentException("nei")) }
+            Mono.defer { attempts.incrementAndGet(); Mono.error<String>(IllegalArgumentException("nei")) }
                 .retryWhen(WebClientConfig.defaultRetry(maxAttempts = 3, backoffDurationMillis = 10))
                 .block()
         }.isInstanceOf(IllegalArgumentException::class.java)
 
-        assertThat(forsoek.get()).isEqualTo(1)
+        assertThat(attempts.get()).isEqualTo(1)
     }
 }
-


### PR DESCRIPTION
En connection timeout mot en ekstern tjeneste kan boble ut som en 500 til
brukeren. `defaultRetry` prøvde kun på nytt ved HTTP 5xx, mens en forbindelses-
feil – som aldri når frem til et svar – kommer som `WebClientRequestException`
og gikk rett gjennom uten nytt forsøk.

Dette er en generell hjelpemetode som alle WebClient-konsumentene bruker (PDL,
repr m.fl.), så fiksen gjelder alle.

- Retryer nå også `WebClientRequestException` (timeout, reset, DNS)
- Kaster original-exception videre når retries er oppbrukt
- Enhetstest for retry på forbindelsesfeil + at 4xx og andre feil ikke retryes

## Testing
- [x] Enhetstester
