### PR TITLE
8145: Regn saksdekning verdibasert i bruksstatistikk

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -4,13 +4,16 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import java.time.LocalDate
 import java.util.UUID
 import no.nav.melosys.skjema.service.AdminService
 import no.nav.melosys.skjema.sikkerhet.AdminBeskyttet
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 private val log = KotlinLogging.logger {}
@@ -41,12 +44,16 @@ class AdminController(
     @Operation(
         summary = "Hent bruksstatistikk for skjemaene",
         description = "Antall utkast med aldersfordeling, innsendte fordelt på skjemadel/flyt/språk, " +
-            "antall komplette og koblede saker, samt unike personer og virksomheter."
+            "saksdekning, unike personer/virksomheter og anonym toppliste. Innsendt-statistikken kan " +
+            "filtreres på innsendingsdato med fraOgMed/tilOgMed (begge valgfrie; utelat for alt)."
     )
     @ApiResponse(responseCode = "200", description = "Bruksstatistikk hentet")
-    fun hentBruksstatistikk(): BrukStatistikkDto {
-        log.info { "Admin: Henter bruksstatistikk" }
-        return adminService.hentBruksstatistikk()
+    fun hentBruksstatistikk(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) fraOgMed: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) tilOgMed: LocalDate?
+    ): BrukStatistikkDto {
+        log.info { "Admin: Henter bruksstatistikk (fraOgMed=$fraOgMed, tilOgMed=$tilOgMed)" }
+        return adminService.hentBruksstatistikk(fraOgMed, tilOgMed)
     }
 
     @GetMapping("/innsendinger/feilede")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.skjema.controller.admin
 
 import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
@@ -51,8 +52,15 @@ data class RetryResultatDto(
 data class BrukStatistikkDto(
     /** Tidspunkt statistikken ble beregnet (aldersgrenser regnes fra dette). */
     val tidspunkt: Instant,
+    /**
+     * Periodefilteret som ble brukt (innsendingsdato). Null = ingen grense (alt).
+     * Gjelder alle innsendt-feltene (totalt, fordelinger, saksdekning, toppliste, unike).
+     * [utkast] og innsendt-trenden er nåtilstand og påvirkes ikke av perioden.
+     */
+    val periodeFraOgMed: LocalDate?,
+    val periodeTilOgMed: LocalDate?,
     val utkast: UtkastStatistikkDto,
-    /** Totalt antall innsendte skjema (status SENDT). */
+    /** Totalt antall innsendte skjema (status SENDT) i perioden. */
     val totaltInnsendt: Long,
     val innsendtSisteDoegn: Long,
     val innsendtSiste7Dager: Long,
@@ -68,7 +76,12 @@ data class BrukStatistikkDto(
     /** Unike personer (fnr) blant innsendte skjema. */
     val antallUnikePersoner: Long,
     /** Unike virksomheter (orgnr) blant innsendte skjema. */
-    val antallUnikeVirksomheter: Long
+    val antallUnikeVirksomheter: Long,
+    /**
+     * Anonym toppliste over de mest aktive virksomhetene: antall innsendte skjema per virksomhet,
+     * sortert synkende. Inneholder bevisst kun tallene (rang 1, 2, 3 ...), ikke orgnr eller navn.
+     */
+    val topplisteVirksomheter: List<Long>
 )
 
 /**
@@ -82,9 +95,9 @@ data class SaksdekningDto(
     /** Skjema sendt som ett samlet skjema (begge deler i én innsending). */
     val antallKomplette: Long,
     /**
-     * Saker der begge deler er dekket = komplette skjema + saker der en separat arbeidstaker-del og
-     * en separat arbeidsgiver-del matcher (samme fnr + juridisk enhet + overlappende periode).
-     * En «sak» = en unik (person, juridisk enhet) med begge deler i overlappende periode.
+     * Antall unike saker (person + juridisk enhet) der begge deler er dekket – enten via et komplett
+     * skjema, eller via en separat arbeidstaker-del og arbeidsgiver-del som matcher (overlappende
+     * periode). Samme sak telles kun én gang selv om den har både komplett skjema og separate deler.
      */
     val antallSakerMedBeggeDeler: Long,
     /** Separate arbeidstaker-deler som har en matchende arbeidsgiver-del. */

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -63,16 +63,44 @@ data class BrukStatistikkDto(
     val innsendtPerFlyt: Map<Representasjonstype, Long>,
     /** Innsendte fordelt på valgt språk ved innsending. */
     val innsendtPerSprak: Map<Språk, Long>,
-    /** Antall innsendte komplette skjema (begge deler i én innsending). */
-    val antallKomplettInnsendt: Long,
-    /** Antall koblede par der arbeidsgivers del og arbeidstakers del er sendt hver for seg. */
-    val antallKobledePar: Long,
-    /** Saker der begge deler er dekket = komplette + koblede par. */
-    val antallSakerMedBeggeDeler: Long,
+    /** Saksdekning – om begge deler (arbeidstaker + arbeidsgiver) er dekket, regnet fra faktiske verdier. */
+    val saksdekning: SaksdekningDto,
     /** Unike personer (fnr) blant innsendte skjema. */
     val antallUnikePersoner: Long,
     /** Unike virksomheter (orgnr) blant innsendte skjema. */
     val antallUnikeVirksomheter: Long
+)
+
+/**
+ * Saksdekning for utsendt arbeidstaker: en komplett A1-sak trenger BÅDE arbeidstakers del og
+ * arbeidsgivers del. Disse kan komme som ett samlet skjema, eller som to separate deler.
+ *
+ * Tallene regnes ut fra **faktiske verdier** (samme fnr + samme juridiske enhet + overlappende
+ * utsendelsesperiode) — samme matching som mottak bruker for å gruppere relaterte deler.
+ */
+data class SaksdekningDto(
+    /** Skjema sendt som ett samlet skjema (begge deler i én innsending). */
+    val antallKomplette: Long,
+    /**
+     * Saker der begge deler er dekket = komplette skjema + saker der en separat arbeidstaker-del og
+     * en separat arbeidsgiver-del matcher (samme fnr + juridisk enhet + overlappende periode).
+     * En «sak» = en unik (person, juridisk enhet) med begge deler i overlappende periode.
+     */
+    val antallSakerMedBeggeDeler: Long,
+    /** Separate arbeidstaker-deler som har en matchende arbeidsgiver-del. */
+    val antallArbeidstakerDelMedMotpart: Long,
+    /** Separate arbeidsgiver-deler som har en matchende arbeidstaker-del. */
+    val antallArbeidsgiverDelMedMotpart: Long,
+    /** Arbeidstaker-deler som (ennå) mangler en matchende arbeidsgiver-del. */
+    val antallArbeidstakerDelUtenMotpart: Long,
+    /** Arbeidsgiver-deler som (ennå) mangler en matchende arbeidstaker-del. */
+    val antallArbeidsgiverDelUtenMotpart: Long,
+    /**
+     * Mulige dobbeltinnsendinger: samme person har sendt samme del for samme juridiske enhet med
+     * overlappende periode flere ganger. Versjons-erstatninger (erstatterSkjemaId) er holdt utenfor,
+     * så dette er ekte mulige duplikater – ikke nye versjoner av samme søknad.
+     */
+    val antallMuligeDobbeltinnsendinger: Long
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
@@ -7,12 +7,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.Repository
 import org.springframework.stereotype.Repository as RepositoryAnnotation
 
-/** Projeksjon for «antall per kategori»-aggregeringer (GROUP BY). */
-interface AntallPerKategori {
-    val kategori: String?
-    val antall: Long
-}
-
 /**
  * Aldersfordeling for utkast, beregnet i én spørring (ett snapshot) slik at bøttene alltid
  * er ikke-negative og summerer til [totalt]. Bøttene er gjensidig utelukkende.
@@ -33,59 +27,12 @@ interface InnsendtTrend {
 }
 
 /**
- * Aggregeringsspørringer for bruksstatistikk på skjema/innsendinger.
- *
- * Skjemadel/flyt/språk hentes via native JSONB-/kolonneaggregering (samme mønster som
- * [UtsendtArbeidstakerSkjemaRepository]). Utkast-tellinger og unike tellinger gjøres med JPQL.
+ * Spørringer for utkast og innsendingstrend i bruksstatistikken. Disse er nåtilstand-mål og
+ * påvirkes ikke av periodefilteret. Innsendt-statistikken (fordelinger, saksdekning, toppliste)
+ * regnes i minnet i [no.nav.melosys.skjema.service.AdminService] for å kunne filtreres på periode.
  */
 @RepositoryAnnotation
 interface AdminStatistikkRepository : Repository<Skjema, UUID> {
-
-    @Query(
-        nativeQuery = true,
-        value = """
-        SELECT metadata->>'skjemadel' AS kategori, COUNT(*) AS antall
-        FROM skjema
-        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
-        GROUP BY metadata->>'skjemadel'
-    """
-    )
-    fun antallInnsendtPerSkjemadel(): List<AntallPerKategori>
-
-    @Query(
-        nativeQuery = true,
-        value = """
-        SELECT metadata->>'representasjonstype' AS kategori, COUNT(*) AS antall
-        FROM skjema
-        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
-        GROUP BY metadata->>'representasjonstype'
-    """
-    )
-    fun antallInnsendtPerFlyt(): List<AntallPerKategori>
-
-    @Query(
-        nativeQuery = true,
-        value = """
-        SELECT innsendt_sprak AS kategori, COUNT(*) AS antall
-        FROM innsending
-        GROUP BY innsendt_sprak
-    """
-    )
-    fun antallInnsendtPerSprak(): List<AntallPerKategori>
-
-    /**
-     * Henter alle innsendte (SENDT) utsendt-arbeidstaker-skjema for saksdekningsanalyse i minnet.
-     *
-     * Saksdekning (begge deler dekket) regnes ut fra faktiske verdier — samme fnr + juridisk enhet +
-     * overlappende periode — på samme måte som mottak grupperer relaterte deler. Datamengden er liten
-     * og endepunktet kjøres sjelden, så in-memory er ok.
-     */
-    @Query(
-        "SELECT s FROM Skjema s " +
-            "WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT " +
-            "AND s.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
-    )
-    fun finnAlleInnsendte(): List<Skjema>
 
     @Query(
         nativeQuery = true,
@@ -104,15 +51,6 @@ interface AdminStatistikkRepository : Repository<Skjema, UUID> {
 
     @Query("SELECT MIN(s.opprettetDato) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.UTKAST")
     fun eldsteUtkastOpprettetDato(): Instant?
-
-    @Query("SELECT COUNT(s) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
-    fun antallInnsendteSkjema(): Long
-
-    @Query("SELECT COUNT(DISTINCT s.fnr) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
-    fun antallUnikePersoner(): Long
-
-    @Query("SELECT COUNT(DISTINCT s.orgnr) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT")
-    fun antallUnikeVirksomheter(): Long
 
     /** Innsendingstrend: kumulativt antall innsendinger i siste døgn / 7 / 30 dager (ett snapshot). */
     @Query(

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
@@ -74,19 +74,18 @@ interface AdminStatistikkRepository : Repository<Skjema, UUID> {
     fun antallInnsendtPerSprak(): List<AntallPerKategori>
 
     /**
-     * Antall innsendte skjema som er koblet til en motpart (begge deler sendt hver for seg).
-     * Hvert koblet par teller 2 (begge sider peker på hverandre), så del på 2 for antall par.
+     * Henter alle innsendte (SENDT) utsendt-arbeidstaker-skjema for saksdekningsanalyse i minnet.
+     *
+     * Saksdekning (begge deler dekket) regnes ut fra faktiske verdier — samme fnr + juridisk enhet +
+     * overlappende periode — på samme måte som mottak grupperer relaterte deler. Datamengden er liten
+     * og endepunktet kjøres sjelden, så in-memory er ok.
      */
     @Query(
-        nativeQuery = true,
-        value = """
-        SELECT COUNT(*)
-        FROM skjema
-        WHERE type = 'UTSENDT_ARBEIDSTAKER' AND status = 'SENDT'
-        AND metadata->>'kobletSkjemaId' IS NOT NULL
-    """
+        "SELECT s FROM Skjema s " +
+            "WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT " +
+            "AND s.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
     )
-    fun antallKobledeSkjema(): Long
+    fun finnAlleInnsendte(): List<Skjema>
 
     @Query(
         nativeQuery = true,

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -48,4 +48,15 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
     fun findByStatusMedSkjema(status: InnsendingStatus): List<Innsending>
 
     fun countByStatus(status: InnsendingStatus): Long
+
+    /**
+     * Henter alle innsendinger med tilhørende innsendte (SENDT) utsendt-arbeidstaker-skjema (JOIN FETCH),
+     * for bruksstatistikk regnet i minnet. Gir både innsendingstidspunkt/språk og skjemadata i én spørring.
+     */
+    @Query(
+        "SELECT i FROM Innsending i JOIN FETCH i.skjema s " +
+            "WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT " +
+            "AND s.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
+    )
+    fun finnAlleInnsendteMedSkjema(): List<Innsending>
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -8,17 +8,22 @@ import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
 import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
+import no.nav.melosys.skjema.controller.admin.SaksdekningDto
 import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
+import no.nav.melosys.skjema.extensions.overlapper
+import no.nav.melosys.skjema.extensions.utsendelsePeriode
 import no.nav.melosys.skjema.repository.AdminStatistikkRepository
 import no.nav.melosys.skjema.repository.AntallPerKategori
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.common.Språk
+import no.nav.melosys.skjema.types.felles.PeriodeDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -57,8 +62,6 @@ class AdminService(
         val perSprak = adminStatistikkRepository.antallInnsendtPerSprak().tilMap()
         val innsendtPerSprak = Språk.entries.associateWith { perSprak[it.kode] ?: 0L }
 
-        val antallKomplettInnsendt = innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] ?: 0L
-        val antallKobledePar = adminStatistikkRepository.antallKobledeSkjema() / 2
         val trend = adminStatistikkRepository.innsendtTrend(
             grense1d = naa.minus(1, ChronoUnit.DAYS),
             grense7d = naa.minus(7, ChronoUnit.DAYS),
@@ -75,12 +78,89 @@ class AdminService(
             innsendtPerSkjemadel = innsendtPerSkjemadel,
             innsendtPerFlyt = innsendtPerFlyt,
             innsendtPerSprak = innsendtPerSprak,
-            antallKomplettInnsendt = antallKomplettInnsendt,
-            antallKobledePar = antallKobledePar,
-            antallSakerMedBeggeDeler = antallKomplettInnsendt + antallKobledePar,
+            saksdekning = beregnSaksdekning(),
             antallUnikePersoner = adminStatistikkRepository.antallUnikePersoner(),
             antallUnikeVirksomheter = adminStatistikkRepository.antallUnikeVirksomheter()
         )
+    }
+
+    /**
+     * Beregner saksdekning ut fra faktiske verdier: to deler hører til samme sak når de har samme
+     * fnr + samme juridiske enhet + overlappende utsendelsesperiode — samme matching som mottak
+     * bruker for å gruppere relaterte deler.
+     */
+    private fun beregnSaksdekning(): SaksdekningDto {
+        val alle = adminStatistikkRepository.finnAlleInnsendte()
+
+        // Id-er som er erstattet av en nyere versjon (holdes utenfor duplikat-tellingen).
+        val erstattedeIder: Set<UUID> = alle
+            .mapNotNull { (it.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
+            .toSet()
+
+        val deler = alle.mapNotNull { skjema ->
+            val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+            Del(
+                id = skjema.id!!,
+                fnr = skjema.fnr,
+                juridiskEnhet = metadata.juridiskEnhetOrgnr,
+                skjemadel = metadata.skjemadel,
+                periode = skjema.utsendelsePeriode(),
+                erstattet = skjema.id in erstattedeIder
+            )
+        }
+
+        val antallKomplette = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong()
+        val arbeidstakerDeler = deler.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+        val arbeidsgiverDeler = deler.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
+        val arbeidstakerePerSak = arbeidstakerDeler.groupBy { it.sakNokkel() }
+        val arbeidsgiverePerSak = arbeidsgiverDeler.groupBy { it.sakNokkel() }
+
+        val atMedMotpart = arbeidstakerDeler.count { at ->
+            arbeidsgiverePerSak[at.sakNokkel()]?.any { at.matcher(it) } == true
+        }.toLong()
+        val agMedMotpart = arbeidsgiverDeler.count { ag ->
+            arbeidstakerePerSak[ag.sakNokkel()]?.any { ag.matcher(it) } == true
+        }.toLong()
+
+        // Saker (unik person + juridisk enhet) der separat at-del og ag-del overlapper.
+        val sakerMedBeggeSeparat = arbeidstakerePerSak.keys.intersect(arbeidsgiverePerSak.keys).count { nokkel ->
+            val ats = arbeidstakerePerSak.getValue(nokkel)
+            val ags = arbeidsgiverePerSak.getValue(nokkel)
+            ats.any { at -> ags.any { at.matcher(it) } }
+        }.toLong()
+
+        return SaksdekningDto(
+            antallKomplette = antallKomplette,
+            antallSakerMedBeggeDeler = antallKomplette + sakerMedBeggeSeparat,
+            antallArbeidstakerDelMedMotpart = atMedMotpart,
+            antallArbeidsgiverDelMedMotpart = agMedMotpart,
+            antallArbeidstakerDelUtenMotpart = arbeidstakerDeler.size - atMedMotpart,
+            antallArbeidsgiverDelUtenMotpart = arbeidsgiverDeler.size - agMedMotpart,
+            antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler)
+        )
+    }
+
+    /** Antall deler som overlapper med en annen gjeldende del av samme type/sak (mulig dobbeltinnsending). */
+    private fun antallDuplikater(deler: List<Del>): Long =
+        deler.filter { !it.erstattet }
+            .groupBy { it.sakNokkel() }
+            .values
+            .sumOf { gruppe -> gruppe.count { del -> gruppe.any { it.id != del.id && del.matcher(it) } }.toLong() }
+
+    private data class Del(
+        val id: UUID,
+        val fnr: String,
+        val juridiskEnhet: String,
+        val skjemadel: Skjemadel,
+        val periode: PeriodeDto?,
+        val erstattet: Boolean
+    ) {
+        fun sakNokkel() = fnr to juridiskEnhet
+        fun matcher(annen: Del): Boolean =
+            fnr == annen.fnr &&
+                juridiskEnhet == annen.juridiskEnhet &&
+                periode != null && annen.periode != null &&
+                periode.overlapper(annen.periode)
     }
 
     private fun hentUtkastStatistikk(naa: Instant): UtkastStatistikkDto {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -64,14 +64,14 @@ class AdminService(
         val fraGrense = fraOgMed?.atStartOfDay(OSLO)?.toInstant()
         val tilGrenseEksklusiv = tilOgMed?.plusDays(1)?.atStartOfDay(OSLO)?.toInstant()
 
-        val alleInnsendinger = innsendingRepository.finnAlleInnsendteMedSkjema()
-        // Id-er som er erstattet av en nyere versjon (på tvers av perioden), for duplikat-tellingen.
-        val erstattedeIder: Set<UUID> = alleInnsendinger
+        val iPeriode = innsendingRepository.finnAlleInnsendteMedSkjema()
+            .filter { innenfor(it.opprettetDato, fraGrense, tilGrenseEksklusiv) }
+        // Id-er som er erstattet av en nyere versjon innenfor perioden (holdes utenfor duplikat-tellingen).
+        val erstattedeIder: Set<UUID> = iPeriode
             .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
             .toSet()
 
-        val innsendt = alleInnsendinger
-            .filter { innenfor(it.opprettetDato, fraGrense, tilGrenseEksklusiv) }
+        val innsendt = iPeriode
             .mapNotNull { innsending ->
                 val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
                 InnsendtSkjema(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -2,6 +2,8 @@ package no.nav.melosys.skjema.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
@@ -15,7 +17,6 @@ import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.extensions.overlapper
 import no.nav.melosys.skjema.extensions.utsendelsePeriode
 import no.nav.melosys.skjema.repository.AdminStatistikkRepository
-import no.nav.melosys.skjema.repository.AntallPerKategori
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.types.common.SkjemaStatus
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 private val log = KotlinLogging.logger {}
+private val OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 
 /**
  * Administrative operasjoner som eksponeres via [no.nav.melosys.skjema.controller.admin.AdminController]
@@ -51,16 +53,39 @@ class AdminService(
         )
     }
 
+    /**
+     * Bruksstatistikk. Innsendt-statistikken (fordelinger, saksdekning, toppliste, unike) regnes i
+     * minnet fra innsendinger med skjema, filtrert på innsendingsdato [fraOgMed]–[tilOgMed] (begge
+     * valgfrie; null = ingen grense). Utkast og innsendt-trend er nåtilstand og påvirkes ikke av perioden.
+     */
     @Transactional(readOnly = true)
-    fun hentBruksstatistikk(): BrukStatistikkDto {
+    fun hentBruksstatistikk(fraOgMed: LocalDate?, tilOgMed: LocalDate?): BrukStatistikkDto {
         val naa = Instant.now()
+        val fraGrense = fraOgMed?.atStartOfDay(OSLO)?.toInstant()
+        val tilGrenseEksklusiv = tilOgMed?.plusDays(1)?.atStartOfDay(OSLO)?.toInstant()
 
-        val perSkjemadel = adminStatistikkRepository.antallInnsendtPerSkjemadel().tilMap()
-        val innsendtPerSkjemadel = Skjemadel.entries.associateWith { perSkjemadel[it.name] ?: 0L }
-        val perFlyt = adminStatistikkRepository.antallInnsendtPerFlyt().tilMap()
-        val innsendtPerFlyt = Representasjonstype.entries.associateWith { perFlyt[it.name] ?: 0L }
-        val perSprak = adminStatistikkRepository.antallInnsendtPerSprak().tilMap()
-        val innsendtPerSprak = Språk.entries.associateWith { perSprak[it.kode] ?: 0L }
+        val alleInnsendinger = innsendingRepository.finnAlleInnsendteMedSkjema()
+        // Id-er som er erstattet av en nyere versjon (på tvers av perioden), for duplikat-tellingen.
+        val erstattedeIder: Set<UUID> = alleInnsendinger
+            .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
+            .toSet()
+
+        val innsendt = alleInnsendinger
+            .filter { innenfor(it.opprettetDato, fraGrense, tilGrenseEksklusiv) }
+            .mapNotNull { innsending ->
+                val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+                InnsendtSkjema(
+                    id = innsending.skjema.id!!,
+                    fnr = innsending.skjema.fnr,
+                    orgnr = innsending.skjema.orgnr,
+                    juridiskEnhet = metadata.juridiskEnhetOrgnr,
+                    skjemadel = metadata.skjemadel,
+                    flyt = metadata.representasjonstype,
+                    sprak = innsending.innsendtSprak,
+                    periode = innsending.skjema.utsendelsePeriode(),
+                    erstattet = innsending.skjema.id in erstattedeIder
+                )
+            }
 
         val trend = adminStatistikkRepository.innsendtTrend(
             grense1d = naa.minus(1, ChronoUnit.DAYS),
@@ -70,48 +95,35 @@ class AdminService(
 
         return BrukStatistikkDto(
             tidspunkt = naa,
+            periodeFraOgMed = fraOgMed,
+            periodeTilOgMed = tilOgMed,
             utkast = hentUtkastStatistikk(naa),
-            totaltInnsendt = adminStatistikkRepository.antallInnsendteSkjema(),
+            totaltInnsendt = innsendt.size.toLong(),
             innsendtSisteDoegn = trend.sisteDoegn,
             innsendtSiste7Dager = trend.siste7Dager,
             innsendtSiste30Dager = trend.siste30Dager,
-            innsendtPerSkjemadel = innsendtPerSkjemadel,
-            innsendtPerFlyt = innsendtPerFlyt,
-            innsendtPerSprak = innsendtPerSprak,
-            saksdekning = beregnSaksdekning(),
-            antallUnikePersoner = adminStatistikkRepository.antallUnikePersoner(),
-            antallUnikeVirksomheter = adminStatistikkRepository.antallUnikeVirksomheter()
+            innsendtPerSkjemadel = Skjemadel.entries.associateWith { sd -> innsendt.count { it.skjemadel == sd }.toLong() },
+            innsendtPerFlyt = Representasjonstype.entries.associateWith { f -> innsendt.count { it.flyt == f }.toLong() },
+            innsendtPerSprak = Språk.entries.associateWith { sp -> innsendt.count { it.sprak == sp }.toLong() },
+            saksdekning = beregnSaksdekning(innsendt),
+            antallUnikePersoner = innsendt.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
+            antallUnikeVirksomheter = innsendt.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
+            topplisteVirksomheter = innsendt.groupingBy { it.orgnr }.eachCount().values.sortedDescending().map { it.toLong() }
         )
     }
+
+    private fun innenfor(tidspunkt: Instant, fra: Instant?, tilEksklusiv: Instant?): Boolean =
+        (fra == null || !tidspunkt.isBefore(fra)) && (tilEksklusiv == null || tidspunkt.isBefore(tilEksklusiv))
 
     /**
      * Beregner saksdekning ut fra faktiske verdier: to deler hører til samme sak når de har samme
      * fnr + samme juridiske enhet + overlappende utsendelsesperiode — samme matching som mottak
      * bruker for å gruppere relaterte deler.
      */
-    private fun beregnSaksdekning(): SaksdekningDto {
-        val alle = adminStatistikkRepository.finnAlleInnsendte()
-
-        // Id-er som er erstattet av en nyere versjon (holdes utenfor duplikat-tellingen).
-        val erstattedeIder: Set<UUID> = alle
-            .mapNotNull { (it.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
-            .toSet()
-
-        val deler = alle.mapNotNull { skjema ->
-            val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
-            Del(
-                id = skjema.id!!,
-                fnr = skjema.fnr,
-                juridiskEnhet = metadata.juridiskEnhetOrgnr,
-                skjemadel = metadata.skjemadel,
-                periode = skjema.utsendelsePeriode(),
-                erstattet = skjema.id in erstattedeIder
-            )
-        }
-
-        val antallKomplette = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong()
-        val arbeidstakerDeler = deler.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
-        val arbeidsgiverDeler = deler.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
+    private fun beregnSaksdekning(innsendt: List<InnsendtSkjema>): SaksdekningDto {
+        val antallKomplette = innsendt.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong()
+        val arbeidstakerDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+        val arbeidsgiverDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
         val arbeidstakerePerSak = arbeidstakerDeler.groupBy { it.sakNokkel() }
         val arbeidsgiverePerSak = arbeidsgiverDeler.groupBy { it.sakNokkel() }
 
@@ -122,16 +134,20 @@ class AdminService(
             arbeidstakerePerSak[ag.sakNokkel()]?.any { ag.matcher(it) } == true
         }.toLong()
 
-        // Saker (unik person + juridisk enhet) der separat at-del og ag-del overlapper.
-        val sakerMedBeggeSeparat = arbeidstakerePerSak.keys.intersect(arbeidsgiverePerSak.keys).count { nokkel ->
+        // Saker (unik person + juridisk enhet) med begge deler dekket – enten via et komplett skjema
+        // eller via separat at-del + ag-del som overlapper. Dedupliseres på sak slik at samme sak ikke
+        // telles flere ganger om den har både komplett skjema og separate deler.
+        val komplettSaker = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+            .mapTo(mutableSetOf()) { it.sakNokkel() }
+        val separateSaker = arbeidstakerePerSak.keys.intersect(arbeidsgiverePerSak.keys).filterTo(mutableSetOf()) { nokkel ->
             val ats = arbeidstakerePerSak.getValue(nokkel)
             val ags = arbeidsgiverePerSak.getValue(nokkel)
             ats.any { at -> ags.any { at.matcher(it) } }
-        }.toLong()
+        }
 
         return SaksdekningDto(
             antallKomplette = antallKomplette,
-            antallSakerMedBeggeDeler = antallKomplette + sakerMedBeggeSeparat,
+            antallSakerMedBeggeDeler = (komplettSaker + separateSaker).size.toLong(),
             antallArbeidstakerDelMedMotpart = atMedMotpart,
             antallArbeidsgiverDelMedMotpart = agMedMotpart,
             antallArbeidstakerDelUtenMotpart = arbeidstakerDeler.size - atMedMotpart,
@@ -141,22 +157,25 @@ class AdminService(
     }
 
     /** Antall deler som overlapper med en annen gjeldende del av samme type/sak (mulig dobbeltinnsending). */
-    private fun antallDuplikater(deler: List<Del>): Long =
+    private fun antallDuplikater(deler: List<InnsendtSkjema>): Long =
         deler.filter { !it.erstattet }
             .groupBy { it.sakNokkel() }
             .values
             .sumOf { gruppe -> gruppe.count { del -> gruppe.any { it.id != del.id && del.matcher(it) } }.toLong() }
 
-    private data class Del(
+    private data class InnsendtSkjema(
         val id: UUID,
         val fnr: String,
+        val orgnr: String,
         val juridiskEnhet: String,
         val skjemadel: Skjemadel,
+        val flyt: Representasjonstype,
+        val sprak: Språk,
         val periode: PeriodeDto?,
         val erstattet: Boolean
     ) {
         fun sakNokkel() = fnr to juridiskEnhet
-        fun matcher(annen: Del): Boolean =
+        fun matcher(annen: InnsendtSkjema): Boolean =
             fnr == annen.fnr &&
                 juridiskEnhet == annen.juridiskEnhet &&
                 periode != null && annen.periode != null &&
@@ -178,9 +197,6 @@ class AdminService(
             eldsteOpprettetDato = adminStatistikkRepository.eldsteUtkastOpprettetDato()
         )
     }
-
-    private fun List<AntallPerKategori>.tilMap(): Map<String, Long> =
-        filter { it.kategori != null }.associate { it.kategori!! to it.antall }
 
     @Transactional(readOnly = true)
     fun hentFeiledeInnsendinger(): List<InnsendingAdminDto> =

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -274,18 +274,21 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         private val periodeOverlapp = PeriodeDto(LocalDate.parse("2026-03-01"), LocalDate.parse("2026-08-31"))
         private val periodeSenere = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-12-31"))
 
-        /** Lager et innsendt (SENDT) skjema med full kontroll på fnr, juridisk enhet, del og periode. */
+        /** Lager et innsendt (SENDT) skjema med full kontroll på fnr, virksomhet, del, periode og innsendingsdato. */
         private fun lagInnsendt(
             skjemadel: Skjemadel,
             fnr: String = "10000000001",
-            juridiskEnhet: String = korrektSyntetiskOrgnr,
+            orgnr: String = korrektSyntetiskOrgnr,
+            juridiskEnhet: String = orgnr,
             periode: PeriodeDto = periodeA,
             representasjonstype: Representasjonstype = Representasjonstype.DEG_SELV,
             sprak: Språk = Språk.NORSK_BOKMAL,
-            erstatterSkjemaId: UUID? = null
+            erstatterSkjemaId: UUID? = null,
+            innsendtDato: Instant = Instant.now()
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
+                orgnr = orgnr,
                 status = SkjemaStatus.SENDT,
                 data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(
                     utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = periode)
@@ -298,11 +301,16 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 )
             )
         ).also { skjema ->
-            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak))
+            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, opprettetDato = innsendtDato))
         }
 
-        private fun hentBruk(): BrukStatistikkDto =
-            adminClient.get().uri("/admin/statistikk/bruk")
+        private fun hentBruk(fraOgMed: String? = null, tilOgMed: String? = null): BrukStatistikkDto =
+            adminClient.get().uri { b ->
+                b.path("/admin/statistikk/bruk")
+                fraOgMed?.let { b.queryParam("fraOgMed", it) }
+                tilOgMed?.let { b.queryParam("tilOgMed", it) }
+                b.build()
+            }
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -370,6 +378,18 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
+        fun `saksdekning - samme sak med komplett og separate deler telles kun en gang`() {
+            val fnr = "50000000001"
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = fnr)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = periodeOverlapp)
+
+            val s = hentBruk().saksdekning
+            s.antallKomplette shouldBe 1
+            s.antallSakerMedBeggeDeler shouldBe 1 // samme (fnr, juridisk enhet) – ikke dobbelttalt
+        }
+
+        @Test
         fun `saksdekning - mulige dobbeltinnsendinger, men ikke versjon-erstatninger`() {
             // Ekte dobbeltinnsending: samme person sender arbeidsgivers del to ganger, overlappende periode
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "30000000001", periode = periodeA)
@@ -403,6 +423,27 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             body.saksdekning.antallSakerMedBeggeDeler shouldBe 0
             body.saksdekning.antallMuligeDobbeltinnsendinger shouldBe 0
             body.utkast.eldsteOpprettetDato shouldBe null
+        }
+
+        @Test
+        fun `skal filtrere innsendt-statistikk paa innsendingsperiode`() {
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "60000000001", innsendtDato = Instant.parse("2026-01-15T10:00:00Z"))
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "60000000002", innsendtDato = Instant.parse("2026-03-15T10:00:00Z"))
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "60000000003", innsendtDato = Instant.parse("2026-06-15T10:00:00Z"))
+
+            hentBruk().totaltInnsendt shouldBe 3 // ingen grense = alt
+            hentBruk(fraOgMed = "2026-02-01", tilOgMed = "2026-04-30").totaltInnsendt shouldBe 1 // kun mars
+            hentBruk(fraOgMed = "2026-02-01").totaltInnsendt shouldBe 2 // mars + juni
+            hentBruk(tilOgMed = "2026-02-01").totaltInnsendt shouldBe 1 // kun januar
+        }
+
+        @Test
+        fun `toppliste viser anonyme antall per virksomhet sortert synkende`() {
+            repeat(3) { i -> lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "7000000000$i", orgnr = "910000001") }
+            repeat(2) { i -> lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "7100000000$i", orgnr = "910000002") }
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "72000000001", orgnr = "910000003")
+
+            hentBruk().topplisteVirksomheter shouldBe listOf(3L, 2L, 1L)
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -7,14 +7,16 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.verify
 import java.time.Instant
+import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.ApiTestBase
 import no.nav.melosys.skjema.adminTokenMedTilgang
 import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.domain.InnsendingStatus
-import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
+import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.innsendingMedDefaultVerdier
+import no.nav.melosys.skjema.korrektSyntetiskOrgnr
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
@@ -23,9 +25,11 @@ import no.nav.melosys.skjema.sikkerhet.AdminApiKeyInterceptor.Companion.API_KEY_
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.felles.PeriodeDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
-import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
+import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -266,55 +270,39 @@ class AdminControllerIntegrationTest : ApiTestBase() {
     @DisplayName("GET /admin/statistikk/bruk")
     inner class Bruksstatistikk {
 
-        private fun lagInnsendtSkjema(
-            representasjonstype: Representasjonstype,
+        private val periodeA = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-06-30"))
+        private val periodeOverlapp = PeriodeDto(LocalDate.parse("2026-03-01"), LocalDate.parse("2026-08-31"))
+        private val periodeSenere = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-12-31"))
+
+        /** Lager et innsendt (SENDT) skjema med full kontroll på fnr, juridisk enhet, del og periode. */
+        private fun lagInnsendt(
             skjemadel: Skjemadel,
+            fnr: String = "10000000001",
+            juridiskEnhet: String = korrektSyntetiskOrgnr,
+            periode: PeriodeDto = periodeA,
+            representasjonstype: Representasjonstype = Representasjonstype.DEG_SELV,
             sprak: Språk = Språk.NORSK_BOKMAL,
-            kobletSkjemaId: UUID? = null,
-            fnr: String = no.nav.melosys.skjema.korrektSyntetiskFnr,
-            referanseId: String
-        ) = skjemaRepository.save(
+            erstatterSkjemaId: UUID? = null
+        ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
                 status = SkjemaStatus.SENDT,
-                data = arbeidstakersSkjemaDataDtoMedDefaultVerdier(),
+                data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(
+                    utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = periode)
+                ),
                 metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
                     representasjonstype = representasjonstype,
                     skjemadel = skjemadel,
-                    kobletSkjemaId = kobletSkjemaId
+                    juridiskEnhetOrgnr = juridiskEnhet,
+                    erstatterSkjemaId = erstatterSkjemaId
                 )
             )
         ).also { skjema ->
-            innsendingRepository.save(
-                innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, referanseId = referanseId)
-            )
+            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak))
         }
 
-        @Test
-        fun `skal aggregere utkast, innsendte per skjemadel-flyt-spraak, koblinger og unike`() {
-            // Utkast: ett ferskt og ett gammelt (>30 dager)
-            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = Instant.now()))
-            val gammeltUtkastDato = Instant.now().minus(40, ChronoUnit.DAYS)
-            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = gammeltUtkastDato))
-
-            // Innsendte enkeltdeler
-            lagInnsendtSkjema(Representasjonstype.DEG_SELV, Skjemadel.ARBEIDSTAKERS_DEL, Språk.NORSK_BOKMAL, referanseId = "AA0001")
-            lagInnsendtSkjema(Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL, Språk.ENGELSK, fnr = etAnnetKorrektSyntetiskFnr, referanseId = "AA0002")
-
-            // Komplett innsending (begge deler i én)
-            lagInnsendtSkjema(Representasjonstype.RADGIVER, Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, referanseId = "AA0003")
-
-            // Koblet par: arbeidsgivers del + arbeidstakers del sendt hver for seg
-            val arbeidstakerDel = lagInnsendtSkjema(Representasjonstype.DEG_SELV, Skjemadel.ARBEIDSTAKERS_DEL, referanseId = "AA0004")
-            val arbeidsgiverDel = lagInnsendtSkjema(
-                Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL,
-                kobletSkjemaId = arbeidstakerDel.id, referanseId = "AA0005"
-            )
-            arbeidstakerDel.metadata =
-                (arbeidstakerDel.metadata as UtsendtArbeidstakerMetadata).medKobletSkjemaId(arbeidsgiverDel.id)
-            skjemaRepository.save(arbeidstakerDel)
-
-            val body = adminClient.get().uri("/admin/statistikk/bruk")
+        private fun hentBruk(): BrukStatistikkDto =
+            adminClient.get().uri("/admin/statistikk/bruk")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
@@ -322,56 +310,98 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 .expectBody<BrukStatistikkDto>()
                 .returnResult().responseBody.shouldNotBeNull()
 
-            // Utkast med aldersfordeling
+        @Test
+        fun `skal aggregere utkast, innsendte per skjemadel-flyt-spraak, trend og unike`() {
+            // Utkast: ett ferskt og ett gammelt (>30 dager)
+            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = Instant.now()))
+            skjemaRepository.save(skjemaMedDefaultVerdier(status = SkjemaStatus.UTKAST, opprettetDato = Instant.now().minus(40, ChronoUnit.DAYS)))
+
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "10000000001", representasjonstype = Representasjonstype.DEG_SELV)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "10000000002", representasjonstype = Representasjonstype.ARBEIDSGIVER, sprak = Språk.ENGELSK)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "10000000003", representasjonstype = Representasjonstype.RADGIVER)
+
+            val body = hentBruk()
+
             body.utkast.antall shouldBe 2
             body.utkast.under1Dag shouldBe 1
             body.utkast.over30Dager shouldBe 1
             body.utkast.mellom1Og7Dager shouldBe 0
             body.utkast.eldsteOpprettetDato.shouldNotBeNull()
 
-            // Innsendte totalt og per skjemadel (5 SENDT skjema)
-            body.totaltInnsendt shouldBe 5
-            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 2
-            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVERS_DEL] shouldBe 2
+            body.totaltInnsendt shouldBe 3
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 1
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVERS_DEL] shouldBe 1
             body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] shouldBe 1
 
-            // Per flyt
-            body.innsendtPerFlyt[Representasjonstype.DEG_SELV] shouldBe 2
-            body.innsendtPerFlyt[Representasjonstype.ARBEIDSGIVER] shouldBe 2
+            body.innsendtPerFlyt[Representasjonstype.DEG_SELV] shouldBe 1
+            body.innsendtPerFlyt[Representasjonstype.ARBEIDSGIVER] shouldBe 1
             body.innsendtPerFlyt[Representasjonstype.RADGIVER] shouldBe 1
             body.innsendtPerFlyt[Representasjonstype.ANNEN_PERSON] shouldBe 0
 
-            // Per språk (4 nb, 1 en)
-            body.innsendtPerSprak[Språk.NORSK_BOKMAL] shouldBe 4
+            body.innsendtPerSprak[Språk.NORSK_BOKMAL] shouldBe 2
             body.innsendtPerSprak[Språk.ENGELSK] shouldBe 1
 
-            // Koblinger: 1 komplett + 1 koblet par = 2 saker med begge deler
-            body.antallKomplettInnsendt shouldBe 1
-            body.antallKobledePar shouldBe 1
-            body.antallSakerMedBeggeDeler shouldBe 2
-
-            // Trend: alle innsendinger er ferske
-            body.innsendtSisteDoegn shouldBe 5
-
-            // Unike: to ulike fnr, én virksomhet (default orgnr)
-            body.antallUnikePersoner shouldBe 2
+            body.innsendtSisteDoegn shouldBe 3
+            body.antallUnikePersoner shouldBe 3
             body.antallUnikeVirksomheter shouldBe 1
         }
 
         @Test
+        fun `saksdekning - komplett, matchende separate deler og uten motpart`() {
+            // Komplett (begge deler i ett)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "20000000001")
+            // Sak med begge deler hver for seg (samme person + enhet + overlappende periode)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "20000000002", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "20000000002", periode = periodeOverlapp)
+            // Kun arbeidstaker-del (ingen motpart)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "20000000003")
+            // Kun arbeidsgiver-del (ingen motpart)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "20000000004")
+
+            val s = hentBruk().saksdekning
+
+            s.antallKomplette shouldBe 1
+            s.antallSakerMedBeggeDeler shouldBe 2 // 1 komplett + 1 matchende separat sak
+            s.antallArbeidstakerDelMedMotpart shouldBe 1
+            s.antallArbeidsgiverDelMedMotpart shouldBe 1
+            s.antallArbeidstakerDelUtenMotpart shouldBe 1
+            s.antallArbeidsgiverDelUtenMotpart shouldBe 1
+            s.antallMuligeDobbeltinnsendinger shouldBe 0
+        }
+
+        @Test
+        fun `saksdekning - mulige dobbeltinnsendinger, men ikke versjon-erstatninger`() {
+            // Ekte dobbeltinnsending: samme person sender arbeidsgivers del to ganger, overlappende periode
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "30000000001", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "30000000001", periode = periodeOverlapp)
+
+            // Versjon-erstatning: ny arbeidstaker-del erstatter en eldre (skal IKKE telles som duplikat)
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "30000000002", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "30000000002", periode = periodeOverlapp, erstatterSkjemaId = gammel.id)
+
+            hentBruk().saksdekning.antallMuligeDobbeltinnsendinger shouldBe 2
+        }
+
+        @Test
+        fun `saksdekning - ikke-overlappende periode gir ikke match`() {
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "40000000001", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "40000000001", periode = periodeSenere)
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedBeggeDeler shouldBe 0
+            s.antallArbeidstakerDelUtenMotpart shouldBe 1
+            s.antallArbeidsgiverDelUtenMotpart shouldBe 1
+        }
+
+        @Test
         fun `skal returnere nuller naar ingen data`() {
-            val body = adminClient.get().uri("/admin/statistikk/bruk")
-                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk
-                .expectBody<BrukStatistikkDto>()
-                .returnResult().responseBody.shouldNotBeNull()
+            val body = hentBruk()
 
             body.utkast.antall shouldBe 0
             body.totaltInnsendt shouldBe 0
             body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 0
-            body.antallSakerMedBeggeDeler shouldBe 0
+            body.saksdekning.antallSakerMedBeggeDeler shouldBe 0
+            body.saksdekning.antallMuligeDobbeltinnsendinger shouldBe 0
             body.utkast.eldsteOpprettetDato shouldBe null
         }
 


### PR DESCRIPTION
Bygger ut bruksstatistikken (`GET /admin/statistikk/bruk`) for å lære mer av hvordan skjemaene brukes.

- **Verdibasert saksdekning**: «Saker med begge deler» regnes fra faktiske verdier (samme fnr + juridisk enhet + overlappende periode) — samme matching som mottak bruker — i stedet for `kobletSkjemaId`-flagget. Dedupliseres på (person, juridisk enhet). Inkluderer del-med/uten-motpart og mulige dobbeltinnsendinger (versjon-erstatninger holdt utenfor).
- **Periodefilter**: innsendt-statistikken kan avgrenses på innsendingsdato (`fraOgMed`/`tilOgMed`, begge valgfrie; utelat = alt). Utkast og trend er nåtilstand og påvirkes ikke.
- **Anonym toppliste** over mest aktive virksomheter: kun rangerte tall, ingen orgnr/navn.
- Innsendt-statistikken regnes i minnet fra innsendinger med skjema (kjøres sjelden, liten datamengde).

Kun aggregerte tall — ingen personopplysninger eksponeres.

GUI ligger i egen PR i `melosys-console`. Full `kobletSkjema`-opprydding tas separat etter at MELOSYS-8092 er merget.
