### PR TITLE
Koble melosys-skjema-api til melosys-console med admin-endepunkter

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -73,6 +73,9 @@ spec:
         - application: melosys
           namespace: teammelosys
           cluster: dev-fss
+        - application: melosys-console-q2
+          namespace: teammelosys
+          cluster: dev-gcp
     outbound:
       external:
         - host: pdl-api.dev-fss-pub.nais.io
@@ -93,6 +96,10 @@ spec:
           namespace: nais-system
         - application: logging
           namespace: nais-system
+  env:
+    # azp_name til melosys-console (q2) som har tilgang til /admin/**-endepunktene
+    - name: MELOSYS_CONSOLE_AZP_NAMES
+      value: dev-gcp:teammelosys:melosys-console-q2
   envFrom:
     - secret: melosys-skjema-api
   kafka:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -70,6 +70,9 @@ spec:
         - application: melosys
           namespace: teammelosys
           cluster: prod-fss
+        - application: melosys-console
+          namespace: teammelosys
+          cluster: prod-gcp
     outbound:
       external:
         - host: pdl-api.prod-fss-pub.nais.io
@@ -90,6 +93,10 @@ spec:
           namespace: nais-system
         - application: logging
           namespace: nais-system
+  env:
+    # azp_name til melosys-console som har tilgang til /admin/**-endepunktene
+    - name: MELOSYS_CONSOLE_AZP_NAMES
+      value: prod-gcp:teammelosys:melosys-console
   envFrom:
     - secret: melosys-skjema-api
   kafka:

--- a/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
@@ -13,18 +13,29 @@ data class M2mConfigProperties(
     @field:Valid
     val readSkjemadata: ClientConfig = ClientConfig(),
     @field:Valid
-    val admin: ClientConfig = ClientConfig()
+    val admin: AdminConfig = AdminConfig()
 ) {
     data class ClientConfig(
         @field:NotEmpty(message = "m2m-klientliste må være konfigurert")
         val clients: List<@NotBlank String> = emptyList()
     )
 
+    /**
+     * Tilgangsstyring for admin-endepunktene: både azp_name-allowlist ([clients]) og en delt
+     * API-nøkkel ([apikey]) må stemme (i tillegg til gyldig Azure AD-token).
+     */
+    data class AdminConfig(
+        @field:NotEmpty(message = "m2m.admin.clients må være konfigurert")
+        val clients: List<@NotBlank String> = emptyList(),
+        @field:NotBlank(message = "m2m.admin.apikey må være konfigurert")
+        val apikey: String = ""
+    )
+
     @PostConstruct
     fun validateNoUnresolvedPlaceholders() {
-        (readSkjemadata.clients + admin.clients).forEach { client ->
-            require(!client.contains("\${")) {
-                "Uoppløst placeholder i m2m-klientliste: '$client'. Sjekk at miljøvariabelen er satt."
+        (readSkjemadata.clients + admin.clients + admin.apikey).forEach { verdi ->
+            require(!verdi.contains("\${")) {
+                "Uoppløst placeholder i m2m-konfigurasjon: '$verdi'. Sjekk at miljøvariabelen er satt."
             }
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
@@ -11,18 +11,20 @@ import org.springframework.validation.annotation.Validated
 @ConfigurationProperties(prefix = "m2m")
 data class M2mConfigProperties(
     @field:Valid
-    val readSkjemadata: ClientConfig = ClientConfig()
+    val readSkjemadata: ClientConfig = ClientConfig(),
+    @field:Valid
+    val admin: ClientConfig = ClientConfig()
 ) {
     data class ClientConfig(
-        @field:NotEmpty(message = "m2m.read-skjemadata.clients må være konfigurert")
+        @field:NotEmpty(message = "m2m-klientliste må være konfigurert")
         val clients: List<@NotBlank String> = emptyList()
     )
 
     @PostConstruct
     fun validateNoUnresolvedPlaceholders() {
-        readSkjemadata.clients.forEach { client ->
+        (readSkjemadata.clients + admin.clients).forEach { client ->
             require(!client.contains("\${")) {
-                "Uoppløst placeholder i m2m.read-skjemadata.clients: '$client'. Sjekk at miljøvariabelen er satt."
+                "Uoppløst placeholder i m2m-klientliste: '$client'. Sjekk at miljøvariabelen er satt."
             }
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -17,6 +18,20 @@ class SwaggerConfig {
     init {
         ModelResolver.enumsAsRef = true
     }
+
+    /**
+     * Egen OpenAPI-gruppe for admin-endepunktene under /admin.
+     *
+     * Eksponeres på /v3/api-docs/admin og brukes av melosys-console til å
+     * generere et generisk admin-grensesnitt. Den fulle spec'en på
+     * /v3/api-docs er uendret og brukes fortsatt til frontend-typegenerering.
+     */
+    @Bean
+    fun adminApi(): GroupedOpenApi = GroupedOpenApi.builder()
+        .group("admin")
+        .displayName("Melosys Skjema Admin API")
+        .pathsToMatch("/admin/**")
+        .build()
 
     @Bean
     fun customOpenAPI(): OpenAPI = OpenAPI()

--- a/src/main/kotlin/no/nav/melosys/skjema/config/WebConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/WebConfig.kt
@@ -1,20 +1,23 @@
 package no.nav.melosys.skjema.config
 
 import no.nav.melosys.skjema.config.observability.CorrelationIdInterceptor
+import no.nav.melosys.skjema.sikkerhet.AdminApiKeyInterceptor
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 /**
  * Konfigurasjon for Spring Web MVC.
- * Registrerer interceptors for bl.a. MDC-håndtering.
+ * Registrerer interceptors for bl.a. MDC-håndtering og API-nøkkel på admin-endepunktene.
  */
 @Configuration
 class WebConfig(
-    private val correlationIdInterceptor: CorrelationIdInterceptor
+    private val correlationIdInterceptor: CorrelationIdInterceptor,
+    private val adminApiKeyInterceptor: AdminApiKeyInterceptor
 ) : WebMvcConfigurer {
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(correlationIdInterceptor)
+        registry.addInterceptor(adminApiKeyInterceptor).addPathPatterns("/admin/**")
     }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -37,6 +37,18 @@ class AdminController(
         return adminService.hentStatistikk()
     }
 
+    @GetMapping("/statistikk/bruk")
+    @Operation(
+        summary = "Hent bruksstatistikk for skjemaene",
+        description = "Antall utkast med aldersfordeling, innsendte fordelt på skjemadel/flyt/språk, " +
+            "antall komplette og koblede saker, samt unike personer og virksomheter."
+    )
+    @ApiResponse(responseCode = "200", description = "Bruksstatistikk hentet")
+    fun hentBruksstatistikk(): BrukStatistikkDto {
+        log.info { "Admin: Henter bruksstatistikk" }
+        return adminService.hentBruksstatistikk()
+    }
+
     @GetMapping("/innsendinger/feilede")
     @Operation(summary = "List innsendinger som har feilet Kafka-sending (KAFKA_FEILET)")
     @ApiResponse(responseCode = "200", description = "Feilede innsendinger hentet")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -1,0 +1,80 @@
+package no.nav.melosys.skjema.controller.admin
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.util.UUID
+import no.nav.melosys.skjema.service.AdminService
+import no.nav.melosys.skjema.sikkerhet.AdminBeskyttet
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Administrative endepunkter for drift og feilsøking, eksponert mot melosys-console.
+ *
+ * Alle endepunkter er beskyttet av [AdminBeskyttet] (Azure AD-token + azp_name-allowlist),
+ * og dukker opp som egen OpenAPI-gruppe på `/v3/api-docs/admin`.
+ */
+@RestController
+@RequestMapping("/admin")
+@AdminBeskyttet
+@Tag(name = "Admin", description = "Administrative endepunkter for drift og feilsøking (melosys-console)")
+class AdminController(
+    private val adminService: AdminService
+) {
+
+    @GetMapping("/statistikk")
+    @Operation(summary = "Hent aggregert statistikk for skjema og innsendinger")
+    @ApiResponse(responseCode = "200", description = "Statistikk hentet")
+    fun hentStatistikk(): AdminStatistikkDto {
+        log.info { "Admin: Henter statistikk" }
+        return adminService.hentStatistikk()
+    }
+
+    @GetMapping("/innsendinger/feilede")
+    @Operation(summary = "List innsendinger som har feilet Kafka-sending (KAFKA_FEILET)")
+    @ApiResponse(responseCode = "200", description = "Feilede innsendinger hentet")
+    fun hentFeiledeInnsendinger(): List<InnsendingAdminDto> {
+        log.info { "Admin: Henter feilede innsendinger" }
+        return adminService.hentFeiledeInnsendinger()
+    }
+
+    @GetMapping("/innsendinger/feilede/antall")
+    @Operation(summary = "Antall innsendinger med status KAFKA_FEILET")
+    @ApiResponse(responseCode = "200", description = "Antall hentet")
+    fun hentAntallFeiledeInnsendinger(): AntallDto {
+        return AntallDto(adminService.antallFeiledeInnsendinger())
+    }
+
+    @GetMapping("/innsendinger/{innsendingId}")
+    @Operation(summary = "Hent detaljer for en enkelt innsending")
+    @ApiResponse(responseCode = "200", description = "Innsending hentet")
+    @ApiResponse(responseCode = "404", description = "Innsending ikke funnet")
+    fun hentInnsending(@PathVariable innsendingId: UUID): InnsendingAdminDto {
+        log.info { "Admin: Henter innsending $innsendingId" }
+        return adminService.hentInnsending(innsendingId)
+    }
+
+    @PostMapping("/innsendinger/{innsendingId}/retry")
+    @Operation(summary = "Tving ny prosessering (Kafka-sending) av en enkelt innsending")
+    @ApiResponse(responseCode = "200", description = "Reprosessering utført")
+    @ApiResponse(responseCode = "404", description = "Innsending ikke funnet")
+    fun retryInnsending(@PathVariable innsendingId: UUID): InnsendingAdminDto {
+        log.info { "Admin: Retry av innsending $innsendingId" }
+        return adminService.retryInnsending(innsendingId)
+    }
+
+    @PostMapping("/innsendinger/retry-feilede")
+    @Operation(summary = "Tving ny prosessering av alle innsendinger med status KAFKA_FEILET")
+    @ApiResponse(responseCode = "200", description = "Reprosessering utført")
+    fun retryAlleFeilede(): RetryResultatDto {
+        log.info { "Admin: Retry av alle feilede innsendinger" }
+        return adminService.retryAlleFeilede()
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -1,0 +1,42 @@
+package no.nav.melosys.skjema.controller.admin
+
+import java.time.Instant
+import java.util.UUID
+import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+
+/**
+ * Administrativ visning av en innsending. Inneholder bevisst ingen personopplysninger
+ * (fødselsnummer/navn) – kun orgnr og prosesseringsmetadata.
+ */
+data class InnsendingAdminDto(
+    val innsendingId: UUID,
+    val skjemaId: UUID,
+    val referanseId: String,
+    val status: InnsendingStatus,
+    val skjemaStatus: SkjemaStatus,
+    val orgnr: String,
+    val antallForsok: Int,
+    val feilmelding: String?,
+    val sisteForsoekTidspunkt: Instant?,
+    val opprettetDato: Instant,
+    val saksnummer: String?
+)
+
+/**
+ * Aggregert statistikk for skjema og innsendinger – nyttig som operasjonelt dashbord.
+ */
+data class AdminStatistikkDto(
+    val skjemaPerStatus: Map<SkjemaStatus, Long>,
+    val innsendingPerStatus: Map<InnsendingStatus, Long>,
+    val antallFeiledeInnsendinger: Long
+)
+
+data class AntallDto(
+    val antall: Long
+)
+
+data class RetryResultatDto(
+    val antallForsoekt: Int,
+    val antallFeilet: Int
+)

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -4,6 +4,9 @@ import java.time.Instant
 import java.util.UUID
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.common.Språk
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 
 /**
  * Administrativ visning av en innsending. Inneholder bevisst ingen personopplysninger
@@ -39,4 +42,49 @@ data class AntallDto(
 data class RetryResultatDto(
     val antallForsoekt: Int,
     val antallFeilet: Int
+)
+
+/**
+ * Bruksstatistikk for skjemaene – ment for overvåking av bruk via melosys-console.
+ * Inneholder kun aggregerte tall, ingen personopplysninger.
+ */
+data class BrukStatistikkDto(
+    /** Tidspunkt statistikken ble beregnet (aldersgrenser regnes fra dette). */
+    val tidspunkt: Instant,
+    val utkast: UtkastStatistikkDto,
+    /** Totalt antall innsendte skjema (status SENDT). */
+    val totaltInnsendt: Long,
+    val innsendtSisteDoegn: Long,
+    val innsendtSiste7Dager: Long,
+    val innsendtSiste30Dager: Long,
+    /** Innsendte fordelt på skjemadel (arbeidsgivers del, arbeidstakers del, komplett). */
+    val innsendtPerSkjemadel: Map<Skjemadel, Long>,
+    /** Innsendte fordelt på flyt/representasjonstype (deg selv, arbeidsgiver, rådgiver, ...). */
+    val innsendtPerFlyt: Map<Representasjonstype, Long>,
+    /** Innsendte fordelt på valgt språk ved innsending. */
+    val innsendtPerSprak: Map<Språk, Long>,
+    /** Antall innsendte komplette skjema (begge deler i én innsending). */
+    val antallKomplettInnsendt: Long,
+    /** Antall koblede par der arbeidsgivers del og arbeidstakers del er sendt hver for seg. */
+    val antallKobledePar: Long,
+    /** Saker der begge deler er dekket = komplette + koblede par. */
+    val antallSakerMedBeggeDeler: Long,
+    /** Unike personer (fnr) blant innsendte skjema. */
+    val antallUnikePersoner: Long,
+    /** Unike virksomheter (orgnr) blant innsendte skjema. */
+    val antallUnikeVirksomheter: Long
+)
+
+/**
+ * Antall utkast med aldersfordeling. Bøttene er gjensidig utelukkende og summerer til [antall].
+ * Alder regnes fra opprettelsestidspunkt.
+ */
+data class UtkastStatistikkDto(
+    val antall: Long,
+    val under1Dag: Long,
+    val mellom1Og7Dager: Long,
+    val mellom7Og30Dager: Long,
+    val over30Dager: Long,
+    /** Opprettelsestidspunkt for det eldste utkastet, eller null hvis ingen utkast finnes. */
+    val eldsteOpprettetDato: Instant?
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
@@ -1,0 +1,117 @@
+package no.nav.melosys.skjema.repository
+
+import java.time.Instant
+import java.util.UUID
+import no.nav.melosys.skjema.entity.Skjema
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.stereotype.Repository as RepositoryAnnotation
+
+/** Projeksjon for «antall per kategori»-aggregeringer (GROUP BY). */
+interface AntallPerKategori {
+    val kategori: String?
+    val antall: Long
+}
+
+/**
+ * Aldersfordeling for utkast, beregnet i én spørring (ett snapshot) slik at bøttene alltid
+ * er ikke-negative og summerer til [totalt]. Bøttene er gjensidig utelukkende.
+ */
+interface UtkastAldersfordeling {
+    val totalt: Long
+    val under1Dag: Long
+    val mellom1Og7Dager: Long
+    val mellom7Og30Dager: Long
+    val over30Dager: Long
+}
+
+/**
+ * Aggregeringsspørringer for bruksstatistikk på skjema/innsendinger.
+ *
+ * Skjemadel/flyt/språk hentes via native JSONB-/kolonneaggregering (samme mønster som
+ * [UtsendtArbeidstakerSkjemaRepository]). Utkast-tellinger og unike tellinger gjøres med JPQL.
+ */
+@RepositoryAnnotation
+interface AdminStatistikkRepository : Repository<Skjema, UUID> {
+
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT metadata->>'skjemadel' AS kategori, COUNT(*) AS antall
+        FROM skjema
+        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
+        GROUP BY metadata->>'skjemadel'
+    """
+    )
+    fun antallInnsendtPerSkjemadel(): List<AntallPerKategori>
+
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT metadata->>'representasjonstype' AS kategori, COUNT(*) AS antall
+        FROM skjema
+        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
+        GROUP BY metadata->>'representasjonstype'
+    """
+    )
+    fun antallInnsendtPerFlyt(): List<AntallPerKategori>
+
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT innsendt_sprak AS kategori, COUNT(*) AS antall
+        FROM innsending
+        GROUP BY innsendt_sprak
+    """
+    )
+    fun antallInnsendtPerSprak(): List<AntallPerKategori>
+
+    /**
+     * Antall innsendte skjema som er koblet til en motpart (begge deler sendt hver for seg).
+     * Hvert koblet par teller 2 (begge sider peker på hverandre), så del på 2 for antall par.
+     */
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT COUNT(*)
+        FROM skjema
+        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
+        AND metadata->>'kobletSkjemaId' IS NOT NULL
+    """
+    )
+    fun antallKobledeSkjema(): Long
+
+    @Query(
+        nativeQuery = true,
+        value = """
+        SELECT
+          COUNT(*) AS "totalt",
+          COUNT(*) FILTER (WHERE opprettet_dato >= :grense1d) AS "under1Dag",
+          COUNT(*) FILTER (WHERE opprettet_dato < :grense1d AND opprettet_dato >= :grense7d) AS "mellom1Og7Dager",
+          COUNT(*) FILTER (WHERE opprettet_dato < :grense7d AND opprettet_dato >= :grense30d) AS "mellom7Og30Dager",
+          COUNT(*) FILTER (WHERE opprettet_dato < :grense30d) AS "over30Dager"
+        FROM skjema
+        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'UTKAST'
+    """
+    )
+    fun utkastAldersfordeling(grense1d: Instant, grense7d: Instant, grense30d: Instant): UtkastAldersfordeling
+
+    @Query("SELECT MIN(s.opprettetDato) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.UTKAST")
+    fun eldsteUtkastOpprettetDato(): Instant?
+
+    @Query("SELECT COUNT(s) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
+    fun antallInnsendteSkjema(): Long
+
+    @Query("SELECT COUNT(DISTINCT s.fnr) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
+    fun antallUnikePersoner(): Long
+
+    @Query("SELECT COUNT(DISTINCT s.orgnr) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
+    fun antallUnikeVirksomheter(): Long
+
+    /** Antall innsendinger registrert etter et gitt tidspunkt (innsendingstrend). */
+    @Query(
+        nativeQuery = true,
+        value = "SELECT COUNT(*) FROM innsending WHERE opprettet_dato >= :grense"
+    )
+    fun antallInnsendtEtter(grense: Instant): Long
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
@@ -25,6 +25,13 @@ interface UtkastAldersfordeling {
     val over30Dager: Long
 }
 
+/** Innsendingstrend (kumulative vinduer) beregnet i ett snapshot. */
+interface InnsendtTrend {
+    val sisteDoegn: Long
+    val siste7Dager: Long
+    val siste30Dager: Long
+}
+
 /**
  * Aggregeringsspørringer for bruksstatistikk på skjema/innsendinger.
  *
@@ -108,10 +115,16 @@ interface AdminStatistikkRepository : Repository<Skjema, UUID> {
     @Query("SELECT COUNT(DISTINCT s.orgnr) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
     fun antallUnikeVirksomheter(): Long
 
-    /** Antall innsendinger registrert etter et gitt tidspunkt (innsendingstrend). */
+    /** Innsendingstrend: kumulativt antall innsendinger i siste døgn / 7 / 30 dager (ett snapshot). */
     @Query(
         nativeQuery = true,
-        value = "SELECT COUNT(*) FROM innsending WHERE opprettet_dato >= :grense"
+        value = """
+        SELECT
+          COUNT(*) FILTER (WHERE opprettet_dato >= :grense1d) AS "sisteDoegn",
+          COUNT(*) FILTER (WHERE opprettet_dato >= :grense7d) AS "siste7Dager",
+          COUNT(*) FILTER (WHERE opprettet_dato >= :grense30d) AS "siste30Dager"
+        FROM innsending
+    """
     )
-    fun antallInnsendtEtter(grense: Instant): Long
+    fun innsendtTrend(grense1d: Instant, grense7d: Instant, grense30d: Instant): InnsendtTrend
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.skjema.repository
 
 import java.time.Instant
 import java.util.UUID
+import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.entity.Skjema
 import org.springframework.data.jpa.repository.JpaRepository
@@ -37,4 +38,14 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
     fun findRetryKandidater(@Param("sisteForsoekTidspunktGrense") sisteForsoekTidspunktGrense: Instant, @Param("maxAttempts") maxAttempts: Int): List<Innsending>
 
     fun existsByReferanseId(referanseId: String): Boolean
+
+    /**
+     * Henter innsendinger med gitt status og laster tilhørende skjema i samme spørring
+     * (JOIN FETCH) for å unngå N+1 når admin-DTO-er mappes – viktig når mange innsendinger
+     * har feilet samtidig.
+     */
+    @Query("SELECT i FROM Innsending i JOIN FETCH i.skjema WHERE i.status = :status")
+    fun findByStatusMedSkjema(status: InnsendingStatus): List<Innsending>
+
+    fun countByStatus(status: InnsendingStatus): Long
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/SkjemaRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/SkjemaRepository.kt
@@ -19,4 +19,6 @@ interface SkjemaRepository : JpaRepository<Skjema, UUID> {
 
     @Query("SELECT s FROM Skjema s WHERE s.id = :id AND s.status = 'SENDT'")
     fun findByIdAndStatusSendt(id: UUID): Skjema?
+
+    fun countByStatus(status: SkjemaStatus): Long
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -1,0 +1,103 @@
+package no.nav.melosys.skjema.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.UUID
+import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
+import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
+import no.nav.melosys.skjema.controller.admin.RetryResultatDto
+import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.entity.Innsending
+import no.nav.melosys.skjema.repository.InnsendingRepository
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Administrative operasjoner som eksponeres via [no.nav.melosys.skjema.controller.admin.AdminController]
+ * og konsumeres av melosys-console. Gir innsyn i og mulighet til å reprosessere feilede innsendinger.
+ */
+@Service
+class AdminService(
+    private val innsendingRepository: InnsendingRepository,
+    private val skjemaRepository: SkjemaRepository,
+    private val innsendingService: InnsendingService
+) {
+
+    @Transactional(readOnly = true)
+    fun hentStatistikk(): AdminStatistikkDto = AdminStatistikkDto(
+        skjemaPerStatus = SkjemaStatus.entries.associateWith { skjemaRepository.countByStatus(it) },
+        innsendingPerStatus = InnsendingStatus.entries.associateWith { innsendingRepository.countByStatus(it) },
+        antallFeiledeInnsendinger = innsendingRepository.countByStatus(InnsendingStatus.KAFKA_FEILET)
+    )
+
+    @Transactional(readOnly = true)
+    fun hentFeiledeInnsendinger(): List<InnsendingAdminDto> =
+        innsendingRepository.findByStatusMedSkjema(InnsendingStatus.KAFKA_FEILET)
+            .map { it.tilAdminDto() }
+            .sortedByDescending { it.opprettetDato }
+
+    @Transactional(readOnly = true)
+    fun antallFeiledeInnsendinger(): Long =
+        innsendingRepository.countByStatus(InnsendingStatus.KAFKA_FEILET)
+
+    @Transactional(readOnly = true)
+    fun hentInnsending(innsendingId: UUID): InnsendingAdminDto =
+        finnInnsending(innsendingId).tilAdminDto()
+
+    /**
+     * Tvinger en ny prosessering (Kafka-sending) av en enkelt innsending.
+     */
+    fun retryInnsending(innsendingId: UUID): InnsendingAdminDto {
+        val skjemaId = finnSkjemaId(innsendingId)
+        log.info { "Admin: Tvinger retry av innsending $innsendingId (skjema $skjemaId)" }
+        innsendingService.prosesserInnsending(skjemaId)
+        return hentInnsending(innsendingId)
+    }
+
+    /**
+     * Tvinger ny prosessering av alle innsendinger med status KAFKA_FEILET.
+     */
+    fun retryAlleFeilede(): RetryResultatDto {
+        val skjemaIder = hentFeiledeSkjemaIder()
+        log.info { "Admin: Tvinger retry av ${skjemaIder.size} feilede innsendinger" }
+
+        var feilet = 0
+        skjemaIder.forEach { skjemaId ->
+            try {
+                innsendingService.prosesserInnsending(skjemaId)
+            } catch (e: Exception) {
+                feilet++
+                log.error(e) { "Admin: Retry feilet for skjema $skjemaId" }
+            }
+        }
+        return RetryResultatDto(antallForsoekt = skjemaIder.size, antallFeilet = feilet)
+    }
+
+    @Transactional(readOnly = true)
+    fun hentFeiledeSkjemaIder(): List<UUID> =
+        innsendingRepository.findByStatusMedSkjema(InnsendingStatus.KAFKA_FEILET).map { it.skjema.id!! }
+
+    @Transactional(readOnly = true)
+    fun finnSkjemaId(innsendingId: UUID): UUID = finnInnsending(innsendingId).skjema.id!!
+
+    private fun finnInnsending(innsendingId: UUID): Innsending =
+        innsendingRepository.findById(innsendingId)
+            .orElseThrow { NoSuchElementException("Fant ingen innsending med id $innsendingId") }
+
+    private fun Innsending.tilAdminDto() = InnsendingAdminDto(
+        innsendingId = id!!,
+        skjemaId = skjema.id!!,
+        referanseId = referanseId,
+        status = status,
+        skjemaStatus = skjema.status,
+        orgnr = skjema.orgnr,
+        antallForsok = antallForsok,
+        feilmelding = feilmelding,
+        sisteForsoekTidspunkt = sisteForsoekTidspunkt,
+        opprettetDato = opprettetDato,
+        saksnummer = saksnummer
+    )
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -1,15 +1,24 @@
 package no.nav.melosys.skjema.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
+import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
+import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
+import no.nav.melosys.skjema.repository.AdminStatistikkRepository
+import no.nav.melosys.skjema.repository.AntallPerKategori
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.common.Språk
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,6 +32,7 @@ private val log = KotlinLogging.logger {}
 class AdminService(
     private val innsendingRepository: InnsendingRepository,
     private val skjemaRepository: SkjemaRepository,
+    private val adminStatistikkRepository: AdminStatistikkRepository,
     private val innsendingService: InnsendingService
 ) {
 
@@ -32,6 +42,57 @@ class AdminService(
         innsendingPerStatus = InnsendingStatus.entries.associateWith { innsendingRepository.countByStatus(it) },
         antallFeiledeInnsendinger = innsendingRepository.countByStatus(InnsendingStatus.KAFKA_FEILET)
     )
+
+    @Transactional(readOnly = true)
+    fun hentBruksstatistikk(): BrukStatistikkDto {
+        val naa = Instant.now()
+
+        val perSkjemadel = adminStatistikkRepository.antallInnsendtPerSkjemadel().tilMap()
+        val innsendtPerSkjemadel = Skjemadel.entries.associateWith { perSkjemadel[it.name] ?: 0L }
+        val perFlyt = adminStatistikkRepository.antallInnsendtPerFlyt().tilMap()
+        val innsendtPerFlyt = Representasjonstype.entries.associateWith { perFlyt[it.name] ?: 0L }
+        val perSprak = adminStatistikkRepository.antallInnsendtPerSprak().tilMap()
+        val innsendtPerSprak = Språk.entries.associateWith { perSprak[it.kode] ?: 0L }
+
+        val antallKomplettInnsendt = innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] ?: 0L
+        val antallKobledePar = adminStatistikkRepository.antallKobledeSkjema() / 2
+
+        return BrukStatistikkDto(
+            tidspunkt = naa,
+            utkast = hentUtkastStatistikk(naa),
+            totaltInnsendt = adminStatistikkRepository.antallInnsendteSkjema(),
+            innsendtSisteDoegn = adminStatistikkRepository.antallInnsendtEtter(naa.minus(1, ChronoUnit.DAYS)),
+            innsendtSiste7Dager = adminStatistikkRepository.antallInnsendtEtter(naa.minus(7, ChronoUnit.DAYS)),
+            innsendtSiste30Dager = adminStatistikkRepository.antallInnsendtEtter(naa.minus(30, ChronoUnit.DAYS)),
+            innsendtPerSkjemadel = innsendtPerSkjemadel,
+            innsendtPerFlyt = innsendtPerFlyt,
+            innsendtPerSprak = innsendtPerSprak,
+            antallKomplettInnsendt = antallKomplettInnsendt,
+            antallKobledePar = antallKobledePar,
+            antallSakerMedBeggeDeler = antallKomplettInnsendt + antallKobledePar,
+            antallUnikePersoner = adminStatistikkRepository.antallUnikePersoner(),
+            antallUnikeVirksomheter = adminStatistikkRepository.antallUnikeVirksomheter()
+        )
+    }
+
+    private fun hentUtkastStatistikk(naa: Instant): UtkastStatistikkDto {
+        val fordeling = adminStatistikkRepository.utkastAldersfordeling(
+            grense1d = naa.minus(1, ChronoUnit.DAYS),
+            grense7d = naa.minus(7, ChronoUnit.DAYS),
+            grense30d = naa.minus(30, ChronoUnit.DAYS)
+        )
+        return UtkastStatistikkDto(
+            antall = fordeling.totalt,
+            under1Dag = fordeling.under1Dag,
+            mellom1Og7Dager = fordeling.mellom1Og7Dager,
+            mellom7Og30Dager = fordeling.mellom7Og30Dager,
+            over30Dager = fordeling.over30Dager,
+            eldsteOpprettetDato = adminStatistikkRepository.eldsteUtkastOpprettetDato()
+        )
+    }
+
+    private fun List<AntallPerKategori>.tilMap(): Map<String, Long> =
+        filter { it.kategori != null }.associate { it.kategori!! to it.antall }
 
     @Transactional(readOnly = true)
     fun hentFeiledeInnsendinger(): List<InnsendingAdminDto> =

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -37,11 +37,14 @@ class AdminService(
 ) {
 
     @Transactional(readOnly = true)
-    fun hentStatistikk(): AdminStatistikkDto = AdminStatistikkDto(
-        skjemaPerStatus = SkjemaStatus.entries.associateWith { skjemaRepository.countByStatus(it) },
-        innsendingPerStatus = InnsendingStatus.entries.associateWith { innsendingRepository.countByStatus(it) },
-        antallFeiledeInnsendinger = innsendingRepository.countByStatus(InnsendingStatus.KAFKA_FEILET)
-    )
+    fun hentStatistikk(): AdminStatistikkDto {
+        val innsendingPerStatus = InnsendingStatus.entries.associateWith { innsendingRepository.countByStatus(it) }
+        return AdminStatistikkDto(
+            skjemaPerStatus = SkjemaStatus.entries.associateWith { skjemaRepository.countByStatus(it) },
+            innsendingPerStatus = innsendingPerStatus,
+            antallFeiledeInnsendinger = innsendingPerStatus[InnsendingStatus.KAFKA_FEILET] ?: 0L
+        )
+    }
 
     @Transactional(readOnly = true)
     fun hentBruksstatistikk(): BrukStatistikkDto {
@@ -56,14 +59,19 @@ class AdminService(
 
         val antallKomplettInnsendt = innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] ?: 0L
         val antallKobledePar = adminStatistikkRepository.antallKobledeSkjema() / 2
+        val trend = adminStatistikkRepository.innsendtTrend(
+            grense1d = naa.minus(1, ChronoUnit.DAYS),
+            grense7d = naa.minus(7, ChronoUnit.DAYS),
+            grense30d = naa.minus(30, ChronoUnit.DAYS)
+        )
 
         return BrukStatistikkDto(
             tidspunkt = naa,
             utkast = hentUtkastStatistikk(naa),
             totaltInnsendt = adminStatistikkRepository.antallInnsendteSkjema(),
-            innsendtSisteDoegn = adminStatistikkRepository.antallInnsendtEtter(naa.minus(1, ChronoUnit.DAYS)),
-            innsendtSiste7Dager = adminStatistikkRepository.antallInnsendtEtter(naa.minus(7, ChronoUnit.DAYS)),
-            innsendtSiste30Dager = adminStatistikkRepository.antallInnsendtEtter(naa.minus(30, ChronoUnit.DAYS)),
+            innsendtSisteDoegn = trend.sisteDoegn,
+            innsendtSiste7Dager = trend.siste7Dager,
+            innsendtSiste30Dager = trend.siste30Dager,
             innsendtPerSkjemadel = innsendtPerSkjemadel,
             innsendtPerFlyt = innsendtPerFlyt,
             innsendtPerSprak = innsendtPerSprak,

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminApiKeyInterceptor.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminApiKeyInterceptor.kt
@@ -1,0 +1,47 @@
+package no.nav.melosys.skjema.sikkerhet
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import no.nav.melosys.skjema.config.M2mConfigProperties
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Krever en gyldig delt API-nøkkel i header for alle admin-endepunktene (under /admin),
+ * i tillegg til Azure AD-token og azp_name-allowlist (se [AdminBeskyttet]).
+ *
+ * Tilsvarer mønsteret i melosys-api: console sender nøkkelen i [API_KEY_HEADER].
+ */
+@Component
+class AdminApiKeyInterceptor(
+    private val m2mConfigProperties: M2mConfigProperties
+) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (!gyldigApiNokkel(request.getHeader(API_KEY_HEADER))) {
+            log.warn { "Admin: ugyldig eller manglende API-nøkkel for ${request.method} ${request.requestURI}" }
+            response.status = HttpServletResponse.SC_FORBIDDEN
+            response.writer.write("Ugyldig API-nøkkel")
+            return false
+        }
+        return true
+    }
+
+    private fun gyldigApiNokkel(oppgitt: String?): Boolean {
+        if (oppgitt.isNullOrEmpty()) return false
+        // Konstant-tid sammenligning for å unngå timing-angrep mot nøkkelen.
+        return MessageDigest.isEqual(
+            oppgitt.toByteArray(StandardCharsets.UTF_8),
+            m2mConfigProperties.admin.apikey.toByteArray(StandardCharsets.UTF_8)
+        )
+    }
+
+    companion object {
+        const val API_KEY_HEADER = "X-MELOSYS-SKJEMA-ADMIN-APIKEY"
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminBeskyttet.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminBeskyttet.kt
@@ -10,6 +10,9 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
  * 1. Token er gyldig Azure AD-token
  * 2. Tokenets azp_name-claim matcher tillatte klienter fra m2m.admin.clients
  *    (typisk `<cluster>:teammelosys:melosys-console`)
+ *
+ * I tillegg krever [no.nav.melosys.skjema.sikkerhet.AdminApiKeyInterceptor] en gyldig delt
+ * API-nøkkel i header for alle requests under /admin.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminBeskyttet.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/AdminBeskyttet.kt
@@ -1,0 +1,18 @@
+package no.nav.melosys.skjema.sikkerhet
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+
+/**
+ * Annotasjon for admin-beskyttede endepunkter som kalles fra melosys-console.
+ * Kombinerer Azure AD token-validering med klient-tilgangsstyring.
+ *
+ * Validerer at:
+ * 1. Token er gyldig Azure AD-token
+ * 2. Tokenets azp_name-claim matcher tillatte klienter fra m2m.admin.clients
+ *    (typisk `<cluster>:teammelosys:melosys-console`)
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@ProtectedWithClaims(issuer = "azure")
+annotation class AdminBeskyttet

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MProtectedAspect.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MProtectedAspect.kt
@@ -31,6 +31,14 @@ class M2MProtectedAspect(
         validateClientAccess(m2mConfigProperties.readSkjemadata.clients)
     }
 
+    @Before(
+        "@annotation(no.nav.melosys.skjema.sikkerhet.AdminBeskyttet) || " +
+            "@within(no.nav.melosys.skjema.sikkerhet.AdminBeskyttet)"
+    )
+    fun validateAdminAccess() {
+        validateClientAccess(m2mConfigProperties.admin.clients)
+    }
+
     private fun validateClientAccess(allowedClients: List<String>) {
         val context = tokenValidationContextHolder.getTokenValidationContext()
         val token = context.getJwtToken(AZURE)

--- a/src/main/resources/application-local-q2.yml
+++ b/src/main/resources/application-local-q2.yml
@@ -31,6 +31,7 @@ PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token
 AZURE_APP_WELL_KNOWN_URL: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: placeholder-melosys-client-id
+MELOSYS_CONSOLE_AZP_NAMES: dev-gcp:teammelosys:melosys-console-q2
 KAFKA_SKJEMA_MOTTAK_TOPIC: teammelosys.skjema.innsendt.q2-local
 KAFKA_BRUKERVARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 VEDLEGG_BUCKET_NAME: melosys-skjema-vedlegg-local

--- a/src/main/resources/application-local-q2.yml
+++ b/src/main/resources/application-local-q2.yml
@@ -32,6 +32,7 @@ AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/966ac572-f
 AZURE_APP_WELL_KNOWN_URL: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: placeholder-melosys-client-id
 MELOSYS_CONSOLE_AZP_NAMES: dev-gcp:teammelosys:melosys-console-q2
+MELOSYS_SKJEMA_ADMIN_APIKEY: placeholder-admin-apikey
 KAFKA_SKJEMA_MOTTAK_TOPIC: teammelosys.skjema.innsendt.q2-local
 KAFKA_BRUKERVARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 VEDLEGG_BUCKET_NAME: melosys-skjema-vedlegg-local

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,6 +35,7 @@ PDL_URL: http://localhost:8083/graphql
 REPR_URL: http://localhost:8083/repr
 AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: dev-fss:teammelosys:melosys
+MELOSYS_CONSOLE_AZP_NAMES: local:teammelosys:melosys-console
 VEDLEGG_BUCKET_NAME: melosys-skjema-vedlegg-local
 VEDLEGG_MOCK_STORAGE_URL: http://localhost:8083/vedlegg-storage
 CLAMAV_URL: http://localhost:8083/clamav

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,6 +36,7 @@ REPR_URL: http://localhost:8083/repr
 AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: dev-fss:teammelosys:melosys
 MELOSYS_CONSOLE_AZP_NAMES: local:teammelosys:melosys-console
+MELOSYS_SKJEMA_ADMIN_APIKEY: local-admin-apikey
 VEDLEGG_BUCKET_NAME: melosys-skjema-vedlegg-local
 VEDLEGG_MOCK_STORAGE_URL: http://localhost:8083/vedlegg-storage
 CLAMAV_URL: http://localhost:8083/clamav

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -196,7 +196,9 @@ m2m:
   read-skjemadata:
     clients:
       - ${MELOSYS_CLIENT_ID}
-  # Tillatte klienter for admin-endepunktene (/admin/**). Typisk melosys-console
-  # på formatet `<cluster>:teammelosys:melosys-console`. Komma-separert liste.
+  # Tilgang til admin-endepunktene (/admin/**): både azp_name-allowlist og delt
+  # API-nøkkel må stemme (i tillegg til gyldig Azure AD-token).
+  # clients: typisk melosys-console på formatet `<cluster>:teammelosys:melosys-console`.
   admin:
     clients: ${MELOSYS_CONSOLE_AZP_NAMES}
+    apikey: ${MELOSYS_SKJEMA_ADMIN_APIKEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -196,3 +196,7 @@ m2m:
   read-skjemadata:
     clients:
       - ${MELOSYS_CLIENT_ID}
+  # Tillatte klienter for admin-endepunktene (/admin/**). Typisk melosys-console
+  # på formatet `<cluster>:teammelosys:melosys-console`. Komma-separert liste.
+  admin:
+    clients: ${MELOSYS_CONSOLE_AZP_NAMES}

--- a/src/test/kotlin/no/nav/melosys/skjema/MockOAuth2ServerExtensions.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/MockOAuth2ServerExtensions.kt
@@ -7,6 +7,7 @@ import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 const val ACCEPTED_AUDIENCE = "test-client-id"
 const val ACCEPTED_AZURE_AUDIENCE = "test-azure-client-id"
 const val MELOSYS_CLIENT_ID = "test-melosys-client-id"
+const val MELOSYS_CONSOLE_CLIENT_ID = "test-console-client-id"
 const val ISSUER_ID = "tokenx"
 const val AZURE_ISSUER_ID = "azure"
 
@@ -38,3 +39,5 @@ fun MockOAuth2Server.tokenWithAzpClaim(azpName: String): String = getToken(
 fun MockOAuth2Server.m2mTokenWithReadSkjemaDataAccess(): String = tokenWithAzpClaim(MELOSYS_CLIENT_ID)
 
 fun MockOAuth2Server.m2mTokenWithoutAccess(): String = tokenWithAzpClaim("ukjent-klient-id")
+
+fun MockOAuth2Server.adminTokenMedTilgang(): String = tokenWithAzpClaim(MELOSYS_CONSOLE_CLIENT_ID)

--- a/src/test/kotlin/no/nav/melosys/skjema/config/OpenApiGruppeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/config/OpenApiGruppeIntegrationTest.kt
@@ -1,0 +1,38 @@
+package no.nav.melosys.skjema.config
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import no.nav.melosys.skjema.ApiTestBase
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
+
+class OpenApiGruppeIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Test
+    fun `full spec paa v3 api-docs inneholder bruker-endepunkter (brukes av frontend-typegen)`() {
+        val spec = webTestClient.get().uri("/v3/api-docs")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+            .returnResult().responseBody!!
+
+        spec shouldContain "/api/skjema"
+    }
+
+    @Test
+    fun `admin-gruppe paa v3 api-docs admin inneholder kun admin-endepunkter`() {
+        val spec = webTestClient.get().uri("/v3/api-docs/admin")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+            .returnResult().responseBody!!
+
+        spec shouldContain "/admin/statistikk"
+        spec shouldNotContain "/api/skjema"
+    }
+}

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -19,6 +19,7 @@ import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.service.InnsendingService
+import no.nav.melosys.skjema.sikkerhet.AdminApiKeyInterceptor.Companion.API_KEY_HEADER
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.common.SkjemaStatus
@@ -36,6 +37,8 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
+private const val TEST_ADMIN_APIKEY = "test-admin-apikey"
+
 class AdminControllerIntegrationTest : ApiTestBase() {
 
     @Autowired
@@ -52,6 +55,11 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
     @MockkBean(relaxed = true)
     private lateinit var innsendingService: InnsendingService
+
+    /** WebTestClient som sender gyldig admin-API-nøkkel på alle kall (jf. application-test.yml). */
+    private val adminClient by lazy {
+        webTestClient.mutate().defaultHeader(API_KEY_HEADER, TEST_ADMIN_APIKEY).build()
+    }
 
     @BeforeEach
     fun setUp() {
@@ -80,15 +88,32 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal returnere 401 naar token mangler`() {
-            webTestClient.get().uri("/admin/statistikk")
+            adminClient.get().uri("/admin/statistikk")
                 .exchange()
                 .expectStatus().isUnauthorized
         }
 
         @Test
         fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
-            webTestClient.get().uri("/admin/statistikk")
+            adminClient.get().uri("/admin/statistikk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+
+        @Test
+        fun `skal returnere 403 naar API-noekkel mangler selv med gyldig token`() {
+            webTestClient.get().uri("/admin/statistikk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+
+        @Test
+        fun `skal returnere 403 naar API-noekkel er feil`() {
+            webTestClient.get().uri("/admin/statistikk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .header(API_KEY_HEADER, "feil-noekkel")
                 .exchange()
                 .expectStatus().isForbidden
         }
@@ -102,7 +127,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         fun `skal returnere antall per status`() {
             lagFeiletInnsending()
 
-            val body = webTestClient.get().uri("/admin/statistikk")
+            val body = adminClient.get().uri("/admin/statistikk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -124,7 +149,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         fun `skal returnere feilede innsendinger uten personopplysninger`() {
             val innsending = lagFeiletInnsending()
 
-            val body = webTestClient.get().uri("/admin/innsendinger/feilede")
+            val body = adminClient.get().uri("/admin/innsendinger/feilede")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -144,7 +169,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             lagFeiletInnsending("FEIL01")
             lagFeiletInnsending("FEIL02")
 
-            val body = webTestClient.get().uri("/admin/innsendinger/feilede/antall")
+            val body = adminClient.get().uri("/admin/innsendinger/feilede/antall")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -164,7 +189,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         fun `skal returnere innsending`() {
             val innsending = lagFeiletInnsending()
 
-            webTestClient.get().uri("/admin/innsendinger/${innsending.id}")
+            adminClient.get().uri("/admin/innsendinger/${innsending.id}")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -176,7 +201,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal returnere 404 naar innsending ikke finnes`() {
-            webTestClient.get().uri("/admin/innsendinger/${UUID.randomUUID()}")
+            adminClient.get().uri("/admin/innsendinger/${UUID.randomUUID()}")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -193,7 +218,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             val innsending = lagFeiletInnsending()
             val skjemaId = innsending.skjema.id!!
 
-            webTestClient.post().uri("/admin/innsendinger/${innsending.id}/retry")
+            adminClient.post().uri("/admin/innsendinger/${innsending.id}/retry")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -204,7 +229,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal returnere 404 naar innsending ikke finnes`() {
-            webTestClient.post().uri("/admin/innsendinger/${UUID.randomUUID()}/retry")
+            adminClient.post().uri("/admin/innsendinger/${UUID.randomUUID()}/retry")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -222,7 +247,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             val innsending2 = lagFeiletInnsending("FEIL02")
             every { innsendingService.prosesserInnsending(any()) } returns Unit
 
-            val body = webTestClient.post().uri("/admin/innsendinger/retry-feilede")
+            val body = adminClient.post().uri("/admin/innsendinger/retry-feilede")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -289,7 +314,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 (arbeidstakerDel.metadata as UtsendtArbeidstakerMetadata).medKobletSkjemaId(arbeidsgiverDel.id)
             skjemaRepository.save(arbeidstakerDel)
 
-            val body = webTestClient.get().uri("/admin/statistikk/bruk")
+            val body = adminClient.get().uri("/admin/statistikk/bruk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -335,7 +360,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal returnere nuller naar ingen data`() {
-            val body = webTestClient.get().uri("/admin/statistikk/bruk")
+            val body = adminClient.get().uri("/admin/statistikk/bruk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -352,7 +377,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
-            webTestClient.get().uri("/admin/statistikk/bruk")
+            adminClient.get().uri("/admin/statistikk/bruk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
                 .exchange()
                 .expectStatus().isForbidden

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -6,18 +6,26 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.verify
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.ApiTestBase
 import no.nav.melosys.skjema.adminTokenMedTilgang
 import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.innsendingMedDefaultVerdier
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.service.InnsendingService
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
+import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -226,6 +234,128 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             body.antallFeilet shouldBe 0
             verify(exactly = 1) { innsendingService.prosesserInnsending(innsending1.skjema.id!!) }
             verify(exactly = 1) { innsendingService.prosesserInnsending(innsending2.skjema.id!!) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/statistikk/bruk")
+    inner class Bruksstatistikk {
+
+        private fun lagInnsendtSkjema(
+            representasjonstype: Representasjonstype,
+            skjemadel: Skjemadel,
+            sprak: Språk = Språk.NORSK_BOKMAL,
+            kobletSkjemaId: UUID? = null,
+            fnr: String = no.nav.melosys.skjema.korrektSyntetiskFnr,
+            referanseId: String
+        ) = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = fnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidstakersSkjemaDataDtoMedDefaultVerdier(),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = representasjonstype,
+                    skjemadel = skjemadel,
+                    kobletSkjemaId = kobletSkjemaId
+                )
+            )
+        ).also { skjema ->
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, referanseId = referanseId)
+            )
+        }
+
+        @Test
+        fun `skal aggregere utkast, innsendte per skjemadel-flyt-spraak, koblinger og unike`() {
+            // Utkast: ett ferskt og ett gammelt (>30 dager)
+            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = Instant.now()))
+            val gammeltUtkastDato = Instant.now().minus(40, ChronoUnit.DAYS)
+            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = gammeltUtkastDato))
+
+            // Innsendte enkeltdeler
+            lagInnsendtSkjema(Representasjonstype.DEG_SELV, Skjemadel.ARBEIDSTAKERS_DEL, Språk.NORSK_BOKMAL, referanseId = "AA0001")
+            lagInnsendtSkjema(Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL, Språk.ENGELSK, fnr = etAnnetKorrektSyntetiskFnr, referanseId = "AA0002")
+
+            // Komplett innsending (begge deler i én)
+            lagInnsendtSkjema(Representasjonstype.RADGIVER, Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, referanseId = "AA0003")
+
+            // Koblet par: arbeidsgivers del + arbeidstakers del sendt hver for seg
+            val arbeidstakerDel = lagInnsendtSkjema(Representasjonstype.DEG_SELV, Skjemadel.ARBEIDSTAKERS_DEL, referanseId = "AA0004")
+            val arbeidsgiverDel = lagInnsendtSkjema(
+                Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL,
+                kobletSkjemaId = arbeidstakerDel.id, referanseId = "AA0005"
+            )
+            arbeidstakerDel.metadata =
+                (arbeidstakerDel.metadata as UtsendtArbeidstakerMetadata).medKobletSkjemaId(arbeidsgiverDel.id)
+            skjemaRepository.save(arbeidstakerDel)
+
+            val body = webTestClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BrukStatistikkDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            // Utkast med aldersfordeling
+            body.utkast.antall shouldBe 2
+            body.utkast.under1Dag shouldBe 1
+            body.utkast.over30Dager shouldBe 1
+            body.utkast.mellom1Og7Dager shouldBe 0
+            body.utkast.eldsteOpprettetDato.shouldNotBeNull()
+
+            // Innsendte totalt og per skjemadel (5 SENDT skjema)
+            body.totaltInnsendt shouldBe 5
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 2
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVERS_DEL] shouldBe 2
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] shouldBe 1
+
+            // Per flyt
+            body.innsendtPerFlyt[Representasjonstype.DEG_SELV] shouldBe 2
+            body.innsendtPerFlyt[Representasjonstype.ARBEIDSGIVER] shouldBe 2
+            body.innsendtPerFlyt[Representasjonstype.RADGIVER] shouldBe 1
+            body.innsendtPerFlyt[Representasjonstype.ANNEN_PERSON] shouldBe 0
+
+            // Per språk (4 nb, 1 en)
+            body.innsendtPerSprak[Språk.NORSK_BOKMAL] shouldBe 4
+            body.innsendtPerSprak[Språk.ENGELSK] shouldBe 1
+
+            // Koblinger: 1 komplett + 1 koblet par = 2 saker med begge deler
+            body.antallKomplettInnsendt shouldBe 1
+            body.antallKobledePar shouldBe 1
+            body.antallSakerMedBeggeDeler shouldBe 2
+
+            // Trend: alle innsendinger er ferske
+            body.innsendtSisteDoegn shouldBe 5
+
+            // Unike: to ulike fnr, én virksomhet (default orgnr)
+            body.antallUnikePersoner shouldBe 2
+            body.antallUnikeVirksomheter shouldBe 1
+        }
+
+        @Test
+        fun `skal returnere nuller naar ingen data`() {
+            val body = webTestClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BrukStatistikkDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            body.utkast.antall shouldBe 0
+            body.totaltInnsendt shouldBe 0
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 0
+            body.antallSakerMedBeggeDeler shouldBe 0
+            body.utkast.eldsteOpprettetDato shouldBe null
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            webTestClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .exchange()
+                .expectStatus().isForbidden
         }
     }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -1,0 +1,231 @@
+package no.nav.melosys.skjema.controller.admin
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.verify
+import java.util.UUID
+import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.adminTokenMedTilgang
+import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.innsendingMedDefaultVerdier
+import no.nav.melosys.skjema.m2mTokenWithoutAccess
+import no.nav.melosys.skjema.repository.InnsendingRepository
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.service.InnsendingService
+import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import no.nav.security.mock.oauth2.MockOAuth2Server
+
+class AdminControllerIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var mockOAuth2Server: MockOAuth2Server
+
+    @Autowired
+    private lateinit var skjemaRepository: SkjemaRepository
+
+    @Autowired
+    private lateinit var innsendingRepository: InnsendingRepository
+
+    @MockkBean(relaxed = true)
+    private lateinit var innsendingService: InnsendingService
+
+    @BeforeEach
+    fun setUp() {
+        innsendingRepository.deleteAll()
+        skjemaRepository.deleteAll()
+    }
+
+    private fun lagFeiletInnsending(referanseId: String = "FEIL01") =
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
+        ).let { skjema ->
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(
+                    skjema = skjema,
+                    status = InnsendingStatus.KAFKA_FEILET,
+                    antallForsok = 3,
+                    feilmelding = "Kafka utilgjengelig",
+                    referanseId = referanseId
+                )
+            )
+        }
+
+    @Nested
+    @DisplayName("Sikkerhet")
+    inner class Sikkerhet {
+
+        @Test
+        fun `skal returnere 401 naar token mangler`() {
+            webTestClient.get().uri("/admin/statistikk")
+                .exchange()
+                .expectStatus().isUnauthorized
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            webTestClient.get().uri("/admin/statistikk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/statistikk")
+    inner class Statistikk {
+
+        @Test
+        fun `skal returnere antall per status`() {
+            lagFeiletInnsending()
+
+            val body = webTestClient.get().uri("/admin/statistikk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<AdminStatistikkDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            body.skjemaPerStatus[SkjemaStatus.SENDT] shouldBe 1
+            body.innsendingPerStatus[InnsendingStatus.KAFKA_FEILET] shouldBe 1
+            body.antallFeiledeInnsendinger shouldBe 1
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/innsendinger/feilede")
+    inner class FeiledeInnsendinger {
+
+        @Test
+        fun `skal returnere feilede innsendinger uten personopplysninger`() {
+            val innsending = lagFeiletInnsending()
+
+            val body = webTestClient.get().uri("/admin/innsendinger/feilede")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<List<InnsendingAdminDto>>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            body shouldHaveSize 1
+            body[0].innsendingId shouldBe innsending.id
+            body[0].status shouldBe InnsendingStatus.KAFKA_FEILET
+            body[0].feilmelding shouldBe "Kafka utilgjengelig"
+            body[0].antallForsok shouldBe 3
+        }
+
+        @Test
+        fun `skal returnere antall feilede`() {
+            lagFeiletInnsending("FEIL01")
+            lagFeiletInnsending("FEIL02")
+
+            val body = webTestClient.get().uri("/admin/innsendinger/feilede/antall")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<AntallDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            body.antall shouldBe 2
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/innsendinger/{id}")
+    inner class HentInnsending {
+
+        @Test
+        fun `skal returnere innsending`() {
+            val innsending = lagFeiletInnsending()
+
+            webTestClient.get().uri("/admin/innsendinger/${innsending.id}")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<InnsendingAdminDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+                .innsendingId shouldBe innsending.id
+        }
+
+        @Test
+        fun `skal returnere 404 naar innsending ikke finnes`() {
+            webTestClient.get().uri("/admin/innsendinger/${UUID.randomUUID()}")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /admin/innsendinger/{id}/retry")
+    inner class RetryInnsending {
+
+        @Test
+        fun `skal reprosessere innsending og returnere 200`() {
+            val innsending = lagFeiletInnsending()
+            val skjemaId = innsending.skjema.id!!
+
+            webTestClient.post().uri("/admin/innsendinger/${innsending.id}/retry")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+
+            verify(exactly = 1) { innsendingService.prosesserInnsending(skjemaId) }
+        }
+
+        @Test
+        fun `skal returnere 404 naar innsending ikke finnes`() {
+            webTestClient.post().uri("/admin/innsendinger/${UUID.randomUUID()}/retry")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /admin/innsendinger/retry-feilede")
+    inner class RetryAlleFeilede {
+
+        @Test
+        fun `skal reprosessere alle feilede og returnere antall`() {
+            val innsending1 = lagFeiletInnsending("FEIL01")
+            val innsending2 = lagFeiletInnsending("FEIL02")
+            every { innsendingService.prosesserInnsending(any()) } returns Unit
+
+            val body = webTestClient.post().uri("/admin/innsendinger/retry-feilede")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<RetryResultatDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            body.antallForsoekt shouldBe 2
+            body.antallFeilet shouldBe 0
+            verify(exactly = 1) { innsendingService.prosesserInnsending(innsending1.skjema.id!!) }
+            verify(exactly = 1) { innsendingService.prosesserInnsending(innsending2.skjema.id!!) }
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,5 +35,6 @@ VARSLING_ARBEIDSTAKER_SKJEMA_LENKE: https://melosys-skjema-web.intern.dev.nav.no
 AZURE_APP_WELL_KNOWN_URL: ${mock-oauth2-server.baseUrl}/azure/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: test-melosys-client-id
 MELOSYS_CONSOLE_AZP_NAMES: test-console-client-id
+MELOSYS_SKJEMA_ADMIN_APIKEY: test-admin-apikey
 VEDLEGG_BUCKET_NAME: test-vedlegg-bucket
 CLAMAV_URL: http://localhost:9999

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,5 +34,6 @@ BRUK_SYNTETISK_FNR: true
 VARSLING_ARBEIDSTAKER_SKJEMA_LENKE: https://melosys-skjema-web.intern.dev.nav.no
 AZURE_APP_WELL_KNOWN_URL: ${mock-oauth2-server.baseUrl}/azure/.well-known/openid-configuration
 MELOSYS_CLIENT_ID: test-melosys-client-id
+MELOSYS_CONSOLE_AZP_NAMES: test-console-client-id
 VEDLEGG_BUCKET_NAME: test-vedlegg-bucket
 CLAMAV_URL: http://localhost:9999


### PR DESCRIPTION
Kobler melosys-skjema-api til melosys-console (på linje med melosys-api, melosys-eessi og faktureringskomponenten) og legger til admin-endepunkter for drift, feilsøking og bruksovervåking.

- Egen OpenAPI-gruppe på `/v3/api-docs/admin` for `/admin`-endepunktene. Full spec på `/v3/api-docs` er uendret (frontend-typegenerering påvirkes ikke).
- Drift: `/admin/statistikk`, listing/antall av feilede innsendinger, og retry (enkelt + alle).
- Bruksstatistikk: `GET /admin/statistikk/bruk` — antall utkast med aldersfordeling, innsendte fordelt på skjemadel/flyt/språk, antall komplette og koblede saker, samt unike personer og virksomheter.
- DTO-ene inneholder bevisst ingen personopplysninger.
- Sikret med Azure AD-token + `azp_name`-allowlist for console **og** delt API-nøkkel i `X-MELOSYS-SKJEMA-ADMIN-APIKEY` (som melosys-api).
- `melosys-console(-q2)` lagt i `accessPolicy.inbound` (dev/prod).

**Før deploy:** secret `melosys-skjema-api` må få `MELOSYS_SKJEMA_ADMIN_APIKEY` (samme verdi som console bruker), ellers starter ikke appen.

Console-siden ligger i egen PR i `melosys-console`: https://github.com/navikt/melosys-console/pull/146