### PR TITLE
Skru av SMS for varsler uten handlingsbehov

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselMelding.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselMelding.kt
@@ -5,7 +5,8 @@ import no.nav.melosys.skjema.types.common.Språk
 data class BrukervarselMelding(
     val ident: String,
     val tekster: List<Varseltekst>,
-    val link: String? = null
+    val link: String? = null,
+    val sms: Boolean = true
 )
 
 data class Varseltekst(

--- a/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerKafka.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerKafka.kt
@@ -68,8 +68,10 @@ class BrukervarselProducerKafka(
             }
             brukervarselMelding.link?.let { this.link = it }
             aktivFremTil = ZonedDateTime.now(ZoneId.of("Z")).plusDays(14)
-            eksternVarsling {
-                preferertKanal = EksternKanal.SMS
+            if (brukervarselMelding.sms) {
+                eksternVarsling {
+                    preferertKanal = EksternKanal.SMS
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -81,7 +81,8 @@ class ArbeidstakerVarslingService(
     private fun varsleOmFullmaktsInnsending(fnr: String, orgnr: String, metadata: UtsendtArbeidstakerMetadata) {
         val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
         val tekster = lagVarselteksterMedFullmakt(navn)
-        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster))
+        // Mottaker trenger ikke foreta seg noe, så vi sender ikke SMS – kun varsel i innboks
+        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, sms = false))
         log.info { "Sendt informasjonsvarsel til arbeidstaker om fullmaktsinnsending" }
     }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/kafka/BrukervarselProducerTest.kt
@@ -2,8 +2,10 @@ package no.nav.melosys.skjema.kafka
 
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import java.util.concurrent.CompletableFuture
 import no.nav.melosys.skjema.kafka.exception.SendBrukervarselFeilet
@@ -41,6 +43,38 @@ class BrukervarselProducerTest {
     }
 
     @Test
+    fun `sendBrukervarsel skal aktivere SMS-varsling naar sms er true`() {
+        val melding = BrukervarselMelding(
+            ident = "12345678901",
+            tekster = listOf(Varseltekst(Språk.NORSK_BOKMAL, "Test notifikasjon", true)),
+            sms = true
+        )
+        val sendResult: SendResult<String, String> = mockk(relaxed = true)
+        val varselSlot = slot<String>()
+        every { kafkaTemplate.send(any<String>(), any(), capture(varselSlot)) } returns CompletableFuture.completedFuture(sendResult)
+
+        producer.sendBrukervarsel(melding)
+
+        varselSlot.captured shouldContain "SMS"
+    }
+
+    @Test
+    fun `sendBrukervarsel skal ikke aktivere SMS-varsling naar sms er false`() {
+        val melding = BrukervarselMelding(
+            ident = "12345678901",
+            tekster = listOf(Varseltekst(Språk.NORSK_BOKMAL, "Test notifikasjon", true)),
+            sms = false
+        )
+        val sendResult: SendResult<String, String> = mockk(relaxed = true)
+        val varselSlot = slot<String>()
+        every { kafkaTemplate.send(any<String>(), any(), capture(varselSlot)) } returns CompletableFuture.completedFuture(sendResult)
+
+        producer.sendBrukervarsel(melding)
+
+        varselSlot.captured shouldNotContain "SMS"
+    }
+
+    @Test
     fun `sendBrukervarsel skal kaste SendBrukervarselFeilet ved feil`() {
         val ident = "12345678901"
         val melding = BrukervarselMelding(
@@ -63,3 +97,4 @@ class BrukervarselProducerTest {
         }
     }
 }
+

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -48,7 +48,8 @@ class ArbeidstakerVarslingServiceTest {
                     melding.tekster.size == 2 &&
                     melding.tekster.any { it.språk == Språk.NORSK_BOKMAL && it.default } &&
                     melding.tekster.any { it.språk == Språk.ENGELSK } &&
-                    melding.link == forventetLenke
+                    melding.link == forventetLenke &&
+                    melding.sms
                 }
             )
         }
@@ -115,7 +116,7 @@ class ArbeidstakerVarslingServiceTest {
         service.varsleArbeidstakerHvisAktuelt(skjema.id!!)
 
         verify {
-            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == null })
+            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == null && !it.sms })
         }
     }
 
@@ -134,7 +135,7 @@ class ArbeidstakerVarslingServiceTest {
         service.varsleArbeidstakerHvisAktuelt(skjema.id!!)
 
         verify {
-            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == null })
+            brukervarselProducer.sendBrukervarsel(match<BrukervarselMelding> { it.link == null && !it.sms })
         }
     }
 


### PR DESCRIPTION
Slår av SMS-varsel for arbeidstakere som ikke trenger å foreta seg noe.

Ved fullmaktsinnsending får arbeidstaker et rent informasjonsvarsel ("Du trenger ikke foreta deg noe"). Disse skal ikke få SMS, kun varsel i innboksen. SMS-flagget settes derfor disablet for fullmaktstilfellene.

- Nytt `sms`-flagg på `BrukervarselMelding` (default `true`)
- `eksternVarsling` (SMS) settes kun når `sms = true`
- Fullmaktsvarsel sendes med `sms = false`

## Testing
- [x] Enhetstester
- [ ] Manuell testing lokalt
- [ ] E2E-tester (hvis relevant)

