### PR TITLE
NOJIRA Økt buffergrense for Altinn-tilganger WebClient til 16MB

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientProducer.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientProducer.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
@@ -21,6 +22,7 @@ class ArbeidsgiverAltinnTilgangerClientProducer(
 
     companion object {
         private const val CLIENT_NAME = "arbeidsgiver-altinn-tilganger"
+        private const val MAX_IN_MEMORY_SIZE_BYTES = 16 * 1024 * 1024
     }
 
     @Bean
@@ -39,6 +41,11 @@ class ArbeidsgiverAltinnTilgangerClientProducer(
 
         return webClientBuilder
             .baseUrl(arbeidsgiverAltinnTilgangerBaseUrl)
+            .exchangeStrategies(
+                ExchangeStrategies.builder()
+                    .codecs { it.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE_BYTES) }
+                    .build()
+            )
             .filter(tokenXContextExchangeFilter)
             .filter(WebClientConfig.errorFilter("Kall mot arbeidsgiver-altinn-tilganger feilet"))
             .filter(headerFilter())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,9 +47,6 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
-  codec:
-    max-in-memory-size: 16MB
-
 server:
   port: ${SERVER_PORT:8080}
 


### PR DESCRIPTION
Øker buffergrensen for WebClient-en mot arbeidsgiver-altinn-tilganger fra
standardgrensen på 256 KB til 16 MB.

I produksjon feiler kall mot Altinn-tilganger med
`DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144`
for brukere med store tilgangshierarkier (f.eks. regnskapsførere med mange
organisasjoner). Responsen overstiger WebClient-ens standardgrense på 256 KB.
Feilen oppstår ikke i dev fordi testbrukerne har få organisasjoner.

Grensen settes nå eksplisitt på selve WebClient-en via `ExchangeStrategies`.
`spring.codec.max-in-memory-size` i application.yml hadde ingen effekt på denne
klienten og er fjernet.

- Setter `maxInMemorySize` til 16 MB på Altinn-tilganger-WebClient
- Fjerner virkningsløs `spring.codec.max-in-memory-size` fra application.yml
