### PR TITLE
8160: Bestill ekstern SMS-varsling for varsel til arbeidstaker

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerKafka.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerKafka.kt
@@ -5,6 +5,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
 import no.nav.melosys.skjema.kafka.exception.SendBrukervarselFeilet
+import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.Produsent
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Tekst
@@ -67,6 +68,9 @@ class BrukervarselProducerKafka(
             }
             brukervarselMelding.link?.let { this.link = it }
             aktivFremTil = ZonedDateTime.now(ZoneId.of("Z")).plusDays(14)
+            eksternVarsling {
+                preferertKanal = EksternKanal.SMS
+            }
         }
     }
 }


### PR DESCRIPTION
Varselet ble bygget uten `eksternVarsling`-blokk, så TMS opprettet kun on-screen-varselet og sendte aldri SMS. Det forklarer hvorfor SMS-varslingen ikke har vært operativ i produksjon.
[MELOSYS-8160](https://jira.adeo.no/browse/MELOSYS-8160)

- Legger til `eksternVarsling { preferertKanal = SMS }` i `buildVarsel()` – ubetinget, gjelder alle arbeidstaker-varsler
- Ingen egen `smsVarslingstekst` ⇒ NAVs standardtekst for Beskjed brukes
- `kanBatches` ikke satt ⇒ NAVs default (batching for Beskjed)

## Testing
- [x] Eksisterende enhetstester grønne (full `./gradlew test`)
- [ ] Manuell/e2e-verifisering i dev-gcp (reell SMS-levering)