### PR TITLE
MELOSYS-8092 Journalfør kun det brukeren sendte (styrt av skjemadel)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,21 +22,24 @@ reprodusere og verifisere koblings-/journalføringsadferd ende-til-ende.
 | `reproduser-motpart-ag-forst.sh` | Arbeidsgiver sender sin del **først**, så arbeidstaker. Arbeidstakers del motpart-kobles til arbeidsgivers del. |
 | `_repro-lib.sh` | Delt bibliotek (source-es av de andre): env-defaults, testidentiteter og helpere. |
 
-Begge henter til slutt M2M-PDF for arbeidstakers del og viser om den (feilaktig) inneholder
-arbeidsgivers del.
+Begge henter til slutt M2M-PDF for arbeidstakers del og inspiserer teksten (krever `pdftotext`)
+for å vise om den (feilaktig) inneholder arbeidsgivers del.
 
 ### Sende flere søknader
 
 `_repro-lib.sh` gir høynivå-helperne `send_arbeidstakerdel`/`send_arbeidsgiverdel` (opprett +
 fyll ut alle steg + send inn i ett kall). De setter `SKJEMA_ID` og `REFERANSE`, så et eget skript
-kan sende mange søknader på rad:
+kan sende mange søknader på rad. Bruk `nyPeriode` mellom hver innsending for å få **distinkte
+saker** – ellers matcher samme person + enhet + overlappende periode og hver iterasjon blir en
+erstatter-/motpart-kobling av den forrige i stedet for en ny sak:
 
 ```bash
 source scripts/_repro-lib.sh
 TOK=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
 for i in $(seq 1 5); do
+  nyPeriode "203${i}-01-01" "203${i}-01-28"   # distinkt, ikke-overlappende periode => ny sak
   send_arbeidstakerdel "$TOK"
-  echo "sendt #$i: skjemaId=$SKJEMA_ID referanse=$REFERANSE"
+  echo "sendt #$i: skjemaId=$SKJEMA_ID referanse=$REFERANSE (periode $FRA–$TIL)"
   sleep "$SLEEP"
 done
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,47 @@
+# E2E-reproduksjonsskript (lokal benk)
+
+Skript som sender inn ekte `UTSENDT_ARBEIDSTAKER`-skjema mot lokal `melosys-skjema-api`
+via de virkelige REST-endepunktene, med ekte tokens fra mock-oauth2-server. Brukes til å
+reprodusere og verifisere koblings-/journalføringsadferd ende-til-ende.
+
+## Forutsetninger
+
+- Lokal benk oppe (`local-mock`): `melosys-skjema-api` på `:8090`, mock-oauth2-server på
+  `:8082`, melosys-mock (PDL/EREG/Altinn) på `:8083`.
+- Verktøy: `bash`, `curl`, `jq`. (`pdftotext` valgfritt for å lese PDF-teksten.)
+- Testidentiteter fra `melosys-docker-compose/TESTBRUKERE.md`:
+  - Arbeidstaker (DEG_SELV): HANS HANSEN `01816023404`
+  - Arbeidsgiver (ARBEIDSGIVER): KARAFFEL TRIVIELL `30056928150` (Altinn-tilgang til Ståles Stål)
+  - Organisasjon: Ståles Stål AS `999999999`
+
+## Skript
+
+| Skript | Scenario |
+|--------|----------|
+| `reproduser-arvet-kobling.sh` | Arbeidstaker → arbeidsgiver → **ny versjon** av arbeidstakers del. Den nye versjonen arver kobling til (utdatert) arbeidsgivers del. |
+| `reproduser-motpart-ag-forst.sh` | Arbeidsgiver sender sin del **først**, så arbeidstaker. Arbeidstakers del motpart-kobles til arbeidsgivers del. |
+
+Begge henter til slutt M2M-PDF for arbeidstakers del og viser om den (feilaktig) inneholder
+arbeidsgivers del.
+
+## Kjøre
+
+```bash
+bash scripts/reproduser-arvet-kobling.sh
+bash scripts/reproduser-motpart-ag-forst.sh
+```
+
+Periode randomiseres by default, så hver kjøring blir en fersk sak. Overstyr ved behov:
+
+```bash
+FRA=2030-05-01 TIL=2030-05-31 SLEEP=4 bash scripts/reproduser-motpart-ag-forst.sh
+```
+
+`SLEEP` er en pause mellom innsendingene slik at melosys-api rekker å opprette sak + mapping
+før neste melding (unngår duplikatsaker ved samtidig prosessering).
+
+## Forventet resultat
+
+- **Før fiks:** PDF for et rent `ARBEIDSTAKERS_DEL`-skjema inneholder både «Arbeidstakers del»
+  og «Arbeidsgivers del».
+- **Etter fiks (MELOSYS-8092):** samme PDF inneholder kun «Arbeidstakers del».

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,26 @@ reprodusere og verifisere koblings-/journalføringsadferd ende-til-ende.
 |--------|----------|
 | `reproduser-arvet-kobling.sh` | Arbeidstaker → arbeidsgiver → **ny versjon** av arbeidstakers del. Den nye versjonen arver kobling til (utdatert) arbeidsgivers del. |
 | `reproduser-motpart-ag-forst.sh` | Arbeidsgiver sender sin del **først**, så arbeidstaker. Arbeidstakers del motpart-kobles til arbeidsgivers del. |
+| `_repro-lib.sh` | Delt bibliotek (source-es av de andre): env-defaults, testidentiteter og helpere. |
 
 Begge henter til slutt M2M-PDF for arbeidstakers del og viser om den (feilaktig) inneholder
 arbeidsgivers del.
+
+### Sende flere søknader
+
+`_repro-lib.sh` gir høynivå-helperne `send_arbeidstakerdel`/`send_arbeidsgiverdel` (opprett +
+fyll ut alle steg + send inn i ett kall). De setter `SKJEMA_ID` og `REFERANSE`, så et eget skript
+kan sende mange søknader på rad:
+
+```bash
+source scripts/_repro-lib.sh
+TOK=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
+for i in $(seq 1 5); do
+  send_arbeidstakerdel "$TOK"
+  echo "sendt #$i: skjemaId=$SKJEMA_ID referanse=$REFERANSE"
+  sleep "$SLEEP"
+done
+```
 
 ## Kjøre
 

--- a/scripts/_repro-lib.sh
+++ b/scripts/_repro-lib.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
-# Delt hjelpebibliotek for repro-skriptene. Source-es inn av kallende skript:
-#   source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
-#
-# Gir env-defaults, testidentiteter, lavnivå-helpere (token/post/opprett/fyll/send_inn) og
-# høynivå-helpere (send_arbeidstakerdel/send_arbeidsgiverdel) slik at det er trivielt å sende
-# inn flere skjema fra et kallende skript.
-#
-# Identiteter (se melosys-docker-compose/TESTBRUKERE.md):
-#   Arbeidstaker (DEG_SELV):     HANS HANSEN       01816023404
-#   Arbeidsgiver (ARBEIDSGIVER): KARAFFEL TRIVIELL 30056928150 (Altinn-tilgang til Ståles Stål)
-#   Organisasjon:                Ståles Stål AS    999999999
+# Delt bibliotek for repro-skriptene. Source-es inn av de andre.
+# Identiteter (melosys-docker-compose/TESTBRUKERE.md): arbeidstaker HANS HANSEN 01816023404,
+# arbeidsgiver KARAFFEL TRIVIELL 30056928150, org Ståles Stål AS 999999999.
 
 SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
 MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
@@ -21,25 +13,20 @@ ORGNR=${ORGNR:-999999999}
 ORGNAVN=${ORGNAVN:-"Ståles Stål AS"}
 LAND=${LAND:-BE}
 
-# Randomiser periode så hver kjøring blir en fersk sak (unngå kollisjon med gamle saker).
 _Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
 FRA=${FRA:-${_Y}-${_M}-01}
 TIL=${TIL:-${_Y}-${_M}-28}
 PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
 
-# Pause mellom innsendinger så melosys-api rekker å committe sak + mapping før neste melding
-# konsumeres (demper duplikatsak-bug ved samtidig prosessering).
 SLEEP=${SLEEP:-4}
-
-# Hvor PDF-er lagres. Overstyr med OUTDIR=. for å skrive til arbeidsmappa.
 OUTDIR=${OUTDIR:-/tmp}
 
-token() { # token <issuer> <param>   (param: "pid=.." for tokenx, "scope=.." for isso)
+token() {
   curl -s -X POST "$MOCK_OAUTH/$1/token" \
     -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'
 }
 
-post() { # post <token> <path> <json>   -> echoer body, feiler ved ikke-2xx
+post() {
   local code body
   body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" \
     -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
@@ -48,7 +35,7 @@ post() { # post <token> <path> <json>   -> echoer body, feiler ved ikke-2xx
   echo "$body"
 }
 
-opprett() { # opprett <token> <representasjonstype>  -> echoer skjemaId
+opprett() {
   local rep=$2 person
   if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}";
   else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
@@ -57,7 +44,7 @@ opprett() { # opprett <token> <representasjonstype>  -> echoer skjemaId
     | jq -r '.id'
 }
 
-fyll_arbeidstakerdel() { # <token> <skjemaId>
+fyll_arbeidstakerdel() {
   post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
   post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
   post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
@@ -66,7 +53,7 @@ fyll_arbeidstakerdel() { # <token> <skjemaId>
   post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
 }
 
-fyll_arbeidsgiverdel() { # <token> <skjemaId>
+fyll_arbeidsgiverdel() {
   post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
   post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
   post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
@@ -76,19 +63,17 @@ fyll_arbeidsgiverdel() { # <token> <skjemaId>
   post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
 }
 
-send_inn() { # <token> <skjemaId> -> echoer referanseId
+send_inn() {
   post "$1" "$2/send-inn" '' | jq -r '.referanseId'
 }
 
-# Høynivå: opprett + fyll + send en komplett del i ett kall. Setter SKJEMA_ID og REFERANSE
-# slik at flere innsendinger blir en enkel sekvens (eller løkke) i kallende skript.
-send_arbeidstakerdel() { # <token>
+send_arbeidstakerdel() {
   SKJEMA_ID=$(opprett "$1" DEG_SELV)
   fyll_arbeidstakerdel "$1" "$SKJEMA_ID"
   REFERANSE=$(send_inn "$1" "$SKJEMA_ID")
 }
 
-send_arbeidsgiverdel() { # <token>
+send_arbeidsgiverdel() {
   SKJEMA_ID=$(opprett "$1" ARBEIDSGIVER)
   fyll_arbeidsgiverdel "$1" "$SKJEMA_ID"
   REFERANSE=$(send_inn "$1" "$SKJEMA_ID")

--- a/scripts/_repro-lib.sh
+++ b/scripts/_repro-lib.sh
@@ -13,7 +13,7 @@ ORGNR=${ORGNR:-999999999}
 ORGNAVN=${ORGNAVN:-"Ståles Stål AS"}
 LAND=${LAND:-BE}
 
-_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
+_Y=$((2027 + RANDOM % 50)); _M=$(printf '%02d' $((1 + RANDOM % 12)))
 FRA=${FRA:-${_Y}-${_M}-01}
 TIL=${TIL:-${_Y}-${_M}-28}
 PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
@@ -77,4 +77,32 @@ send_arbeidsgiverdel() {
   SKJEMA_ID=$(opprett "$1" ARBEIDSGIVER)
   fyll_arbeidsgiverdel "$1" "$SKJEMA_ID"
   REFERANSE=$(send_inn "$1" "$SKJEMA_ID")
+}
+
+# Setter ny FRA/TIL/PERIODE. nyPeriode <fra> <til> for eksplisitt periode, eller uten
+# argumenter for en tilfeldig. Bruk mellom innsendinger for å få distinkte saker (ulik,
+# ikke-overlappende periode => ingen motpart-/erstatter-kobling).
+nyPeriode() {
+  if [[ $# -eq 2 ]]; then
+    FRA=$1; TIL=$2
+  else
+    local y m
+    y=$((2027 + RANDOM % 50)); m=$(printf '%02d' $((1 + RANDOM % 12)))
+    FRA="${y}-${m}-01"; TIL="${y}-${m}-28"
+  fi
+  PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
+}
+
+# Inspiserer PDF-teksten og rapporterer hvilke deler den inneholder (krever pdftotext).
+inspiser_pdf() { # <pdf-fil>
+  if ! command -v pdftotext >/dev/null; then
+    echo "   (pdftotext ikke installert – hopper over tekst-sjekk)"; return
+  fi
+  local tekst; tekst=$(pdftotext -layout "$1" - 2>/dev/null || true)
+  grep -q "Arbeidstakers del" <<<"$tekst" && echo "   ✓ inneholder «Arbeidstakers del»"
+  if grep -q "Arbeidsgivers del" <<<"$tekst"; then
+    echo "   ⚠ inneholder «Arbeidsgivers del» (bug ikke fikset)"
+  else
+    echo "   ✓ inneholder IKKE «Arbeidsgivers del» (fiks virker)"
+  fi
 }

--- a/scripts/_repro-lib.sh
+++ b/scripts/_repro-lib.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Delt hjelpebibliotek for repro-skriptene. Source-es inn av kallende skript:
+#   source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
+#
+# Gir env-defaults, testidentiteter, lavnivå-helpere (token/post/opprett/fyll/send_inn) og
+# høynivå-helpere (send_arbeidstakerdel/send_arbeidsgiverdel) slik at det er trivielt å sende
+# inn flere skjema fra et kallende skript.
+#
+# Identiteter (se melosys-docker-compose/TESTBRUKERE.md):
+#   Arbeidstaker (DEG_SELV):     HANS HANSEN       01816023404
+#   Arbeidsgiver (ARBEIDSGIVER): KARAFFEL TRIVIELL 30056928150 (Altinn-tilgang til Ståles Stål)
+#   Organisasjon:                Ståles Stål AS    999999999
+
+SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
+MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
+BASE="$SKJEMA_API/api/skjema/utsendt-arbeidstaker"
+
+ARBEIDSTAKER_FNR=${ARBEIDSTAKER_FNR:-01816023404}
+ARBEIDSGIVER_FNR=${ARBEIDSGIVER_FNR:-30056928150}
+ORGNR=${ORGNR:-999999999}
+ORGNAVN=${ORGNAVN:-"Ståles Stål AS"}
+LAND=${LAND:-BE}
+
+# Randomiser periode så hver kjøring blir en fersk sak (unngå kollisjon med gamle saker).
+_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
+FRA=${FRA:-${_Y}-${_M}-01}
+TIL=${TIL:-${_Y}-${_M}-28}
+PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
+
+# Pause mellom innsendinger så melosys-api rekker å committe sak + mapping før neste melding
+# konsumeres (demper duplikatsak-bug ved samtidig prosessering).
+SLEEP=${SLEEP:-4}
+
+# Hvor PDF-er lagres. Overstyr med OUTDIR=. for å skrive til arbeidsmappa.
+OUTDIR=${OUTDIR:-/tmp}
+
+token() { # token <issuer> <param>   (param: "pid=.." for tokenx, "scope=.." for isso)
+  curl -s -X POST "$MOCK_OAUTH/$1/token" \
+    -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'
+}
+
+post() { # post <token> <path> <json>   -> echoer body, feiler ved ikke-2xx
+  local code body
+  body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" \
+    -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
+  code=$(tail -n1 <<<"$body"); body=$(sed '$d' <<<"$body")
+  if [[ "$code" != 2* ]]; then echo "  ✗ POST /$2 -> $code: $body" >&2; exit 1; fi
+  echo "$body"
+}
+
+opprett() { # opprett <token> <representasjonstype>  -> echoer skjemaId
+  local rep=$2 person
+  if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}";
+  else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
+  post "$1" "opprett-med-kontekst" \
+    "{\"representasjonstype\":\"$rep\",\"radgiverfirma\":null,\"arbeidsgiver\":{\"orgnr\":\"$ORGNR\",\"navn\":\"$ORGNAVN\"},\"arbeidstaker\":$person}" \
+    | jq -r '.id'
+}
+
+fyll_arbeidstakerdel() { # <token> <skjemaId>
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
+  post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
+  post "$1" "$2/familiemedlemmer" '{"skalHaMedFamiliemedlemmer":false}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+
+fyll_arbeidsgiverdel() { # <token> <skjemaId>
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
+  post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
+  post "$1" "$2/arbeidstakerens-lonn" '{"arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden":true}' >/dev/null
+  post "$1" "$2/arbeidssted-i-utlandet" '{"arbeidsstedType":"PA_SKIP","paSkip":{"navnPaVirksomhet":"navn","navnPaSkip":"navn skip","yrketTilArbeidstaker":"yrke","seilerI":"INTERNASJONALT_FARVANN","flaggland":"BE"}}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+
+send_inn() { # <token> <skjemaId> -> echoer referanseId
+  post "$1" "$2/send-inn" '' | jq -r '.referanseId'
+}
+
+# Høynivå: opprett + fyll + send en komplett del i ett kall. Setter SKJEMA_ID og REFERANSE
+# slik at flere innsendinger blir en enkel sekvens (eller løkke) i kallende skript.
+send_arbeidstakerdel() { # <token>
+  SKJEMA_ID=$(opprett "$1" DEG_SELV)
+  fyll_arbeidstakerdel "$1" "$SKJEMA_ID"
+  REFERANSE=$(send_inn "$1" "$SKJEMA_ID")
+}
+
+send_arbeidsgiverdel() { # <token>
+  SKJEMA_ID=$(opprett "$1" ARBEIDSGIVER)
+  fyll_arbeidsgiverdel "$1" "$SKJEMA_ID"
+  REFERANSE=$(send_inn "$1" "$SKJEMA_ID")
+}

--- a/scripts/reproduser-arvet-kobling.sh
+++ b/scripts/reproduser-arvet-kobling.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# Reproduserer "arvet kobling -> komplett PDF" mot LOKAL benk:
-#   arbeidstaker (v1) -> arbeidsgiver -> NY versjon av arbeidstakers del (v2).
-# v2 arver kobling til (utdatert) arbeidsgivers del, slik at M2M-PDF-en feilaktig får begge deler.
-#
-# Sender ekte skjema via melosys-skjema-api (:8090) med ekte tokens fra mock-oauth2-server (:8082).
-# Resten (Kafka -> melosys-api -> sak) skjer av seg selv.
+# Repro: arbeidstaker (v1) -> arbeidsgiver -> ny versjon arbeidstakers del (v2) som arver kobling.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
 

--- a/scripts/reproduser-arvet-kobling.sh
+++ b/scripts/reproduser-arvet-kobling.sh
@@ -31,6 +31,7 @@ echo "   koblet skjemadel  = $(jq -r '.kobletSkjema.metadata.skjemadel' <<<"$DAT
 PDF="$OUTDIR/v2-$AT_V2.pdf"
 curl -s "$SKJEMA_API/m2m/api/skjema/$AT_V2/pdf" -H "Authorization: Bearer $TOK_M2M" -o "$PDF"
 echo "   PDF lagret: $PDF ($(wc -c <"$PDF") bytes)"
+inspiser_pdf "$PDF"
 
 echo
 echo "✓ Fullført. Referanser: v1=$REF1  AG=$REF2  v2=$REF3"

--- a/scripts/reproduser-arvet-kobling.sh
+++ b/scripts/reproduser-arvet-kobling.sh
@@ -1,111 +1,42 @@
 #!/usr/bin/env bash
-# Reproduserer "arvet kobling -> komplett PDF" (MEL-16515 / MEL-8135) mot LOKAL benk.
+# Reproduserer "arvet kobling -> komplett PDF" mot LOKAL benk:
+#   arbeidstaker (v1) -> arbeidsgiver -> NY versjon av arbeidstakers del (v2).
+# v2 arver kobling til (utdatert) arbeidsgivers del, slik at M2M-PDF-en feilaktig får begge deler.
 #
-# Sender tre ekte skjemaer via melosys-skjema-api (:8090) med ekte tokens fra
-# mock-oauth2-server (:8082). Resten (Kafka -> melosys-api -> sak) skjer av seg selv.
-#
-# Identiteter (se melosys-docker-compose/TESTBRUKERE.md):
-#   Arbeidstaker (DEG_SELV):  HANS HANSEN      01816023404
-#   Arbeidsgiver (ARBEIDSGIVER): KARAFFEL TRIVIELL 30056928150 (Altinn-tilgang til Ståles Stål)
-#   Organisasjon:             Ståles Stål AS   999999999
+# Sender ekte skjema via melosys-skjema-api (:8090) med ekte tokens fra mock-oauth2-server (:8082).
+# Resten (Kafka -> melosys-api -> sak) skjer av seg selv.
 set -euo pipefail
-
-SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
-MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
-BASE="$SKJEMA_API/api/skjema/utsendt-arbeidstaker"
-
-ARBEIDSTAKER_FNR=01816023404
-ARBEIDSGIVER_FNR=30056928150
-ORGNR=999999999
-ORGNAVN="Ståles Stål AS"
-LAND=BE
-# Randomiser periode så hver kjøring blir en fersk sak (unngå kollisjon med gamle saker).
-_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
-FRA=${FRA:-${_Y}-${_M}-01}
-TIL=${TIL:-${_Y}-${_M}-28}
-# Midlertidig demping for samtidighets-bugen (duplikate saker): vent mellom innsendinger
-# så melosys-api rekker å committe sak + mapping før neste melding konsumeres.
-SLEEP=${SLEEP:-4}
-
-token() { # token <issuer> <param>   (param: "pid=.." for tokenx, "scope=.." for isso)
-  curl -s -X POST "$MOCK_OAUTH/$1/token" \
-    -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'
-}
-
-post() { # post <token> <path> <json>   -> echoes body, asserts 2xx
-  local code body
-  body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" \
-    -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
-  code=$(tail -n1 <<<"$body"); body=$(sed '$d' <<<"$body")
-  if [[ "$code" != 2* ]]; then echo "  ✗ POST /$2 -> $code: $body" >&2; exit 1; fi
-  echo "$body"
-}
-
-opprett() { # opprett <token> <representasjonstype>  -> echoes skjemaId
-  local rep=$2 person
-  if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}";
-  else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
-  post "$1" "opprett-med-kontekst" \
-    "{\"representasjonstype\":\"$rep\",\"radgiverfirma\":null,\"arbeidsgiver\":{\"orgnr\":\"$ORGNR\",\"navn\":\"$ORGNAVN\"},\"arbeidstaker\":$person}" \
-    | jq -r '.id'
-}
-
-PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
-
-fyll_arbeidstakerdel() { # <token> <skjemaId>
-  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
-  post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
-  post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
-  post "$1" "$2/familiemedlemmer" '{"skalHaMedFamiliemedlemmer":false}' >/dev/null
-  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
-  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
-}
-
-fyll_arbeidsgiverdel() { # <token> <skjemaId>
-  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
-  post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
-  post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
-  post "$1" "$2/arbeidstakerens-lonn" '{"arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden":true}' >/dev/null
-  post "$1" "$2/arbeidssted-i-utlandet" '{"arbeidsstedType":"PA_SKIP","paSkip":{"navnPaVirksomhet":"navn","navnPaSkip":"navn skip","yrketTilArbeidstaker":"yrke","seilerI":"INTERNASJONALT_FARVANN","flaggland":"BE"}}' >/dev/null
-  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
-  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
-}
-
-send_inn() { # <token> <skjemaId> -> echoes referanseId
-  post "$1" "$2/send-inn" '' | jq -r '.referanseId'
-}
+source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
 
 echo "▶ Minter tokens…"
 TOK_AT=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
 TOK_AG=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSGIVER_FNR")
 
 echo "▶ 1) Arbeidstaker (DEG_SELV) sender ARBEIDSTAKERS_DEL (v1)…"
-AT_V1=$(opprett "$TOK_AT" DEG_SELV);            echo "   skjemaId=$AT_V1"
-fyll_arbeidstakerdel "$TOK_AT" "$AT_V1"
-REF1=$(send_inn "$TOK_AT" "$AT_V1");            echo "   ✓ sendt, referanse=$REF1"
+send_arbeidstakerdel "$TOK_AT"; AT_V1=$SKJEMA_ID; REF1=$REFERANSE
+echo "   skjemaId=$AT_V1, referanse=$REF1"
 echo "   ⏳ venter ${SLEEP}s (lar melosys-api opprette sak + mapping)…"; sleep "$SLEEP"
 
 echo "▶ 2) Arbeidsgiver (ARBEIDSGIVER) sender ARBEIDSGIVERS_DEL…"
-AG=$(opprett "$TOK_AG" ARBEIDSGIVER);           echo "   skjemaId=$AG"
-fyll_arbeidsgiverdel "$TOK_AG" "$AG"
-REF2=$(send_inn "$TOK_AG" "$AG");               echo "   ✓ sendt, referanse=$REF2 (kobles mot v1)"
+send_arbeidsgiverdel "$TOK_AG"; AG=$SKJEMA_ID; REF2=$REFERANSE
+echo "   skjemaId=$AG, referanse=$REF2 (kobles mot v1)"
 echo "   ⏳ venter ${SLEEP}s…"; sleep "$SLEEP"
 
 echo "▶ 3) Arbeidstaker (DEG_SELV) sender NY ARBEIDSTAKERS_DEL (v2)…"
-AT_V2=$(opprett "$TOK_AT" DEG_SELV);            echo "   skjemaId=$AT_V2"
-fyll_arbeidstakerdel "$TOK_AT" "$AT_V2"
-REF3=$(send_inn "$TOK_AT" "$AT_V2");            echo "   ✓ sendt, referanse=$REF3 (arver kobling -> BUG)"
+send_arbeidstakerdel "$TOK_AT"; AT_V2=$SKJEMA_ID; REF3=$REFERANSE
+echo "   skjemaId=$AT_V2, referanse=$REF3 (arver kobling -> BUG)"
 
 echo
 echo "▶ Verifiserer M2M-data + PDF for v2 ($AT_V2)…"
 TOK_M2M=$(token isso "scope=melosys-localhost")
 DATA=$(curl -s "$SKJEMA_API/m2m/api/skjema/utsendt-arbeidstaker/$AT_V2/data" -H "Authorization: Bearer $TOK_M2M")
-echo "   skjemadel       = $(jq -r '.skjema.metadata.skjemadel' <<<"$DATA")"
-echo "   kobletSkjema.id  = $(jq -r '.kobletSkjema.id' <<<"$DATA")  (≠ null = bug)"
-echo "   koblet skjemadel = $(jq -r '.kobletSkjema.metadata.skjemadel' <<<"$DATA")"
-curl -s "$SKJEMA_API/m2m/api/skjema/$AT_V2/pdf" -H "Authorization: Bearer $TOK_M2M" -o /tmp/v2-$AT_V2.pdf
-echo "   PDF lagret: /tmp/v2-$AT_V2.pdf ($(wc -c </tmp/v2-$AT_V2.pdf) bytes)"
+echo "   skjemadel        = $(jq -r '.skjema.metadata.skjemadel' <<<"$DATA")"
+echo "   kobletSkjema.id   = $(jq -r '.kobletSkjema.id' <<<"$DATA")  (≠ null = bug)"
+echo "   koblet skjemadel  = $(jq -r '.kobletSkjema.metadata.skjemadel' <<<"$DATA")"
+PDF="$OUTDIR/v2-$AT_V2.pdf"
+curl -s "$SKJEMA_API/m2m/api/skjema/$AT_V2/pdf" -H "Authorization: Bearer $TOK_M2M" -o "$PDF"
+echo "   PDF lagret: $PDF ($(wc -c <"$PDF") bytes)"
 
 echo
-echo "�fullført. Referanser: v1=$REF1  AG=$REF2  v2=$REF3"
+echo "✓ Fullført. Referanser: v1=$REF1  AG=$REF2  v2=$REF3"
 echo "Saken skal nå dukke opp i melosys-api/melosys-web (Kafka -> melosys-api oppretter sak)."

--- a/scripts/reproduser-arvet-kobling.sh
+++ b/scripts/reproduser-arvet-kobling.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Reproduserer "arvet kobling -> komplett PDF" (MEL-16515 / MEL-8135) mot LOKAL benk.
+#
+# Sender tre ekte skjemaer via melosys-skjema-api (:8090) med ekte tokens fra
+# mock-oauth2-server (:8082). Resten (Kafka -> melosys-api -> sak) skjer av seg selv.
+#
+# Identiteter (se melosys-docker-compose/TESTBRUKERE.md):
+#   Arbeidstaker (DEG_SELV):  HANS HANSEN      01816023404
+#   Arbeidsgiver (ARBEIDSGIVER): KARAFFEL TRIVIELL 30056928150 (Altinn-tilgang til Ståles Stål)
+#   Organisasjon:             Ståles Stål AS   999999999
+set -euo pipefail
+
+SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
+MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
+BASE="$SKJEMA_API/api/skjema/utsendt-arbeidstaker"
+
+ARBEIDSTAKER_FNR=01816023404
+ARBEIDSGIVER_FNR=30056928150
+ORGNR=999999999
+ORGNAVN="Ståles Stål AS"
+LAND=BE
+# Randomiser periode så hver kjøring blir en fersk sak (unngå kollisjon med gamle saker).
+_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
+FRA=${FRA:-${_Y}-${_M}-01}
+TIL=${TIL:-${_Y}-${_M}-28}
+# Midlertidig demping for samtidighets-bugen (duplikate saker): vent mellom innsendinger
+# så melosys-api rekker å committe sak + mapping før neste melding konsumeres.
+SLEEP=${SLEEP:-4}
+
+token() { # token <issuer> <param>   (param: "pid=.." for tokenx, "scope=.." for isso)
+  curl -s -X POST "$MOCK_OAUTH/$1/token" \
+    -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'
+}
+
+post() { # post <token> <path> <json>   -> echoes body, asserts 2xx
+  local code body
+  body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" \
+    -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
+  code=$(tail -n1 <<<"$body"); body=$(sed '$d' <<<"$body")
+  if [[ "$code" != 2* ]]; then echo "  ✗ POST /$2 -> $code: $body" >&2; exit 1; fi
+  echo "$body"
+}
+
+opprett() { # opprett <token> <representasjonstype>  -> echoes skjemaId
+  local rep=$2 person
+  if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}";
+  else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
+  post "$1" "opprett-med-kontekst" \
+    "{\"representasjonstype\":\"$rep\",\"radgiverfirma\":null,\"arbeidsgiver\":{\"orgnr\":\"$ORGNR\",\"navn\":\"$ORGNAVN\"},\"arbeidstaker\":$person}" \
+    | jq -r '.id'
+}
+
+PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
+
+fyll_arbeidstakerdel() { # <token> <skjemaId>
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
+  post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
+  post "$1" "$2/familiemedlemmer" '{"skalHaMedFamiliemedlemmer":false}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+
+fyll_arbeidsgiverdel() { # <token> <skjemaId>
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
+  post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
+  post "$1" "$2/arbeidstakerens-lonn" '{"arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden":true}' >/dev/null
+  post "$1" "$2/arbeidssted-i-utlandet" '{"arbeidsstedType":"PA_SKIP","paSkip":{"navnPaVirksomhet":"navn","navnPaSkip":"navn skip","yrketTilArbeidstaker":"yrke","seilerI":"INTERNASJONALT_FARVANN","flaggland":"BE"}}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+
+send_inn() { # <token> <skjemaId> -> echoes referanseId
+  post "$1" "$2/send-inn" '' | jq -r '.referanseId'
+}
+
+echo "▶ Minter tokens…"
+TOK_AT=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
+TOK_AG=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSGIVER_FNR")
+
+echo "▶ 1) Arbeidstaker (DEG_SELV) sender ARBEIDSTAKERS_DEL (v1)…"
+AT_V1=$(opprett "$TOK_AT" DEG_SELV);            echo "   skjemaId=$AT_V1"
+fyll_arbeidstakerdel "$TOK_AT" "$AT_V1"
+REF1=$(send_inn "$TOK_AT" "$AT_V1");            echo "   ✓ sendt, referanse=$REF1"
+echo "   ⏳ venter ${SLEEP}s (lar melosys-api opprette sak + mapping)…"; sleep "$SLEEP"
+
+echo "▶ 2) Arbeidsgiver (ARBEIDSGIVER) sender ARBEIDSGIVERS_DEL…"
+AG=$(opprett "$TOK_AG" ARBEIDSGIVER);           echo "   skjemaId=$AG"
+fyll_arbeidsgiverdel "$TOK_AG" "$AG"
+REF2=$(send_inn "$TOK_AG" "$AG");               echo "   ✓ sendt, referanse=$REF2 (kobles mot v1)"
+echo "   ⏳ venter ${SLEEP}s…"; sleep "$SLEEP"
+
+echo "▶ 3) Arbeidstaker (DEG_SELV) sender NY ARBEIDSTAKERS_DEL (v2)…"
+AT_V2=$(opprett "$TOK_AT" DEG_SELV);            echo "   skjemaId=$AT_V2"
+fyll_arbeidstakerdel "$TOK_AT" "$AT_V2"
+REF3=$(send_inn "$TOK_AT" "$AT_V2");            echo "   ✓ sendt, referanse=$REF3 (arver kobling -> BUG)"
+
+echo
+echo "▶ Verifiserer M2M-data + PDF for v2 ($AT_V2)…"
+TOK_M2M=$(token isso "scope=melosys-localhost")
+DATA=$(curl -s "$SKJEMA_API/m2m/api/skjema/utsendt-arbeidstaker/$AT_V2/data" -H "Authorization: Bearer $TOK_M2M")
+echo "   skjemadel       = $(jq -r '.skjema.metadata.skjemadel' <<<"$DATA")"
+echo "   kobletSkjema.id  = $(jq -r '.kobletSkjema.id' <<<"$DATA")  (≠ null = bug)"
+echo "   koblet skjemadel = $(jq -r '.kobletSkjema.metadata.skjemadel' <<<"$DATA")"
+curl -s "$SKJEMA_API/m2m/api/skjema/$AT_V2/pdf" -H "Authorization: Bearer $TOK_M2M" -o /tmp/v2-$AT_V2.pdf
+echo "   PDF lagret: /tmp/v2-$AT_V2.pdf ($(wc -c </tmp/v2-$AT_V2.pdf) bytes)"
+
+echo
+echo "�fullført. Referanser: v1=$REF1  AG=$REF2  v2=$REF3"
+echo "Saken skal nå dukke opp i melosys-api/melosys-web (Kafka -> melosys-api oppretter sak)."

--- a/scripts/reproduser-motpart-ag-forst.sh
+++ b/scripts/reproduser-motpart-ag-forst.sh
@@ -2,63 +2,21 @@
 # Reproduserer journalførings-bugen i det ENKLE tilfellet (ingen ny versjon / arvet kobling):
 # Arbeidsgiver sender sin del FØRST, så sender arbeidstaker sin del. Arbeidstakers del blir
 # motpart-koblet til arbeidsgivers del, og arbeidstakers PDF får da BEGGE deler.
-#
-# Periode randomiseres så hver kjøring blir en fersk sak. Kjør mot LOKAL benk.
 set -euo pipefail
-
-SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
-MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
-BASE="$SKJEMA_API/api/skjema/utsendt-arbeidstaker"
-
-ARBEIDSTAKER_FNR=01816023404      # HANS HANSEN (DEG_SELV)
-ARBEIDSGIVER_FNR=30056928150      # KARAFFEL TRIVIELL (ARBEIDSGIVER, Altinn-tilgang til Ståles Stål)
-ORGNR=999999999; ORGNAVN="Ståles Stål AS"; LAND=BE
-_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
-FRA=${FRA:-${_Y}-${_M}-01}; TIL=${TIL:-${_Y}-${_M}-28}
-SLEEP=${SLEEP:-4}
-
-token() { curl -s -X POST "$MOCK_OAUTH/$1/token" -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'; }
-post() {
-  local body code; body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
-  code=$(tail -n1 <<<"$body"); body=$(sed '$d' <<<"$body")
-  [[ "$code" == 2* ]] || { echo "  ✗ POST /$2 -> $code: $body" >&2; exit 1; }; echo "$body"
-}
-opprett() {
-  local rep=$2 person; if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}"; else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
-  post "$1" "opprett-med-kontekst" "{\"representasjonstype\":\"$rep\",\"radgiverfirma\":null,\"arbeidsgiver\":{\"orgnr\":\"$ORGNR\",\"navn\":\"$ORGNAVN\"},\"arbeidstaker\":$person}" | jq -r '.id'
-}
-PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
-fyll_at() {
-  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
-  post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
-  post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
-  post "$1" "$2/familiemedlemmer" '{"skalHaMedFamiliemedlemmer":false}' >/dev/null
-  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
-  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
-}
-fyll_ag() {
-  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
-  post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
-  post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
-  post "$1" "$2/arbeidstakerens-lonn" '{"arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden":true}' >/dev/null
-  post "$1" "$2/arbeidssted-i-utlandet" '{"arbeidsstedType":"PA_SKIP","paSkip":{"navnPaVirksomhet":"navn","navnPaSkip":"navn skip","yrketTilArbeidstaker":"yrke","seilerI":"INTERNASJONALT_FARVANN","flaggland":"BE"}}' >/dev/null
-  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
-  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
-}
-send_inn() { post "$1" "$2/send-inn" '' | jq -r '.referanseId'; }
+source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
 
 echo "▶ Periode: $FRA – $TIL"
 TOK_AT=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
 TOK_AG=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSGIVER_FNR")
 
 echo "▶ 1) Arbeidsgiver (ARBEIDSGIVER) sender ARBEIDSGIVERS_DEL FØRST…"
-AG=$(opprett "$TOK_AG" ARBEIDSGIVER); echo "   skjemaId=$AG"
-fyll_ag "$TOK_AG" "$AG"; REF_AG=$(send_inn "$TOK_AG" "$AG"); echo "   ✓ sendt, referanse=$REF_AG (ingen motpart ennå)"
+send_arbeidsgiverdel "$TOK_AG"; AG=$SKJEMA_ID; REF_AG=$REFERANSE
+echo "   skjemaId=$AG, referanse=$REF_AG (ingen motpart ennå)"
 echo "   ⏳ venter ${SLEEP}s…"; sleep "$SLEEP"
 
 echo "▶ 2) Arbeidstaker (DEG_SELV) sender ARBEIDSTAKERS_DEL etterpå…"
-AT=$(opprett "$TOK_AT" DEG_SELV); echo "   skjemaId=$AT"
-fyll_at "$TOK_AT" "$AT"; REF_AT=$(send_inn "$TOK_AT" "$AT"); echo "   ✓ sendt, referanse=$REF_AT (motpart-kobles til arbeidsgivers del)"
+send_arbeidstakerdel "$TOK_AT"; AT=$SKJEMA_ID; REF_AT=$REFERANSE
+echo "   skjemaId=$AT, referanse=$REF_AT (motpart-kobles til arbeidsgivers del)"
 
 echo
 echo "▶ Sjekker arbeidstakers del ($AT)…"
@@ -66,7 +24,8 @@ TOK_M2M=$(token isso "scope=melosys-localhost")
 DATA=$(curl -s "$SKJEMA_API/m2m/api/skjema/utsendt-arbeidstaker/$AT/data" -H "Authorization: Bearer $TOK_M2M")
 echo "   skjemadel        = $(jq -r '.skjema.metadata.skjemadel' <<<"$DATA")"
 echo "   kobletSkjema.id   = $(jq -r '.kobletSkjema.id' <<<"$DATA")"
-curl -s "$SKJEMA_API/m2m/api/skjema/$AT/pdf" -H "Authorization: Bearer $TOK_M2M" -o "/tmp/at-$AT.pdf"
-echo "   PDF: /tmp/at-$AT.pdf ($(wc -c </tmp/at-$AT.pdf) bytes)"
+PDF="$OUTDIR/at-$AT.pdf"
+curl -s "$SKJEMA_API/m2m/api/skjema/$AT/pdf" -H "Authorization: Bearer $TOK_M2M" -o "$PDF"
+echo "   PDF: $PDF ($(wc -c <"$PDF") bytes)"
 echo
 echo "Referanser: AG=$REF_AG  AT=$REF_AT  | periode $FRA–$TIL"

--- a/scripts/reproduser-motpart-ag-forst.sh
+++ b/scripts/reproduser-motpart-ag-forst.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Reproduserer journalførings-bugen i det ENKLE tilfellet (ingen ny versjon / arvet kobling):
+# Arbeidsgiver sender sin del FØRST, så sender arbeidstaker sin del. Arbeidstakers del blir
+# motpart-koblet til arbeidsgivers del, og arbeidstakers PDF får da BEGGE deler.
+#
+# Periode randomiseres så hver kjøring blir en fersk sak. Kjør mot LOKAL benk.
+set -euo pipefail
+
+SKJEMA_API=${SKJEMA_API:-http://localhost:8090}
+MOCK_OAUTH=${MOCK_OAUTH:-http://localhost:8082}
+BASE="$SKJEMA_API/api/skjema/utsendt-arbeidstaker"
+
+ARBEIDSTAKER_FNR=01816023404      # HANS HANSEN (DEG_SELV)
+ARBEIDSGIVER_FNR=30056928150      # KARAFFEL TRIVIELL (ARBEIDSGIVER, Altinn-tilgang til Ståles Stål)
+ORGNR=999999999; ORGNAVN="Ståles Stål AS"; LAND=BE
+_Y=$((2027 + RANDOM % 5)); _M=$(printf '%02d' $((1 + RANDOM % 9)))
+FRA=${FRA:-${_Y}-${_M}-01}; TIL=${TIL:-${_Y}-${_M}-28}
+SLEEP=${SLEEP:-4}
+
+token() { curl -s -X POST "$MOCK_OAUTH/$1/token" -d "grant_type=client_credentials&client_id=test&client_secret=dummy&$2" | jq -r '.access_token'; }
+post() {
+  local body code; body=$(curl -s -w '\n%{http_code}' -X POST "$BASE/$2" -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3")
+  code=$(tail -n1 <<<"$body"); body=$(sed '$d' <<<"$body")
+  [[ "$code" == 2* ]] || { echo "  ✗ POST /$2 -> $code: $body" >&2; exit 1; }; echo "$body"
+}
+opprett() {
+  local rep=$2 person; if [[ "$rep" == DEG_SELV ]]; then person="{\"fnr\":\"$ARBEIDSTAKER_FNR\"}"; else person="{\"fnr\":\"$ARBEIDSTAKER_FNR\",\"etternavn\":\"HANSEN\"}"; fi
+  post "$1" "opprett-med-kontekst" "{\"representasjonstype\":\"$rep\",\"radgiverfirma\":null,\"arbeidsgiver\":{\"orgnr\":\"$ORGNR\",\"navn\":\"$ORGNAVN\"},\"arbeidstaker\":$person}" | jq -r '.id'
+}
+PERIODE="{\"utsendelseLand\":\"$LAND\",\"utsendelsePeriode\":{\"fraDato\":\"$FRA\",\"tilDato\":\"$TIL\"}}"
+fyll_at() {
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidssituasjon" '{"harVaertEllerSkalVaereILonnetArbeidFoerUtsending":true,"skalJobbeForFlereVirksomheter":false}' >/dev/null
+  post "$1" "$2/skatteforhold-og-inntekt" '{"erSkattepliktigTilNorgeIHeleutsendingsperioden":true,"mottarPengestotteFraAnnetEosLandEllerSveits":false,"inntektFraNorskEllerUtenlandskVirksomhet":["NORSK_VIRKSOMHET"],"hvilkeTyperInntektHarDu":["LOENN"]}' >/dev/null
+  post "$1" "$2/familiemedlemmer" '{"skalHaMedFamiliemedlemmer":false}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+fyll_ag() {
+  post "$1" "$2/utsendingsperiode-og-land" "$PERIODE" >/dev/null
+  post "$1" "$2/arbeidsgiverens-virksomhet-i-norge" '{"erArbeidsgiverenOffentligVirksomhet":false,"erArbeidsgiverenBemanningsEllerVikarbyraa":false,"opprettholderArbeidsgiverenVanligDrift":true}' >/dev/null
+  post "$1" "$2/utenlandsoppdraget" '{"arbeidsgiverHarOppdragILandet":true,"arbeidstakerBleAnsattForUtenlandsoppdraget":false,"arbeidstakerForblirAnsattIHelePerioden":true,"arbeidstakerErstatterAnnenPerson":false}' >/dev/null
+  post "$1" "$2/arbeidstakerens-lonn" '{"arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden":true}' >/dev/null
+  post "$1" "$2/arbeidssted-i-utlandet" '{"arbeidsstedType":"PA_SKIP","paSkip":{"navnPaVirksomhet":"navn","navnPaSkip":"navn skip","yrketTilArbeidstaker":"yrke","seilerI":"INTERNASJONALT_FARVANN","flaggland":"BE"}}' >/dev/null
+  post "$1" "$2/tilleggsopplysninger" '{"harFlereOpplysningerTilSoknaden":false}' >/dev/null
+  post "$1" "$2/vedlegg" '{"harAnnenDokumentasjon":false}' >/dev/null
+}
+send_inn() { post "$1" "$2/send-inn" '' | jq -r '.referanseId'; }
+
+echo "▶ Periode: $FRA – $TIL"
+TOK_AT=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSTAKER_FNR")
+TOK_AG=$(token tokenx "audience=melosys-skjema-api&pid=$ARBEIDSGIVER_FNR")
+
+echo "▶ 1) Arbeidsgiver (ARBEIDSGIVER) sender ARBEIDSGIVERS_DEL FØRST…"
+AG=$(opprett "$TOK_AG" ARBEIDSGIVER); echo "   skjemaId=$AG"
+fyll_ag "$TOK_AG" "$AG"; REF_AG=$(send_inn "$TOK_AG" "$AG"); echo "   ✓ sendt, referanse=$REF_AG (ingen motpart ennå)"
+echo "   ⏳ venter ${SLEEP}s…"; sleep "$SLEEP"
+
+echo "▶ 2) Arbeidstaker (DEG_SELV) sender ARBEIDSTAKERS_DEL etterpå…"
+AT=$(opprett "$TOK_AT" DEG_SELV); echo "   skjemaId=$AT"
+fyll_at "$TOK_AT" "$AT"; REF_AT=$(send_inn "$TOK_AT" "$AT"); echo "   ✓ sendt, referanse=$REF_AT (motpart-kobles til arbeidsgivers del)"
+
+echo
+echo "▶ Sjekker arbeidstakers del ($AT)…"
+TOK_M2M=$(token isso "scope=melosys-localhost")
+DATA=$(curl -s "$SKJEMA_API/m2m/api/skjema/utsendt-arbeidstaker/$AT/data" -H "Authorization: Bearer $TOK_M2M")
+echo "   skjemadel        = $(jq -r '.skjema.metadata.skjemadel' <<<"$DATA")"
+echo "   kobletSkjema.id   = $(jq -r '.kobletSkjema.id' <<<"$DATA")"
+curl -s "$SKJEMA_API/m2m/api/skjema/$AT/pdf" -H "Authorization: Bearer $TOK_M2M" -o "/tmp/at-$AT.pdf"
+echo "   PDF: /tmp/at-$AT.pdf ($(wc -c </tmp/at-$AT.pdf) bytes)"
+echo
+echo "Referanser: AG=$REF_AG  AT=$REF_AT  | periode $FRA–$TIL"

--- a/scripts/reproduser-motpart-ag-forst.sh
+++ b/scripts/reproduser-motpart-ag-forst.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Reproduserer journalførings-bugen i det ENKLE tilfellet (ingen ny versjon / arvet kobling):
-# Arbeidsgiver sender sin del FØRST, så sender arbeidstaker sin del. Arbeidstakers del blir
-# motpart-koblet til arbeidsgivers del, og arbeidstakers PDF får da BEGGE deler.
+# Repro: arbeidsgiver sender sin del først, så arbeidstaker → motpart-kobling.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/_repro-lib.sh"
 

--- a/scripts/reproduser-motpart-ag-forst.sh
+++ b/scripts/reproduser-motpart-ag-forst.sh
@@ -25,5 +25,6 @@ echo "   kobletSkjema.id   = $(jq -r '.kobletSkjema.id' <<<"$DATA")"
 PDF="$OUTDIR/at-$AT.pdf"
 curl -s "$SKJEMA_API/m2m/api/skjema/$AT/pdf" -H "Authorization: Bearer $TOK_M2M" -o "$PDF"
 echo "   PDF: $PDF ($(wc -c <"$PDF") bytes)"
+inspiser_pdf "$PDF"
 echo
 echo "Referanser: AG=$REF_AG  AT=$REF_AT  | periode $FRA–$TIL"

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/HtmlDokumentGenerator.kt
@@ -41,10 +41,6 @@ object HtmlDokumentGenerator {
             append(byggHeader(tittel, skjema.referanseId, skjema.innsendtDato, språk))
             append(byggAktørInfoSeksjon(skjema.aktørInfo, skjema.fullmektigInfo, skjema.radgiverInfo, språk))
             appendSkjemaData(skjema.skjemaData, skjema.definisjon, primaryRenderer, språk)
-            skjema.kobletSkjemaData?.let {
-                val kobletRenderer = SeksjonRenderer(feltRenderer, skjema.kobletVedlegg)
-                appendSkjemaData(it, skjema.definisjon, kobletRenderer, språk)
-            }
             append(byggHtmlSlutt())
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/pdf/SkjemaPdfData.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/pdf/SkjemaPdfData.kt
@@ -50,8 +50,6 @@ data class SkjemaPdfData(
     val fullmektigInfo: FullmektigInfo? = null,
     val radgiverInfo: RadgiverInfo? = null,
     val skjemaData: UtsendtArbeidstakerSkjemaData,
-    val kobletSkjemaData: UtsendtArbeidstakerSkjemaData?,
     val vedlegg: List<VedleggDto>,
-    val kobletVedlegg: List<VedleggDto> = emptyList(),
     val definisjon: SkjemaDefinisjonDto
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -162,9 +162,7 @@ class M2MSkjemaService(
             fullmektigInfo = fullmektigInfo,
             radgiverInfo = radgiverInfo,
             skjemaData = skjema.data as UtsendtArbeidstakerSkjemaData,
-            kobletSkjemaData = null,
             vedlegg = vedleggService.listBySkjemaId(skjema.id!!),
-            kobletVedlegg = emptyList(),
             definisjon = definisjon
         )
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -134,11 +134,6 @@ class M2MSkjemaService(
     private fun byggSkjemaPdfData(skjema: Skjema, innsending: Innsending): SkjemaPdfData {
         val metadata = skjema.metadata as UtsendtArbeidstakerMetadata
 
-        // MELOSYS-8092: Journalføringen skal gjenspeile det brukeren faktisk sendte inn — styrt av
-        // skjemadel. `kobletSkjema` brukes kun til samme-sak-vurdering (på /data), ikke til å bygge
-        // PDF-en. En ekte komplett søknad (ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) har begge deler i sitt
-        // eget data-objekt og rendres komplett uten kobling.
-
         val definisjon = skjemaDefinisjonService.hent(
             type = skjema.type,
             versjon = innsending.skjemaDefinisjonVersjon,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -134,9 +134,10 @@ class M2MSkjemaService(
     private fun byggSkjemaPdfData(skjema: Skjema, innsending: Innsending): SkjemaPdfData {
         val metadata = skjema.metadata as UtsendtArbeidstakerMetadata
 
-        val kobletSkjema = metadata.kobletSkjemaId?.let { kobletId ->
-            skjemaRepository.findByIdAndStatusSendt(kobletId)
-        }
+        // MELOSYS-8092: Journalføringen skal gjenspeile det brukeren faktisk sendte inn — styrt av
+        // skjemadel. `kobletSkjema` brukes kun til samme-sak-vurdering (på /data), ikke til å bygge
+        // PDF-en. En ekte komplett søknad (ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) har begge deler i sitt
+        // eget data-objekt og rendres komplett uten kobling.
 
         val definisjon = skjemaDefinisjonService.hent(
             type = skjema.type,
@@ -166,10 +167,9 @@ class M2MSkjemaService(
             fullmektigInfo = fullmektigInfo,
             radgiverInfo = radgiverInfo,
             skjemaData = skjema.data as UtsendtArbeidstakerSkjemaData,
-            kobletSkjemaData = kobletSkjema?.data as? UtsendtArbeidstakerSkjemaData,
+            kobletSkjemaData = null,
             vedlegg = vedleggService.listBySkjemaId(skjema.id!!),
-            kobletVedlegg = kobletSkjema?.id?.let { vedleggService.listBySkjemaId(it) }
-                ?: emptyList(),
+            kobletVedlegg = emptyList(),
             definisjon = definisjon
         )
     }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
@@ -12,6 +12,7 @@ import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.arbeidsstedIUtlandetDtoMedDefaultVerdier
 import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.entity.Skjema
+import no.nav.melosys.skjema.extensions.utsendtArbeidstakerMetadataOrThrow
 import no.nav.melosys.skjema.getToken
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
 import no.nav.melosys.skjema.integrasjon.pdl.PdlConsumer
@@ -134,7 +135,8 @@ class UtsendtArbeidstakerKoblingPdfReproIntegrationTest : ApiTestBase() {
         sendInn(arbeidsgiverDel.id!!, innbyggerToken)
 
         // Nå er v1 og arbeidsgiverDel koblet sammen (komplett søknad).
-        skjemaRepository.findById(arbeidsgiverDel.id!!).get().utsendtKobletSkjemaId() shouldBe arbeidstakerV1.id
+        skjemaRepository.findById(arbeidsgiverDel.id!!).get()
+            .utsendtArbeidstakerMetadataOrThrow().kobletSkjemaId shouldBe arbeidstakerV1.id
 
         // --- 3) Innbygger (DEG_SELV) sender inn NY ARBEIDSTAKERS_DEL (v2) som erstatter v1 ---
         // Innbyggeren fyller KUN ut sin egen del på nytt; ingen ny arbeidsgivers del sendes.
@@ -253,7 +255,3 @@ class UtsendtArbeidstakerKoblingPdfReproIntegrationTest : ApiTestBase() {
         return Loader.loadPDF(pdfBytes).use { PDFTextStripper().getText(it) }
     }
 }
-
-/** Leser ut `kobletSkjemaId` fra et UTSENDT_ARBEIDSTAKER-skjema sin metadata i testen. */
-private fun Skjema.utsendtKobletSkjemaId(): UUID? =
-    (metadata as no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata).kobletSkjemaId

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
@@ -1,0 +1,259 @@
+package no.nav.melosys.skjema.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import java.util.UUID
+import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.arbeidsstedIUtlandetDtoMedDefaultVerdier
+import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.entity.Skjema
+import no.nav.melosys.skjema.getToken
+import no.nav.melosys.skjema.integrasjon.ereg.EregService
+import no.nav.melosys.skjema.integrasjon.pdl.PdlConsumer
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlFoedselsdato
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlNavn
+import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
+import no.nav.melosys.skjema.integrasjon.repr.ReprService
+import no.nav.melosys.skjema.korrektSyntetiskFnr
+import no.nav.melosys.skjema.korrektSyntetiskOrgnr
+import no.nav.melosys.skjema.m2mTokenWithReadSkjemaDataAccess
+import no.nav.melosys.skjema.repository.InnsendingRepository
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.service.AltinnService
+import no.nav.melosys.skjema.service.NotificationService
+import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.tilleggsopplysningerDtoMedDefaultVerdier
+import no.nav.melosys.skjema.types.SkjemaData
+import no.nav.melosys.skjema.types.SkjemaInnsendtKvittering
+import no.nav.melosys.skjema.types.SkjemaType
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.m2m.UtsendtArbeidstakerSkjemaM2MDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
+import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.text.PDFTextStripper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * MEL-16515 / MEL-8135 — reproduserer at et nytt ARBEIDSTAKERS_DEL-skjema som erstatter et eldre
+ * skjema arver `kobletSkjemaId` til en allerede innsendt arbeidsgivers del, slik at M2M-PDF-en
+ * (journalføringen) feilaktig inneholder BEGGE deler — selv om innbyggeren bare sendte inn sin
+ * egen arbeidstakers del.
+ *
+ * Testen er en ekte black-box e2e mot skjema-api:
+ *  - henter ekte tokens fra MockOAuth2Server (TokenX for innbygger, Azure for M2M)
+ *  - sender inn skjemaene via det virkelige `POST /{id}/send-inn`-endepunktet (kjører validering
+ *    + [no.nav.melosys.skjema.service.UtsendtArbeidstakerSkjemaKoblingService.finnOgKobl])
+ *  - henter ut PDF-en via det virkelige `GET /m2m/api/skjema/{id}/pdf`-endepunktet
+ *
+ * Kun integrasjoner uten verdi for selve bugen er mocket (Altinn/Ereg/Repr/Notification/PDL),
+ * på samme måte som de øvrige controller-integrasjonstestene.
+ */
+class UtsendtArbeidstakerKoblingPdfReproIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var mockOAuth2Server: MockOAuth2Server
+
+    @Autowired
+    private lateinit var skjemaRepository: SkjemaRepository
+
+    @Autowired
+    private lateinit var innsendingRepository: InnsendingRepository
+
+    @MockkBean
+    private lateinit var notificationService: NotificationService
+
+    @MockkBean
+    private lateinit var altinnService: AltinnService
+
+    @MockkBean
+    private lateinit var eregService: EregService
+
+    @MockkBean
+    private lateinit var reprService: ReprService
+
+    @MockkBean
+    private lateinit var pdlConsumer: PdlConsumer
+
+    @BeforeEach
+    fun setUp() {
+        innsendingRepository.deleteAll()
+        skjemaRepository.deleteAll()
+
+        every { altinnService.harBrukerTilgang(any()) } returns true
+        every { reprService.harSkriverettigheterForMedlemskap(any()) } returns true
+        every { eregService.organisasjonsnummerEksisterer(any()) } returns true
+        every { notificationService.sendNotificationToArbeidsgiver(any(), any(), any(), any()) } returns "beskjed-id"
+        every { pdlConsumer.hentPerson(any()) } returns PdlPerson(
+            navn = listOf(PdlNavn("Våken", null, "Elefant")),
+            foedselsdato = listOf(PdlFoedselsdato("1980-01-01"))
+        )
+    }
+
+    @Test
+    @DisplayName("Arvet kobling påvirker ikke journalføring: PDF for ren arbeidstakers-del inneholder kun arbeidstakers del")
+    fun `journalfoering styres av skjemadel ikke av kobletSkjema`() {
+        // Innbygger-token (TokenX) for arbeidstakeren — samme person eier alle utkastene (opprettetAv).
+        val innbyggerToken = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        // --- 1) Innbygger (DEG_SELV) sender inn ARBEIDSTAKERS_DEL (v1) ---
+        val arbeidstakerV1 = seedUtkast(
+            representasjonstype = Representasjonstype.DEG_SELV,
+            skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+            data = arbeidstakersSkjemaDataDtoMedDefaultVerdier()
+        )
+        sendInn(arbeidstakerV1.id!!, innbyggerToken)
+
+        // --- 2) Arbeidsgiver (ARBEIDSGIVER) sender inn ARBEIDSGIVERS_DEL ---
+        // Overlappende periode + samme juridiske enhet => motpart-kobling mot v1.
+        val arbeidsgiverDel = seedUtkast(
+            representasjonstype = Representasjonstype.ARBEIDSGIVER,
+            skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+            data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier().copy(
+                utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier(),
+                arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier(),
+                tilleggsopplysninger = tilleggsopplysningerDtoMedDefaultVerdier()
+            )
+        )
+        sendInn(arbeidsgiverDel.id!!, innbyggerToken)
+
+        // Nå er v1 og arbeidsgiverDel koblet sammen (komplett søknad).
+        skjemaRepository.findById(arbeidsgiverDel.id!!).get().utsendtKobletSkjemaId() shouldBe arbeidstakerV1.id
+
+        // --- 3) Innbygger (DEG_SELV) sender inn NY ARBEIDSTAKERS_DEL (v2) som erstatter v1 ---
+        // Innbyggeren fyller KUN ut sin egen del på nytt; ingen ny arbeidsgivers del sendes.
+        val arbeidstakerV2 = seedUtkast(
+            representasjonstype = Representasjonstype.DEG_SELV,
+            skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+            data = arbeidstakersSkjemaDataDtoMedDefaultVerdier()
+        )
+        sendInn(arbeidstakerV2.id!!, innbyggerToken)
+
+        // --- 4) M2M: hent skjemadata for v2 (det melosys-api konsumerer) ---
+        val m2mToken = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
+        val v2Data = hentM2MData(arbeidstakerV2.id!!, m2mToken)
+
+        // v2 er en ren ARBEIDSTAKERS_DEL og har arvet kobling til arbeidsgivers del.
+        // kobletSkjema eksponeres fortsatt på /data — melosys-api bruker det til samme-sak-vurdering.
+        v2Data.skjema.metadata.skjemadel shouldBe Skjemadel.ARBEIDSTAKERS_DEL
+        val koblet = v2Data.kobletSkjema.shouldNotBeNull()
+        koblet.id shouldBe arbeidsgiverDel.id
+        koblet.metadata.skjemadel shouldBe Skjemadel.ARBEIDSGIVERS_DEL
+
+        // --- 5) M2M: hent PDF for v2. Journalføringen skal gjenspeile skjemadel (ARBEIDSTAKERS_DEL),
+        //         IKKE den arvede koblingen. Derfor: kun arbeidstakers del i PDF-en. ---
+        val pdfTekst = hentM2MPdfTekst(arbeidstakerV2.id!!, m2mToken)
+
+        pdfTekst shouldContain "Arbeidstakers del"
+        pdfTekst shouldNotContain "Arbeidsgivers del"
+    }
+
+    @Test
+    @DisplayName("Arbeidsgivers del sendt først, så arbeidstakers del: arbeidstakers PDF inneholder kun arbeidstakers del")
+    fun `motpart-kobling - arbeidsgiver foerst - paavirker ikke journalfoering`() {
+        val innbyggerToken = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        // 1) Arbeidsgiver sender ARBEIDSGIVERS_DEL først — ingen motpart ennå, ingen kobling.
+        val arbeidsgiverDel = seedUtkast(
+            representasjonstype = Representasjonstype.ARBEIDSGIVER,
+            skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+            data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier().copy(
+                utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier(),
+                arbeidsstedIUtlandet = arbeidsstedIUtlandetDtoMedDefaultVerdier(),
+                tilleggsopplysninger = tilleggsopplysningerDtoMedDefaultVerdier()
+            )
+        )
+        sendInn(arbeidsgiverDel.id!!, innbyggerToken)
+
+        // 2) Arbeidstaker sender ARBEIDSTAKERS_DEL etterpå → motpart-kobles til arbeidsgivers del.
+        val arbeidstakerDel = seedUtkast(
+            representasjonstype = Representasjonstype.DEG_SELV,
+            skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+            data = arbeidstakersSkjemaDataDtoMedDefaultVerdier()
+        )
+        sendInn(arbeidstakerDel.id!!, innbyggerToken)
+
+        val m2mToken = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
+
+        // Arbeidstakers del er nå koblet til arbeidsgivers del (vanlig motpart-kobling, ingen ny versjon).
+        val atData = hentM2MData(arbeidstakerDel.id!!, m2mToken)
+        atData.skjema.metadata.skjemadel shouldBe Skjemadel.ARBEIDSTAKERS_DEL
+        atData.kobletSkjema.shouldNotBeNull().id shouldBe arbeidsgiverDel.id
+
+        // Journalføringen skal kun gjenspeile arbeidstakers del — ikke den koblede arbeidsgiver-delen.
+        // (Før fiks: PDF-en inneholder også "Arbeidsgivers del" → testen feiler.)
+        val pdfTekst = hentM2MPdfTekst(arbeidstakerDel.id!!, m2mToken)
+        pdfTekst shouldContain "Arbeidstakers del"
+        pdfTekst shouldNotContain "Arbeidsgivers del"
+    }
+
+    private fun seedUtkast(
+        representasjonstype: Representasjonstype,
+        skjemadel: Skjemadel,
+        data: SkjemaData
+    ): Skjema = skjemaRepository.save(
+        skjemaMedDefaultVerdier(
+            fnr = korrektSyntetiskFnr,
+            orgnr = korrektSyntetiskOrgnr,
+            status = SkjemaStatus.UTKAST,
+            type = SkjemaType.UTSENDT_ARBEIDSTAKER,
+            data = data,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = representasjonstype,
+                skjemadel = skjemadel
+            )
+        )
+    )
+
+    private fun sendInn(skjemaId: UUID, token: String): SkjemaInnsendtKvittering =
+        webTestClient.post()
+            .uri("/api/skjema/utsendt-arbeidstaker/$skjemaId/send-inn")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(SkjemaInnsendtKvittering::class.java)
+            .returnResult().responseBody!!
+            .also { it.status shouldBe SkjemaStatus.SENDT }
+
+    private fun hentM2MData(skjemaId: UUID, token: String): UtsendtArbeidstakerSkjemaM2MDto =
+        webTestClient.get()
+            .uri("/m2m/api/skjema/utsendt-arbeidstaker/$skjemaId/data")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(UtsendtArbeidstakerSkjemaM2MDto::class.java)
+            .returnResult().responseBody!!
+
+    private fun hentM2MPdfTekst(skjemaId: UUID, token: String): String {
+        val pdfBytes = webTestClient.get()
+            .uri("/m2m/api/skjema/$skjemaId/pdf")
+            .header("Authorization", "Bearer $token")
+            .accept(MediaType.APPLICATION_PDF)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(ByteArray::class.java)
+            .returnResult().responseBody!!
+
+        return Loader.loadPDF(pdfBytes).use { PDFTextStripper().getText(it) }
+    }
+}
+
+/** Leser ut `kobletSkjemaId` fra et UTSENDT_ARBEIDSTAKER-skjema sin metadata i testen. */
+private fun Skjema.utsendtKobletSkjemaId(): UUID? =
+    (metadata as no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata).kobletSkjemaId

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
@@ -48,7 +48,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 
 /**
- * MEL-16515 / MEL-8135 — reproduserer at et nytt ARBEIDSTAKERS_DEL-skjema som erstatter et eldre
+ * Reproduserer at et nytt ARBEIDSTAKERS_DEL-skjema som erstatter et eldre
  * skjema arver `kobletSkjemaId` til en allerede innsendt arbeidsgivers del, slik at M2M-PDF-en
  * (journalføringen) feilaktig inneholder BEGGE deler — selv om innbyggeren bare sendte inn sin
  * egen arbeidstakers del.

--- a/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/pdf/PdfGeneratorTest.kt
@@ -28,6 +28,7 @@ import no.nav.melosys.skjema.skatteforholdOgInntektDtoMedDefaultVerdier
 import no.nav.melosys.skjema.tilleggsopplysningerDtoMedDefaultVerdier
 import no.nav.melosys.skjema.types.SkjemaType
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidstakerensLonnDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedType
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.FastEllerVekslendeArbeidssted
@@ -60,6 +61,26 @@ class PdfGeneratorTest : FunSpec({
     val properties = SkjemaDefinisjonProperties()
     val skjemaDefinisjonService = SkjemaDefinisjonService(properties, jsonMapper)
 
+    fun kombinert(
+        at: UtsendtArbeidstakerArbeidstakersSkjemaDataDto,
+        ag: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
+    ): UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto =
+        UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto(
+            arbeidsgiversData = UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto.ArbeidsgiversData(
+                arbeidsgiverensVirksomhetINorge = ag.arbeidsgiverensVirksomhetINorge,
+                utenlandsoppdraget = ag.utenlandsoppdraget,
+                arbeidstakerensLonn = ag.arbeidstakerensLonn,
+                arbeidsstedIUtlandet = ag.arbeidsstedIUtlandet
+            ),
+            arbeidstakersData = UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto.ArbeidstakersData(
+                arbeidssituasjon = at.arbeidssituasjon,
+                skatteforholdOgInntekt = at.skatteforholdOgInntekt,
+                familiemedlemmer = at.familiemedlemmer
+            ),
+            utsendingsperiodeOgLand = at.utsendingsperiodeOgLand ?: ag.utsendingsperiodeOgLand,
+            tilleggsopplysninger = at.tilleggsopplysninger ?: ag.tilleggsopplysninger,
+            vedlegg = at.vedlegg ?: ag.vedlegg
+        )
 
     fun lagSkjemaPdfData(
         referanseId: String,
@@ -76,9 +97,12 @@ class PdfGeneratorTest : FunSpec({
         radgiverInfo: RadgiverInfo? = null
     ): SkjemaPdfData {
         val definisjon = skjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, null, språk)
-        val skjemaData: UtsendtArbeidstakerSkjemaData = arbeidstakerData ?: arbeidsgiverData
-            ?: throw IllegalArgumentException("Minst en av arbeidstakerData eller arbeidsgiverData må oppgis")
-        val kobletSkjemaData: UtsendtArbeidstakerSkjemaData? = if (arbeidstakerData != null && arbeidsgiverData != null) arbeidsgiverData else null
+        val skjemaData: UtsendtArbeidstakerSkjemaData = when {
+            arbeidstakerData != null && arbeidsgiverData != null -> kombinert(arbeidstakerData, arbeidsgiverData)
+            arbeidstakerData != null -> arbeidstakerData
+            arbeidsgiverData != null -> arbeidsgiverData
+            else -> throw IllegalArgumentException("Minst en av arbeidstakerData eller arbeidsgiverData må oppgis")
+        }
         return SkjemaPdfData(
             skjemaId = UUID.randomUUID(),
             referanseId = referanseId,
@@ -88,7 +112,6 @@ class PdfGeneratorTest : FunSpec({
             fullmektigInfo = fullmektigInfo,
             radgiverInfo = radgiverInfo,
             skjemaData = skjemaData,
-            kobletSkjemaData = kobletSkjemaData,
             vedlegg = emptyList(),
             definisjon = definisjon
         )
@@ -991,7 +1014,6 @@ class PdfGeneratorTest : FunSpec({
                     arbeidstakerFnr = "12345678901"
                 ),
                 skjemaData = data,
-                kobletSkjemaData = null,
                 vedlegg = emptyList(),
                 definisjon = definisjon
             )


### PR DESCRIPTION
Journalføringen (PDF) for utsendt arbeidstaker bygges nå **kun på det brukeren faktisk sendte inn** (`skjema.data`), styrt av `metadata.skjemadel` — ikke av om det finnes et `kobletSkjema`.

Tidligere ble den koblede motpart-delen dratt inn i PDF-en, slik at en innsending av **kun én del** ble journalført som en komplett søknad (MEL-16515). Dette traff både ved vanlig motpart-kobling (den delen som sendes sist) og ved at en ny versjon arvet en utdatert kobling. Var opprinnelig intensjonelt design fra MELOSYS-7771/7850.
