### PR TITLE
8119 Fiks varsel-lenke til arbeidstaker med ingress-path

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -92,7 +92,7 @@ class ArbeidstakerVarslingService(
         }
 
     private fun byggSkjemaLenke(): String =
-        skjemaLenke.trimEnd('/') + ARBEIDSTAKER_SKJEMA_PATH
+        skjemaLenke + ARBEIDSTAKER_SKJEMA_PATH
 
     private fun lagVarselteksterUtenFullmakt(arbeidsgiverNavn: String): List<Varseltekst> {
         return listOf(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -74,7 +74,7 @@ class ArbeidstakerVarslingService(
 
         val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
         val tekster = lagVarselteksterUtenFullmakt(navn)
-        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, skjemaLenke))
+        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke()))
         log.info { "Sendt varsel til arbeidstaker om AG-innsending (skjemadel=${metadata.skjemadel})" }
     }
 
@@ -90,6 +90,9 @@ class ArbeidstakerVarslingService(
             val m = utkast.metadata as? UtsendtArbeidstakerMetadata
             m != null && m.juridiskEnhetOrgnr == juridiskEnhetOrgnr && m.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL
         }
+
+    private fun byggSkjemaLenke(): String =
+        skjemaLenke.trimEnd('/') + ARBEIDSTAKER_SKJEMA_PATH
 
     private fun lagVarselteksterUtenFullmakt(arbeidsgiverNavn: String): List<Varseltekst> {
         return listOf(
@@ -123,5 +126,6 @@ class ArbeidstakerVarslingService(
 
     companion object {
         private const val MAX_ARBEIDSGIVERNAVN_LENGDE = 100
+        private const val ARBEIDSTAKER_SKJEMA_PATH = "/medlemskap-lovvalg/soknad"
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,7 +30,7 @@ MERKELAPP: foo123
 RESSURS_ID: foo123
 EREG_URL: http://localhost:8083/ereg
 BRUK_SYNTETISK_FNR: true
-VARSLING_ARBEIDSTAKER_SKJEMA_LENKE: http://localhost:3000/utsendt-arbeidstaker
+VARSLING_ARBEIDSTAKER_SKJEMA_LENKE: http://localhost:3000
 PDL_URL: http://localhost:8083/graphql
 REPR_URL: http://localhost:8083/repr
 AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -21,7 +21,8 @@ class ArbeidstakerVarslingServiceTest {
 
     private val brukervarselProducer: BrukervarselProducer = mockk(relaxed = true)
     private val skjemaRepository: SkjemaRepository = mockk()
-    private val skjemaLenke = "https://test.nav.no/melosys-skjema/utsendt-arbeidstaker"
+    private val skjemaLenke = "https://test.nav.no"
+    private val forventetLenke = "https://test.nav.no/medlemskap-lovvalg/soknad"
 
     private val service = ArbeidstakerVarslingService(brukervarselProducer, skjemaRepository, skjemaLenke)
 
@@ -47,7 +48,7 @@ class ArbeidstakerVarslingServiceTest {
                     melding.tekster.size == 2 &&
                     melding.tekster.any { it.språk == Språk.NORSK_BOKMAL && it.default } &&
                     melding.tekster.any { it.språk == Språk.ENGELSK } &&
-                    melding.link == skjemaLenke
+                    melding.link == forventetLenke
                 }
             )
         }
@@ -95,7 +96,7 @@ class ArbeidstakerVarslingServiceTest {
         service.varsleArbeidstakerHvisAktuelt(skjema.id!!)
 
         verify {
-            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == skjemaLenke })
+            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == forventetLenke })
         }
     }
 


### PR DESCRIPTION
Retter lenken i brukervarselet som sendes til arbeidstaker når arbeidsgiver/rådgiver sender inn sin del uten fullmakt, slik at den peker til riktig ingress for ny søknadsløsning.

Da frontend ble flyttet under ingress-pathen `/medlemskap-lovvalg/soknad`, ble ikke varsel-lenken oppdatert. Lenken pekte kun på hosten og ga 404 når arbeidstaker klikket på beskjeden på nav.no.

- Lenken bygges nå som host (fra konfig/secret) + ingress-path `/medlemskap-lovvalg/soknad`
- Ryddet `application-local.yml` til host-only verdi
- Oppdatert enhetstest til å verifisere full lenke

## Testing
- [x] Enhetstester (ArbeidstakerVarslingServiceTest)
