### PR TITLE
Utvid bruksstatistikk: venter-trakt, versjoner, toppliste-detaljer

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -78,10 +78,10 @@ data class BrukStatistikkDto(
     /** Unike virksomheter (orgnr) blant innsendte skjema. */
     val antallUnikeVirksomheter: Long,
     /**
-     * Anonym toppliste over de mest aktive virksomhetene: antall innsendte skjema per virksomhet,
-     * sortert synkende. Inneholder bevisst kun tallene (rang 1, 2, 3 ...), ikke orgnr eller navn.
+     * Anonym toppliste over de mest aktive virksomhetene, sortert synkende på antall innsendinger.
+     * Inneholder bevisst kun tall (rang 1, 2, 3 ...), ikke orgnr eller navn.
      */
-    val topplisteVirksomheter: List<Long>
+    val topplisteVirksomheter: List<VirksomhetStatistikkDto>
 )
 
 /**
@@ -100,20 +100,51 @@ data class SaksdekningDto(
      * periode). Samme sak telles kun én gang selv om den har både komplett skjema og separate deler.
      */
     val antallSakerMedBeggeDeler: Long,
-    /** Separate arbeidstaker-deler som har en matchende arbeidsgiver-del. */
-    val antallArbeidstakerDelMedMotpart: Long,
-    /** Separate arbeidsgiver-deler som har en matchende arbeidstaker-del. */
-    val antallArbeidsgiverDelMedMotpart: Long,
-    /** Arbeidstaker-deler som (ennå) mangler en matchende arbeidsgiver-del. */
-    val antallArbeidstakerDelUtenMotpart: Long,
-    /** Arbeidsgiver-deler som (ennå) mangler en matchende arbeidstaker-del. */
-    val antallArbeidsgiverDelUtenMotpart: Long,
+    /** Status for separate arbeidstaker-deler (med motpart / venter). */
+    val arbeidstakerDeler: DelStatusDto,
+    /** Status for separate arbeidsgiver-deler (med motpart / venter). */
+    val arbeidsgiverDeler: DelStatusDto,
     /**
      * Mulige dobbeltinnsendinger: samme person har sendt samme del for samme juridiske enhet med
      * overlappende periode flere ganger. Versjons-erstatninger (erstatterSkjemaId) er holdt utenfor,
      * så dette er ekte mulige duplikater – ikke nye versjoner av samme søknad.
      */
-    val antallMuligeDobbeltinnsendinger: Long
+    val antallMuligeDobbeltinnsendinger: Long,
+    /**
+     * Antall saker der minst én del er sendt i flere versjoner (samme person + juridisk enhet + del
+     * sendt mer enn én gang). Inkluderer versjons-erstatninger – altså saker med «mer enn to deler».
+     */
+    val antallSakerMedFlereVersjoner: Long
+)
+
+/**
+ * Status for en deltype (arbeidstaker- eller arbeidsgiver-deler) som er sendt hver for seg. Viser om
+ * delen har en matchende motpart, og for de som venter: om motparten har påbegynt et utkast eller ikke.
+ */
+data class DelStatusDto(
+    /** Totalt antall separate deler av denne typen. */
+    val totalt: Long,
+    /** Har en matchende, innsendt motpart (samme person + juridisk enhet + overlappende periode). */
+    val medMotpart: Long,
+    /** Mangler innsendt motpart, men motparten har påbegynt et utkast (under arbeid). */
+    val venterMotpartHarUtkast: Long,
+    /** Mangler motpart helt – verken innsendt eller påbegynt utkast. */
+    val venterIngenMotpart: Long
+)
+
+/**
+ * Anonym statistikk for én virksomhet i topplisten – kun tall, ingen orgnr eller navn. Brukerne
+ * (innsendere) kan være flere personer som jobber for samme virksomhet.
+ */
+data class VirksomhetStatistikkDto(
+    val antallInnsendinger: Long,
+    /** Antall unike innsendere (personer som har sendt inn) for virksomheten. */
+    val antallUnikeInnsendere: Long,
+    val antallArbeidstakerDel: Long,
+    val antallArbeidsgiverDel: Long,
+    val antallKomplett: Long,
+    /** Saker (person + juridisk enhet) i virksomheten der begge deler er dekket. */
+    val antallSakerMedBeggeDeler: Long
 )
 
 /**
@@ -127,5 +158,7 @@ data class UtkastStatistikkDto(
     val mellom7Og30Dager: Long,
     val over30Dager: Long,
     /** Opprettelsestidspunkt for det eldste utkastet, eller null hvis ingen utkast finnes. */
-    val eldsteOpprettetDato: Instant?
+    val eldsteOpprettetDato: Instant?,
+    /** Påbegynte utkast fordelt på del – viser hvor folk starter, men (ennå) ikke har sendt inn. */
+    val perSkjemadel: Map<Skjemadel, Long>
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/AdminStatistikkRepository.kt
@@ -52,6 +52,14 @@ interface AdminStatistikkRepository : Repository<Skjema, UUID> {
     @Query("SELECT MIN(s.opprettetDato) FROM Skjema s WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.UTKAST")
     fun eldsteUtkastOpprettetDato(): Instant?
 
+    /** Alle påbegynte utkast – brukes til å se om motparten til en ventende del har startet et utkast. */
+    @Query(
+        "SELECT s FROM Skjema s " +
+            "WHERE s.status = no.nav.melosys.skjema.types.common.SkjemaStatus.UTKAST " +
+            "AND s.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
+    )
+    fun finnAlleUtkast(): List<Skjema>
+
     /** Innsendingstrend: kumulativt antall innsendinger i siste døgn / 7 / 30 dager (ett snapshot). */
     @Query(
         nativeQuery = true,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -8,10 +8,12 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
 import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
+import no.nav.melosys.skjema.controller.admin.DelStatusDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
 import no.nav.melosys.skjema.controller.admin.SaksdekningDto
 import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
+import no.nav.melosys.skjema.controller.admin.VirksomhetStatistikkDto
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.extensions.overlapper
@@ -71,21 +73,26 @@ class AdminService(
             .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
             .toSet()
 
-        val innsendt = iPeriode
-            .mapNotNull { innsending ->
-                val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
-                InnsendtSkjema(
-                    id = innsending.skjema.id!!,
-                    fnr = innsending.skjema.fnr,
-                    orgnr = innsending.skjema.orgnr,
-                    juridiskEnhet = metadata.juridiskEnhetOrgnr,
-                    skjemadel = metadata.skjemadel,
-                    flyt = metadata.representasjonstype,
-                    sprak = innsending.innsendtSprak,
-                    periode = innsending.skjema.utsendelsePeriode(),
-                    erstattet = innsending.skjema.id in erstattedeIder
-                )
-            }
+        val innsendt = iPeriode.mapNotNull { innsending ->
+            val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+            InnsendtSkjema(
+                id = innsending.skjema.id!!,
+                fnr = innsending.skjema.fnr,
+                orgnr = innsending.skjema.orgnr,
+                innsenderFnr = innsending.innsenderFnr,
+                juridiskEnhet = metadata.juridiskEnhetOrgnr,
+                skjemadel = metadata.skjemadel,
+                flyt = metadata.representasjonstype,
+                sprak = innsending.innsendtSprak,
+                periode = innsending.skjema.utsendelsePeriode(),
+                erstattet = innsending.skjema.id in erstattedeIder
+            )
+        }
+
+        val utkast = adminStatistikkRepository.finnAlleUtkast().mapNotNull { skjema ->
+            val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+            UtkastSkjema(skjema.fnr, metadata.juridiskEnhetOrgnr, metadata.skjemadel, skjema.utsendelsePeriode())
+        }
 
         val trend = adminStatistikkRepository.innsendtTrend(
             grense1d = naa.minus(1, ChronoUnit.DAYS),
@@ -97,7 +104,7 @@ class AdminService(
             tidspunkt = naa,
             periodeFraOgMed = fraOgMed,
             periodeTilOgMed = tilOgMed,
-            utkast = hentUtkastStatistikk(naa),
+            utkast = hentUtkastStatistikk(naa, utkast),
             totaltInnsendt = innsendt.size.toLong(),
             innsendtSisteDoegn = trend.sisteDoegn,
             innsendtSiste7Dager = trend.siste7Dager,
@@ -105,10 +112,10 @@ class AdminService(
             innsendtPerSkjemadel = Skjemadel.entries.associateWith { sd -> innsendt.count { it.skjemadel == sd }.toLong() },
             innsendtPerFlyt = Representasjonstype.entries.associateWith { f -> innsendt.count { it.flyt == f }.toLong() },
             innsendtPerSprak = Språk.entries.associateWith { sp -> innsendt.count { it.sprak == sp }.toLong() },
-            saksdekning = beregnSaksdekning(innsendt),
+            saksdekning = beregnSaksdekning(innsendt, utkast),
             antallUnikePersoner = innsendt.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
             antallUnikeVirksomheter = innsendt.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
-            topplisteVirksomheter = innsendt.groupingBy { it.orgnr }.eachCount().values.sortedDescending().map { it.toLong() }
+            topplisteVirksomheter = beregnToppliste(innsendt)
         )
     }
 
@@ -118,43 +125,68 @@ class AdminService(
     /**
      * Beregner saksdekning ut fra faktiske verdier: to deler hører til samme sak når de har samme
      * fnr + samme juridiske enhet + overlappende utsendelsesperiode — samme matching som mottak
-     * bruker for å gruppere relaterte deler.
+     * bruker for å gruppere relaterte deler. For ventende deler ses det også mot påbegynte utkast.
      */
-    private fun beregnSaksdekning(innsendt: List<InnsendtSkjema>): SaksdekningDto {
-        val antallKomplette = innsendt.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong()
+    private fun beregnSaksdekning(innsendt: List<InnsendtSkjema>, utkast: List<UtkastSkjema>): SaksdekningDto {
         val arbeidstakerDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
         val arbeidsgiverDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
         val arbeidstakerePerSak = arbeidstakerDeler.groupBy { it.sakNokkel() }
         val arbeidsgiverePerSak = arbeidsgiverDeler.groupBy { it.sakNokkel() }
-
-        val atMedMotpart = arbeidstakerDeler.count { at ->
-            arbeidsgiverePerSak[at.sakNokkel()]?.any { at.matcher(it) } == true
-        }.toLong()
-        val agMedMotpart = arbeidsgiverDeler.count { ag ->
-            arbeidstakerePerSak[ag.sakNokkel()]?.any { ag.matcher(it) } == true
-        }.toLong()
-
-        // Saker (unik person + juridisk enhet) med begge deler dekket – enten via et komplett skjema
-        // eller via separat at-del + ag-del som overlapper. Dedupliseres på sak slik at samme sak ikke
-        // telles flere ganger om den har både komplett skjema og separate deler.
-        val komplettSaker = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
-            .mapTo(mutableSetOf()) { it.sakNokkel() }
-        val separateSaker = arbeidstakerePerSak.keys.intersect(arbeidsgiverePerSak.keys).filterTo(mutableSetOf()) { nokkel ->
-            val ats = arbeidstakerePerSak.getValue(nokkel)
-            val ags = arbeidsgiverePerSak.getValue(nokkel)
-            ats.any { at -> ags.any { at.matcher(it) } }
-        }
+        val utkastArbeidstakerPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
+        val utkastArbeidsgiverPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
 
         return SaksdekningDto(
-            antallKomplette = antallKomplette,
-            antallSakerMedBeggeDeler = (komplettSaker + separateSaker).size.toLong(),
-            antallArbeidstakerDelMedMotpart = atMedMotpart,
-            antallArbeidsgiverDelMedMotpart = agMedMotpart,
-            antallArbeidstakerDelUtenMotpart = arbeidstakerDeler.size - atMedMotpart,
-            antallArbeidsgiverDelUtenMotpart = arbeidsgiverDeler.size - agMedMotpart,
-            antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler)
+            antallKomplette = innsendt.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
+            antallSakerMedBeggeDeler = antallSakerMedBeggeDeler(innsendt),
+            arbeidstakerDeler = delStatus(arbeidstakerDeler, arbeidsgiverePerSak, utkastArbeidsgiverPerSak),
+            arbeidsgiverDeler = delStatus(arbeidsgiverDeler, arbeidstakerePerSak, utkastArbeidstakerPerSak),
+            antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler),
+            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(innsendt)
         )
     }
+
+    /**
+     * Status for en deltype: har en innsendt motpart (overlappende periode), eller venter.
+     * For de som venter skilles det på om motparten har påbegynt et utkast (samme person + virksomhet)
+     * eller om det ikke finnes noe motpart i det hele tatt.
+     */
+    private fun delStatus(
+        deler: List<InnsendtSkjema>,
+        motpartSendtPerSak: Map<Pair<String, String>, List<InnsendtSkjema>>,
+        motpartUtkastPerSak: Map<Pair<String, String>, List<UtkastSkjema>>
+    ): DelStatusDto {
+        var medMotpart = 0L
+        var venterMotpartHarUtkast = 0L
+        var venterIngenMotpart = 0L
+        for (del in deler) {
+            when {
+                motpartSendtPerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> medMotpart++
+                motpartUtkastPerSak[del.sakNokkel()]?.isNotEmpty() == true -> venterMotpartHarUtkast++
+                else -> venterIngenMotpart++
+            }
+        }
+        return DelStatusDto(deler.size.toLong(), medMotpart, venterMotpartHarUtkast, venterIngenMotpart)
+    }
+
+    /** Saker (person + juridisk enhet) der begge deler er dekket – komplett eller matchende separate deler. */
+    private fun antallSakerMedBeggeDeler(innsendt: List<InnsendtSkjema>): Long {
+        val komplettSaker = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+            .mapTo(mutableSetOf()) { it.sakNokkel() }
+        val ats = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
+        val ags = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
+        val separateSaker = ats.keys.intersect(ags.keys).filterTo(mutableSetOf()) { nokkel ->
+            ats.getValue(nokkel).any { at -> ags.getValue(nokkel).any { at.matcher(it) } }
+        }
+        return (komplettSaker + separateSaker).size.toLong()
+    }
+
+    /** Saker der minst én deltype er sendt i flere overlappende versjoner (inkl. erstatninger). */
+    private fun antallSakerMedFlereVersjoner(innsendt: List<InnsendtSkjema>): Long =
+        innsendt.groupBy { it.sakNokkel() }.count { (_, saksdeler) ->
+            saksdeler.groupBy { it.skjemadel }.values.any { sammeDel ->
+                sammeDel.any { del -> sammeDel.any { it.id != del.id && del.matcher(it) } }
+            }
+        }.toLong()
 
     /** Antall deler som overlapper med en annen gjeldende del av samme type/sak (mulig dobbeltinnsending). */
     private fun antallDuplikater(deler: List<InnsendtSkjema>): Long =
@@ -163,26 +195,55 @@ class AdminService(
             .values
             .sumOf { gruppe -> gruppe.count { del -> gruppe.any { it.id != del.id && del.matcher(it) } }.toLong() }
 
+    /** Anonym toppliste per virksomhet (orgnr), sortert synkende på antall innsendinger. */
+    private fun beregnToppliste(innsendt: List<InnsendtSkjema>): List<VirksomhetStatistikkDto> =
+        innsendt.groupBy { it.orgnr }.values
+            .map { deler ->
+                VirksomhetStatistikkDto(
+                    antallInnsendinger = deler.size.toLong(),
+                    antallUnikeInnsendere = deler.mapTo(mutableSetOf()) { it.innsenderFnr }.size.toLong(),
+                    antallArbeidstakerDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.toLong(),
+                    antallArbeidsgiverDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.toLong(),
+                    antallKomplett = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
+                    antallSakerMedBeggeDeler = antallSakerMedBeggeDeler(deler)
+                )
+            }
+            .sortedByDescending { it.antallInnsendinger }
+
+    private interface SakDel {
+        val fnr: String
+        val juridiskEnhet: String
+        val periode: PeriodeDto?
+    }
+
+    private fun SakDel.sakNokkel(): Pair<String, String> = fnr to juridiskEnhet
+    private fun SakDel.matcher(annen: SakDel): Boolean {
+        val minPeriode = periode ?: return false
+        val annenPeriode = annen.periode ?: return false
+        return fnr == annen.fnr && juridiskEnhet == annen.juridiskEnhet && minPeriode.overlapper(annenPeriode)
+    }
+
     private data class InnsendtSkjema(
         val id: UUID,
-        val fnr: String,
+        override val fnr: String,
         val orgnr: String,
-        val juridiskEnhet: String,
+        val innsenderFnr: String,
+        override val juridiskEnhet: String,
         val skjemadel: Skjemadel,
         val flyt: Representasjonstype,
         val sprak: Språk,
-        val periode: PeriodeDto?,
+        override val periode: PeriodeDto?,
         val erstattet: Boolean
-    ) {
-        fun sakNokkel() = fnr to juridiskEnhet
-        fun matcher(annen: InnsendtSkjema): Boolean =
-            fnr == annen.fnr &&
-                juridiskEnhet == annen.juridiskEnhet &&
-                periode != null && annen.periode != null &&
-                periode.overlapper(annen.periode)
-    }
+    ) : SakDel
 
-    private fun hentUtkastStatistikk(naa: Instant): UtkastStatistikkDto {
+    private data class UtkastSkjema(
+        override val fnr: String,
+        override val juridiskEnhet: String,
+        val skjemadel: Skjemadel,
+        override val periode: PeriodeDto?
+    ) : SakDel
+
+    private fun hentUtkastStatistikk(naa: Instant, utkast: List<UtkastSkjema>): UtkastStatistikkDto {
         val fordeling = adminStatistikkRepository.utkastAldersfordeling(
             grense1d = naa.minus(1, ChronoUnit.DAYS),
             grense7d = naa.minus(7, ChronoUnit.DAYS),
@@ -194,7 +255,8 @@ class AdminService(
             mellom1Og7Dager = fordeling.mellom1Og7Dager,
             mellom7Og30Dager = fordeling.mellom7Og30Dager,
             over30Dager = fordeling.over30Dager,
-            eldsteOpprettetDato = adminStatistikkRepository.eldsteUtkastOpprettetDato()
+            eldsteOpprettetDato = adminStatistikkRepository.eldsteUtkastOpprettetDato(),
+            perSkjemadel = Skjemadel.entries.associateWith { sd -> utkast.count { it.skjemadel == sd }.toLong() }
         )
     }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -147,8 +147,12 @@ class AdminService(
 
     /**
      * Status for en deltype: har en innsendt motpart (overlappende periode), eller venter.
-     * For de som venter skilles det på om motparten har påbegynt et utkast (samme person + virksomhet)
-     * eller om det ikke finnes noe motpart i det hele tatt.
+     * For de som venter skilles det på om motparten har påbegynt et utkast eller ikke.
+     *
+     * Merk – med vilje to ulike matchekriterier:
+     * - innsendt motpart krever overlappende periode (en reell, fullført sak).
+     * - utkast-motpart matcher kun på samme person + juridisk enhet (ikke periode), fordi et utkast
+     *   under arbeid ofte ikke har fylt inn periode ennå. Hensikten er «har motparten startet noe».
      */
     private fun delStatus(
         deler: List<InnsendtSkjema>,
@@ -161,6 +165,7 @@ class AdminService(
         for (del in deler) {
             when {
                 motpartSendtPerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> medMotpart++
+                // Bevisst kun person + juridisk enhet (ikke periode): se kommentar over.
                 motpartUtkastPerSak[del.sakNokkel()]?.isNotEmpty() == true -> venterMotpartHarUtkast++
                 else -> venterIngenMotpart++
             }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -284,7 +284,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             representasjonstype: Representasjonstype = Representasjonstype.DEG_SELV,
             sprak: Språk = Språk.NORSK_BOKMAL,
             erstatterSkjemaId: UUID? = null,
-            innsendtDato: Instant = Instant.now()
+            innsendtDato: Instant = Instant.now(),
+            innsenderFnr: String = "12345678901"
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
@@ -301,8 +302,20 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 )
             )
         ).also { skjema ->
-            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, opprettetDato = innsendtDato))
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, opprettetDato = innsendtDato, innsenderFnr = innsenderFnr)
+            )
         }
+
+        /** Lager et påbegynt utkast (status UTKAST) for å teste venter-trakten. */
+        private fun lagUtkast(skjemadel: Skjemadel, fnr: String, juridiskEnhet: String = korrektSyntetiskOrgnr) =
+            skjemaRepository.save(
+                skjemaMedDefaultVerdier(
+                    fnr = fnr,
+                    status = SkjemaStatus.UTKAST,
+                    metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(skjemadel = skjemadel, juridiskEnhetOrgnr = juridiskEnhet)
+                )
+            )
 
         private fun hentBruk(fraOgMed: String? = null, tilOgMed: String? = null): BrukStatistikkDto =
             adminClient.get().uri { b ->
@@ -335,6 +348,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             body.utkast.over30Dager shouldBe 1
             body.utkast.mellom1Og7Dager shouldBe 0
             body.utkast.eldsteOpprettetDato.shouldNotBeNull()
+            body.utkast.perSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 2
 
             body.totaltInnsendt shouldBe 3
             body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL] shouldBe 1
@@ -370,11 +384,34 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
             s.antallKomplette shouldBe 1
             s.antallSakerMedBeggeDeler shouldBe 2 // 1 komplett + 1 matchende separat sak
-            s.antallArbeidstakerDelMedMotpart shouldBe 1
-            s.antallArbeidsgiverDelMedMotpart shouldBe 1
-            s.antallArbeidstakerDelUtenMotpart shouldBe 1
-            s.antallArbeidsgiverDelUtenMotpart shouldBe 1
+            s.arbeidstakerDeler.medMotpart shouldBe 1
+            s.arbeidsgiverDeler.medMotpart shouldBe 1
+            s.arbeidstakerDeler.venterIngenMotpart shouldBe 1 // P3, ingen motpart
+            s.arbeidsgiverDeler.venterIngenMotpart shouldBe 1 // P4, ingen motpart
             s.antallMuligeDobbeltinnsendinger shouldBe 0
+        }
+
+        @Test
+        fun `saksdekning - ventende del der motparten har paabegynt utkast`() {
+            // Arbeidsgiver har sendt sin del, men arbeidstaker har bare PÅBEGYNT et utkast
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "55000000001")
+            lagUtkast(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "55000000001")
+            // Arbeidsgiver har sendt sin del, og ingen motpart finnes (verken sendt eller utkast)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "55000000002")
+
+            val s = hentBruk().saksdekning
+            s.arbeidsgiverDeler.totalt shouldBe 2
+            s.arbeidsgiverDeler.medMotpart shouldBe 0
+            s.arbeidsgiverDeler.venterMotpartHarUtkast shouldBe 1 // har påbegynt utkast
+            s.arbeidsgiverDeler.venterIngenMotpart shouldBe 1
+        }
+
+        @Test
+        fun `saksdekning - flere versjoner av samme del telles som sak med flere versjoner`() {
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "58000000001", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "58000000001", periode = periodeOverlapp, erstatterSkjemaId = gammel.id)
+
+            hentBruk().saksdekning.antallSakerMedFlereVersjoner shouldBe 1
         }
 
         @Test
@@ -409,8 +446,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
             val s = hentBruk().saksdekning
             s.antallSakerMedBeggeDeler shouldBe 0
-            s.antallArbeidstakerDelUtenMotpart shouldBe 1
-            s.antallArbeidsgiverDelUtenMotpart shouldBe 1
+            s.arbeidstakerDeler.venterIngenMotpart shouldBe 1
+            s.arbeidsgiverDeler.venterIngenMotpart shouldBe 1
         }
 
         @Test
@@ -438,12 +475,21 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `toppliste viser anonyme antall per virksomhet sortert synkende`() {
-            repeat(3) { i -> lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "7000000000$i", orgnr = "910000001") }
-            repeat(2) { i -> lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "7100000000$i", orgnr = "910000002") }
-            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "72000000001", orgnr = "910000003")
+        fun `toppliste viser anonyme detaljer per virksomhet sortert synkende`() {
+            // Virksomhet 1: 3 innsendinger, 2 ulike innsendere, alle arbeidstaker-deler
+            repeat(3) { i ->
+                lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "7000000000$i", orgnr = "910000001", innsenderFnr = if (i == 0) "11111111111" else "22222222222")
+            }
+            repeat(2) { i -> lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "7100000000$i", orgnr = "910000002") }
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "72000000001", orgnr = "910000003")
 
-            hentBruk().topplisteVirksomheter shouldBe listOf(3L, 2L, 1L)
+            val topp = hentBruk().topplisteVirksomheter
+            topp.map { it.antallInnsendinger } shouldBe listOf(3L, 2L, 1L)
+            topp[0].antallUnikeInnsendere shouldBe 2
+            topp[0].antallArbeidstakerDel shouldBe 3
+            topp[1].antallArbeidsgiverDel shouldBe 2
+            topp[2].antallKomplett shouldBe 1
+            topp[2].antallSakerMedBeggeDeler shouldBe 1
         }
 
         @Test


### PR DESCRIPTION
Utvider bruksstatistikken med mer innsikt i hvordan A1-skjemaene faktisk brukes (oppfølging til den verdibaserte statistikken).

- **Venter-trakt**: for deler som venter på motpart skilles det nå på om motparten har *påbegynt et utkast* (i gang) eller *ikke startet* i det hele tatt – viser hvor saker stopper opp (f.eks. mange arbeidsgiver-deler uten arbeidstaker-del).
- **Saker med flere versjoner**: saker der minst én part har sendt sin del mer enn én gang («mer enn to deler»).
- **Toppliste-detaljer**: per virksomhet (fortsatt anonymt) – antall unike *innsendere* (flere personer kan jobbe for samme virksomhet), fordeling per del, og saker med begge deler.
- **Utkast per del**: hvor folk starter, men (ennå) ikke har sendt inn.

Alt er kun aggregerte tall – ingen personopplysninger, og topplisten er anonym. GUI i egen PR i `melosys-console`.
