### PR TITLE
8168 Legg til midlertidig resend-endepunkt for SMS-varsel

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -96,4 +96,18 @@ class AdminController(
         log.info { "Admin: Retry av alle feilede innsendinger" }
         return adminService.retryAlleFeilede()
     }
+
+    @PostMapping("/varsler/resend")
+    @Operation(
+        summary = "Midlertidig (MELOSYS-8168): Resend brukervarsel med SMS til arbeidstakere som mangler SMS-varsel",
+        description = "Resender det handlingspliktige varselet (nå med SMS) til arbeidstakere som ikke fikk SMS " +
+            "før SMS-prodsettingen. Kandidatene finnes i koden: alle handlingspliktige AG-deler (arbeidsgiver/" +
+            "rådgiver uten fullmakt) som ble sendt inn før 2026-06-29 10:41:46 UTC og fortsatt venter på " +
+            "arbeidstakers del. Tar ingen parametere. Returnerer kun totalt antall varsler som ble sendt."
+    )
+    @ApiResponse(responseCode = "200", description = "Resending utført")
+    fun resendVarsler(): ResendVarslerResultatDto {
+        log.info { "Admin: Resend varsler til arbeidstakere som mangler SMS-varsel" }
+        return adminService.resendVarsler()
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -103,7 +103,8 @@ class AdminController(
         description = "Resender det handlingspliktige varselet (nå med SMS) til arbeidstakere som ikke fikk SMS " +
             "før SMS-prodsettingen. Kandidatene finnes i koden: alle handlingspliktige AG-deler (arbeidsgiver/" +
             "rådgiver uten fullmakt) som ble sendt inn før 2026-06-29 10:41:46 UTC og fortsatt venter på " +
-            "arbeidstakers del. Tar ingen parametere. Returnerer kun totalt antall varsler som ble sendt."
+            "arbeidstakers del. Tar ingen parametere. Returnerer antall sendte varsler og saksnumrene som " +
+            "faktisk fikk et nytt varsel."
     )
     @ApiResponse(responseCode = "200", description = "Resending utført")
     fun resendVarsler(): ResendVarslerResultatDto {

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -46,6 +46,15 @@ data class RetryResultatDto(
 )
 
 /**
+ * MELOSYS-8168 (midlertidig): Resultat av resending – kun totalt antall varsler som faktisk ble sendt.
+ * Kandidatene finnes i koden (AG-del innsendt før SMS ble aktivert, som fortsatt venter på AT-del),
+ * så endepunktet trenger ingen request-body.
+ */
+data class ResendVarslerResultatDto(
+    val antallSendt: Int
+)
+
+/**
  * Bruksstatistikk for skjemaene – ment for overvåking av bruk via melosys-console.
  * Inneholder kun aggregerte tall, ingen personopplysninger.
  */

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -46,12 +46,15 @@ data class RetryResultatDto(
 )
 
 /**
- * MELOSYS-8168 (midlertidig): Resultat av resending – kun totalt antall varsler som faktisk ble sendt.
- * Kandidatene finnes i koden (AG-del innsendt før SMS ble aktivert, som fortsatt venter på AT-del),
- * så endepunktet trenger ingen request-body.
+ * MELOSYS-8168 (midlertidig): Resultat av resending. Kandidatene finnes i koden (AG-del innsendt før
+ * SMS ble aktivert, som fortsatt venter på AT-del), så endepunktet trenger ingen request-body.
+ *
+ * [saksnumre] lister sakene som faktisk fikk et nytt varsel (for sporbarhet på fagsiden), og
+ * [antallSendt] er antallet i listen. Saker som mangler saksnummer representeres med skjema-id-en sin.
  */
 data class ResendVarslerResultatDto(
-    val antallSendt: Int
+    val antallSendt: Int,
+    val saksnumre: List<String>
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -10,6 +10,7 @@ import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
 import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
 import no.nav.melosys.skjema.controller.admin.DelStatusDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
+import no.nav.melosys.skjema.controller.admin.ResendVarslerResultatDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
 import no.nav.melosys.skjema.controller.admin.SaksdekningDto
 import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
@@ -42,7 +43,8 @@ class AdminService(
     private val innsendingRepository: InnsendingRepository,
     private val skjemaRepository: SkjemaRepository,
     private val adminStatistikkRepository: AdminStatistikkRepository,
-    private val innsendingService: InnsendingService
+    private val innsendingService: InnsendingService,
+    private val arbeidstakerVarslingService: ArbeidstakerVarslingService
 ) {
 
     @Transactional(readOnly = true)
@@ -308,6 +310,82 @@ class AdminService(
         return RetryResultatDto(antallForsoekt = skjemaIder.size, antallFeilet = feilet)
     }
 
+    /**
+     * MELOSYS-8168 (midlertidig): Resender brukervarsel (nå med SMS) til arbeidstakere som ikke fikk SMS
+     * før SMS-prodsettingen. Kandidatene finnes i koden – ingen kuratert liste – og er bevisst litt
+     * over-inkluderende (kan treffe et par ekstra), men ingen som faktisk trenger SMS skal utelates:
+     *
+     * Kandidat = handlingspliktig AG-del (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn FØR
+     * [SMS_AKTIVERT_TIDSPUNKT] og som fortsatt venter på arbeidstakers del (ingen innsendt arbeidstaker-/
+     * kombinert-del matcher på samme fnr + juridisk enhet + overlappende periode).
+     *
+     * Selve sendingen delegeres til [ArbeidstakerVarslingService.resendVarselTilArbeidstaker], som i tillegg
+     * hopper over arbeidstakere med påbegynt utkast. Sendingen skjer utenfor lese-transaksjonen (jf.
+     * [retryAlleFeilede]) så vi ikke holder en DB-connection åpen gjennom Kafka-sendingen. Returnerer kun
+     * totalt antall varsler som ble sendt.
+     */
+    fun resendVarsler(): ResendVarslerResultatDto {
+        val kandidatSkjemaIder = finnResendKandidatSkjemaIder()
+        log.info { "Admin: Resend – fant ${kandidatSkjemaIder.size} kandidat(er) (handlingspliktig AG-del før $SMS_AKTIVERT_TIDSPUNKT som venter på AT-del)" }
+
+        var antallSendt = 0
+        kandidatSkjemaIder.forEach { skjemaId ->
+            try {
+                if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(skjemaId)) {
+                    antallSendt++
+                }
+            } catch (e: Exception) {
+                log.error(e) { "Admin: Resend feilet for skjema $skjemaId" }
+            }
+        }
+        log.info { "Admin: Resend ferdig – $antallSendt varsler sendt" }
+        return ResendVarslerResultatDto(antallSendt = antallSendt)
+    }
+
+    /** Finner skjema-id-ene til resend-kandidatene (se [resendVarsler] for kriteriene). */
+    @Transactional(readOnly = true)
+    fun finnResendKandidatSkjemaIder(): List<UUID> {
+        val alleInnsendte = innsendingRepository.finnAlleInnsendteMedSkjema()
+        val arbeidstakerDeler = alleInnsendte.filter { erArbeidstakerDel(it) }
+        return alleInnsendte
+            .filter { innsending ->
+                erHandlingspliktigAgDel(innsending) &&
+                    innsending.opprettetDato.isBefore(SMS_AKTIVERT_TIDSPUNKT) &&
+                    venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
+            }
+            .map { it.skjema.id!! }
+    }
+
+    /** Handlingspliktig AG/rådgiver-del uten fullmakt – arbeidstaker må sende inn sin egen del. */
+    private fun erHandlingspliktigAgDel(innsending: Innsending): Boolean {
+        val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return false
+        return metadata.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL &&
+            metadata.representasjonstype in HANDLINGSPLIKTIGE_REPRESENTASJONSTYPER
+    }
+
+    /** Innsendt arbeidstaker-del – enten egen del eller kombinert skjema som dekker arbeidstakers del. */
+    private fun erArbeidstakerDel(innsending: Innsending): Boolean {
+        val skjemadel = (innsending.skjema.metadata as? UtsendtArbeidstakerMetadata)?.skjemadel
+        return skjemadel == Skjemadel.ARBEIDSTAKERS_DEL || skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL
+    }
+
+    /**
+     * AT-del mangler hvis ingen innsendt arbeidstaker-del matcher på samme fnr + juridisk enhet +
+     * overlappende periode (samme matching som mottak/saksdekning bruker). Mangler periode på AG-delen
+     * regnes som "venter" (vi sender da heller én ekstra enn å utelate noen som trenger SMS).
+     */
+    private fun venterPaaArbeidstakerDel(agDel: Innsending, arbeidstakerDeler: List<Innsending>): Boolean {
+        val agMeta = agDel.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return false
+        val agPeriode = agDel.skjema.utsendelsePeriode() ?: return true
+        return arbeidstakerDeler.none { atDel ->
+            val atMeta = atDel.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@none false
+            val atPeriode = atDel.skjema.utsendelsePeriode() ?: return@none false
+            agDel.skjema.fnr == atDel.skjema.fnr &&
+                agMeta.juridiskEnhetOrgnr == atMeta.juridiskEnhetOrgnr &&
+                agPeriode.overlapper(atPeriode)
+        }
+    }
+
     @Transactional(readOnly = true)
     fun hentFeiledeSkjemaIder(): List<UUID> =
         innsendingRepository.findByStatusMedSkjema(InnsendingStatus.KAFKA_FEILET).map { it.skjema.id!! }
@@ -332,4 +410,18 @@ class AdminService(
         opprettetDato = opprettetDato,
         saksnummer = saksnummer
     )
+
+    companion object {
+        /**
+         * MELOSYS-8168: Tidspunktet SMS ble aktivert for handlingspliktige varsler. Handlingspliktige
+         * AG-deler innsendt FØR dette fikk varsel på nav.no, men ingen SMS, og er kandidater for resend.
+         */
+        private val SMS_AKTIVERT_TIDSPUNKT: Instant = Instant.parse("2026-06-29T10:41:46Z")
+
+        /** Representasjonstyper der arbeidstaker selv må sende inn sin del (uten fullmakt). */
+        private val HANDLINGSPLIKTIGE_REPRESENTASJONSTYPER = setOf(
+            Representasjonstype.ARBEIDSGIVER,
+            Representasjonstype.RADGIVER
+        )
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -34,6 +34,12 @@ import org.springframework.transaction.annotation.Transactional
 private val log = KotlinLogging.logger {}
 private val OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 
+/** MELOSYS-8168: En resend-kandidat – skjema som skal få varsel på nytt, med saksnummer hvis det finnes. */
+data class ResendKandidat(
+    val skjemaId: UUID,
+    val saksnummer: String?
+)
+
 /**
  * Administrative operasjoner som eksponeres via [no.nav.melosys.skjema.controller.admin.AdminController]
  * og konsumeres av melosys-console. Gir innsyn i og mulighet til å reprosessere feilede innsendinger.
@@ -321,30 +327,31 @@ class AdminService(
      *
      * Selve sendingen delegeres til [ArbeidstakerVarslingService.resendVarselTilArbeidstaker], som i tillegg
      * hopper over arbeidstakere med påbegynt utkast. Sendingen skjer utenfor lese-transaksjonen (jf.
-     * [retryAlleFeilede]) så vi ikke holder en DB-connection åpen gjennom Kafka-sendingen. Returnerer kun
-     * totalt antall varsler som ble sendt.
+     * [retryAlleFeilede]) så vi ikke holder en DB-connection åpen gjennom Kafka-sendingen. Returnerer antall
+     * sendte varsler og saksnumrene som faktisk fikk et nytt varsel (for sporbarhet på fagsiden).
      */
     fun resendVarsler(): ResendVarslerResultatDto {
-        val kandidatSkjemaIder = finnResendKandidatSkjemaIder()
-        log.info { "Admin: Resend – fant ${kandidatSkjemaIder.size} kandidat(er) (handlingspliktig AG-del før $SMS_AKTIVERT_TIDSPUNKT som venter på AT-del)" }
+        val kandidater = finnResendKandidater()
+        log.info { "Admin: Resend – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $SMS_AKTIVERT_TIDSPUNKT som venter på AT-del)" }
 
-        var antallSendt = 0
-        kandidatSkjemaIder.forEach { skjemaId ->
+        val sendteSaksnumre = mutableListOf<String>()
+        kandidater.forEach { kandidat ->
             try {
-                if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(skjemaId)) {
-                    antallSendt++
+                if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(kandidat.skjemaId)) {
+                    // Saker uten saksnummer representeres med skjema-id-en, så ingen sending blir usynlig.
+                    sendteSaksnumre += kandidat.saksnummer ?: kandidat.skjemaId.toString()
                 }
             } catch (e: Exception) {
-                log.error(e) { "Admin: Resend feilet for skjema $skjemaId" }
+                log.error(e) { "Admin: Resend feilet for skjema ${kandidat.skjemaId}" }
             }
         }
-        log.info { "Admin: Resend ferdig – $antallSendt varsler sendt" }
-        return ResendVarslerResultatDto(antallSendt = antallSendt)
+        log.info { "Admin: Resend ferdig – ${sendteSaksnumre.size} varsler sendt" }
+        return ResendVarslerResultatDto(antallSendt = sendteSaksnumre.size, saksnumre = sendteSaksnumre)
     }
 
-    /** Finner skjema-id-ene til resend-kandidatene (se [resendVarsler] for kriteriene). */
+    /** Finner resend-kandidatene med skjema-id og saksnummer (se [resendVarsler] for kriteriene). */
     @Transactional(readOnly = true)
-    fun finnResendKandidatSkjemaIder(): List<UUID> {
+    fun finnResendKandidater(): List<ResendKandidat> {
         val alleInnsendte = innsendingRepository.finnAlleInnsendteMedSkjema()
         val arbeidstakerDeler = alleInnsendte.filter { erArbeidstakerDel(it) }
         return alleInnsendte
@@ -353,7 +360,7 @@ class AdminService(
                     innsending.opprettetDato.isBefore(SMS_AKTIVERT_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
             }
-            .map { it.skjema.id!! }
+            .map { ResendKandidat(skjemaId = it.skjema.id!!, saksnummer = it.saksnummer) }
     }
 
     /** Handlingspliktig AG/rådgiver-del uten fullmakt – arbeidstaker må sende inn sin egen del. */

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -354,9 +354,13 @@ class AdminService(
     fun finnResendKandidater(): List<ResendKandidat> {
         val alleInnsendte = innsendingRepository.finnAlleInnsendteMedSkjema()
         val arbeidstakerDeler = alleInnsendte.filter { erArbeidstakerDel(it) }
+        val erstattedeIder: Set<UUID> = alleInnsendte
+            .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
+            .toSet()
         return alleInnsendte
             .filter { innsending ->
-                erHandlingspliktigAgDel(innsending) &&
+                innsending.skjema.id !in erstattedeIder &&
+                    erHandlingspliktigAgDel(innsending) &&
                     innsending.opprettetDato.isBefore(SMS_AKTIVERT_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
             }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -86,6 +86,57 @@ class ArbeidstakerVarslingService(
         log.info { "Sendt informasjonsvarsel til arbeidstaker om fullmaktsinnsending" }
     }
 
+    /**
+     * MELOSYS-8168 (midlertidig): Resender det handlingspliktige varselet (med SMS) til arbeidstaker
+     * for et gitt skjema. Brukes av admin-endepunktet for å nå AT-brukere som ikke fikk SMS før
+     * SMS-prodsettingen.
+     *
+     * Sender KUN for handlingspliktige caser (arbeidsgiver/rådgiver uten fullmakt, skjemadel ≠ kombinert).
+     * Bypasser [no.nav.melosys.skjema.entity.Innsending.brukervarselSendt]-sjekken (resend er eksplisitt)
+     * og endrer ikke det feltet, men beholder utkast-guarden slik at de som har påbegynt sin del ikke purres.
+     *
+     * @return true hvis varsel ble sendt på nytt, false hvis caset ble hoppet over.
+     */
+    fun resendVarselTilArbeidstaker(skjemaId: UUID): Boolean {
+        val skjema = skjemaRepository.findById(skjemaId).orElse(null)
+        if (skjema == null) {
+            log.warn { "Resend: fant ikke skjema $skjemaId, hopper over" }
+            return false
+        }
+
+        val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata
+        if (metadata == null) {
+            log.warn { "Resend: skjema $skjemaId har ikke UtsendtArbeidstakerMetadata, hopper over" }
+            return false
+        }
+
+        if (metadata.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) {
+            log.info { "Resend: kombinert skjemadel (skjema $skjemaId) er ikke handlingspliktig, hopper over" }
+            return false
+        }
+
+        return when (metadata) {
+            is ArbeidsgiverMetadata, is RadgiverMetadata -> resendUtenFullmakt(skjema.fnr, metadata)
+            else -> {
+                log.info { "Resend: ${metadata.representasjonstype} (skjema $skjemaId) er ikke handlingspliktig, hopper over" }
+                false
+            }
+        }
+    }
+
+    private fun resendUtenFullmakt(fnr: String, metadata: UtsendtArbeidstakerMetadata): Boolean {
+        if (harEksisterendeArbeidstakerUtkast(fnr, metadata.juridiskEnhetOrgnr)) {
+            log.info { "Resend: arbeidstaker har eksisterende utkast, sender ikke varsel" }
+            return false
+        }
+
+        val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
+        val tekster = lagResendVarselteksterUtenFullmakt(navn)
+        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke()))
+        log.info { "Resend: sendt varsel på nytt til arbeidstaker om AG-innsending (skjemadel=${metadata.skjemadel})" }
+        return true
+    }
+
     private fun harEksisterendeArbeidstakerUtkast(fnr: String, juridiskEnhetOrgnr: String): Boolean =
         skjemaRepository.findByFnrAndTypeAndStatus(fnr, SkjemaType.UTSENDT_ARBEIDSTAKER, SkjemaStatus.UTKAST).any { utkast ->
             val m = utkast.metadata as? UtsendtArbeidstakerMetadata
@@ -109,6 +160,21 @@ class ArbeidstakerVarslingService(
             )
         )
     }
+
+    /**
+     * MELOSYS-8168 (midlertidig): Samme handlingspliktige tekst som [lagVarselteksterUtenFullmakt],
+     * men med en ekstra setning om at de som allerede har sendt inn sin del kan se bort fra meldingen.
+     * Tillegget gjelder kun resend, ikke den vanlige varselstien.
+     */
+    private fun lagResendVarselteksterUtenFullmakt(arbeidsgiverNavn: String): List<Varseltekst> =
+        lagVarselteksterUtenFullmakt(arbeidsgiverNavn).map { varseltekst ->
+            val tillegg = when (varseltekst.språk) {
+                Språk.NORSK_BOKMAL -> " Hvis du allerede har fylt ut og sendt inn din del nylig, kan du se bort fra denne meldingen."
+                Språk.ENGELSK -> " If you have already submitted your part recently, you can disregard this message."
+                else -> ""
+            }
+            varseltekst.copy(tekst = varseltekst.tekst + tillegg)
+        }
 
     private fun lagVarselteksterMedFullmakt(arbeidsgiverNavn: String): List<Varseltekst> {
         return listOf(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -91,7 +91,7 @@ class ArbeidstakerVarslingService(
      * for et gitt skjema. Brukes av admin-endepunktet for å nå AT-brukere som ikke fikk SMS før
      * SMS-prodsettingen.
      *
-     * Sender KUN for handlingspliktige caser (arbeidsgiver/rådgiver uten fullmakt, skjemadel ≠ kombinert).
+     * Sender KUN for handlingspliktige caser (arbeidsgiver/rådgiver uten fullmakt, skjemadel = ARBEIDSGIVERS_DEL).
      * Bypasser [no.nav.melosys.skjema.entity.Innsending.brukervarselSendt]-sjekken (resend er eksplisitt)
      * og endrer ikke det feltet, men beholder utkast-guarden slik at de som har påbegynt sin del ikke purres.
      *
@@ -110,8 +110,8 @@ class ArbeidstakerVarslingService(
             return false
         }
 
-        if (metadata.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) {
-            log.info { "Resend: kombinert skjemadel (skjema $skjemaId) er ikke handlingspliktig, hopper over" }
+        if (metadata.skjemadel != Skjemadel.ARBEIDSGIVERS_DEL) {
+            log.info { "Resend: skjemadel=${metadata.skjemadel} (skjema $skjemaId) er ikke resend-kandidat, hopper over" }
             return false
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
@@ -471,7 +471,8 @@ fun innsendingMedDefaultVerdier(
     referanseId: String = UUID.randomUUID().toString().take(6).uppercase(),
     skjemaDefinisjonVersjon: String = "1",
     innsendtSprak: Språk = Språk.NORSK_BOKMAL,
-    innsenderFnr: String = "12345678901"
+    innsenderFnr: String = "12345678901",
+    saksnummer: String? = null
 ) = Innsending(
     id = id,
     skjema = skjema,
@@ -484,4 +485,6 @@ fun innsendingMedDefaultVerdier(
     skjemaDefinisjonVersjon = skjemaDefinisjonVersjon,
     innsendtSprak = innsendtSprak,
     innsenderFnr = innsenderFnr
-)
+).apply {
+    this.saksnummer = saksnummer
+}

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -525,7 +525,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             periode: PeriodeDto = periodeA,
             innsendtDato: Instant = foerCutoff,
             juridiskEnhet: String = korrektSyntetiskOrgnr,
-            saksnummer: String? = null
+            saksnummer: String? = null,
+            erstatterSkjemaId: UUID? = null
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
@@ -536,7 +537,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
                     representasjonstype = representasjonstype,
                     skjemadel = skjemadel,
-                    juridiskEnhetOrgnr = juridiskEnhet
+                    juridiskEnhetOrgnr = juridiskEnhet,
+                    erstatterSkjemaId = erstatterSkjemaId
                 )
             )
         ).also { skjema ->
@@ -550,8 +552,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             periode: PeriodeDto = periodeA,
             innsendtDato: Instant = foerCutoff,
             juridiskEnhet: String = korrektSyntetiskOrgnr,
-            saksnummer: String? = null
-        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet, saksnummer)
+            saksnummer: String? = null,
+            erstatterSkjemaId: UUID? = null
+        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet, saksnummer, erstatterSkjemaId)
 
         /** Innsendt arbeidstaker-del for samme person/enhet (markerer at saken ikke lenger venter på AT-del). */
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
@@ -658,8 +661,21 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal telle bare de faktiske kandidatene blant en blanding`() {
-            lagAgDel(fnr = "10000000010", saksnummer = "SAK-A")            // kandidat
+        fun `skal ikke sende dobbelt naar AG-del er erstattet av en nyere versjon`() {
+            // Arbeidsgiver sendte AG-delen, korrigerte og sendte inn på nytt før cutoff. Begge versjonene
+            // er SENDT, handlingspliktige og venter på AT-del, men den nye erstatter den gamle – kun ett varsel.
+            val gammel = lagAgDel(fnr = "10000000030", saksnummer = "SAK-ERST")
+            lagAgDel(fnr = "10000000030", saksnummer = "SAK-ERST", erstatterSkjemaId = gammel.id)
+
+            val body = resend()
+
+            body.antallSendt shouldBe 1
+            body.saksnumre shouldBe listOf("SAK-ERST")
+            verify(exactly = 1) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal telle bare de faktiske kandidatene blant en blanding`() {            lagAgDel(fnr = "10000000010", saksnummer = "SAK-A")            // kandidat
             lagAgDel(fnr = "10000000011", saksnummer = "SAK-B")            // kandidat
             lagAgDel(fnr = "10000000012", innsendtDato = etterCutoff)       // etter cutoff – nei
             lagAgDel(fnr = "10000000013", representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT) // med fullmakt – nei

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -16,6 +16,8 @@ import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.innsendingMedDefaultVerdier
+import no.nav.melosys.skjema.kafka.BrukervarselMelding
+import no.nav.melosys.skjema.kafka.BrukervarselProducer
 import no.nav.melosys.skjema.korrektSyntetiskOrgnr
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -59,6 +61,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
     @MockkBean(relaxed = true)
     private lateinit var innsendingService: InnsendingService
+
+    @MockkBean(relaxed = true)
+    private lateinit var brukervarselProducer: BrukervarselProducer
 
     /** WebTestClient som sender gyldig admin-API-nøkkel på alle kall (jf. application-test.yml). */
     private val adminClient by lazy {
@@ -495,6 +500,161 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         @Test
         fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
             adminClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /admin/varsler/resend")
+    inner class ResendVarsler {
+
+        private val periodeA = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-06-30"))
+        private val periodeOverlapp = PeriodeDto(LocalDate.parse("2026-03-01"), LocalDate.parse("2026-08-31"))
+        private val periodeIngenOverlapp = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-12-31"))
+        private val foerCutoff = Instant.parse("2026-06-01T00:00:00Z")
+        private val etterCutoff = Instant.parse("2026-06-29T12:00:00Z")
+
+        /** Lager en innsendt (SENDT) utsendt-arbeidstaker-del med kontroll på del, flyt, periode og innsendingsdato. */
+        private fun lagInnsendtDel(
+            skjemadel: Skjemadel,
+            representasjonstype: Representasjonstype,
+            fnr: String = "10000000001",
+            periode: PeriodeDto = periodeA,
+            innsendtDato: Instant = foerCutoff,
+            juridiskEnhet: String = korrektSyntetiskOrgnr
+        ): Skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = fnr,
+                status = SkjemaStatus.SENDT,
+                data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(
+                    utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = periode)
+                ),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = representasjonstype,
+                    skjemadel = skjemadel,
+                    juridiskEnhetOrgnr = juridiskEnhet
+                )
+            )
+        ).also { skjema ->
+            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato))
+        }
+
+        /** Handlingspliktig AG-del (arbeidsgiver uten fullmakt) – standard resend-kandidat. */
+        private fun lagAgDel(
+            fnr: String = "10000000001",
+            representasjonstype: Representasjonstype = Representasjonstype.ARBEIDSGIVER,
+            periode: PeriodeDto = periodeA,
+            innsendtDato: Instant = foerCutoff,
+            juridiskEnhet: String = korrektSyntetiskOrgnr
+        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet)
+
+        /** Innsendt arbeidstaker-del for samme person/enhet (markerer at saken ikke lenger venter på AT-del). */
+        private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
+            lagInnsendtDel(Skjemadel.ARBEIDSTAKERS_DEL, Representasjonstype.DEG_SELV, fnr, periode, foerCutoff, juridiskEnhet)
+
+        private fun resend(): ResendVarslerResultatDto =
+            adminClient.post().uri("/admin/varsler/resend")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<ResendVarslerResultatDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+        @Test
+        fun `skal sende varsel med SMS og ignorer-tekst for handlingspliktig AG-del foer cutoff som venter paa AT-del`() {
+            val skjema = lagAgDel()
+
+            val body = resend()
+
+            body.antallSendt shouldBe 1
+            verify(exactly = 1) {
+                brukervarselProducer.sendBrukervarsel(
+                    match<BrukervarselMelding> { melding ->
+                        melding.ident == skjema.fnr &&
+                            melding.sms &&
+                            melding.tekster.first { it.språk == Språk.NORSK_BOKMAL }.tekst.contains("kan du se bort fra denne meldingen")
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `skal sende for radgiver uten fullmakt`() {
+            lagAgDel(representasjonstype = Representasjonstype.RADGIVER)
+
+            resend().antallSendt shouldBe 1
+        }
+
+        @Test
+        fun `skal ikke sende naar arbeidstaker allerede har sendt sin del med overlappende periode`() {
+            lagAgDel(fnr = "10000000005", periode = periodeA)
+            lagAtDel(fnr = "10000000005", periode = periodeOverlapp)
+
+            resend().antallSendt shouldBe 0
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal fortsatt sende naar arbeidstakers del er for en ikke-overlappende periode`() {
+            lagAgDel(fnr = "10000000006", periode = periodeA)
+            lagAtDel(fnr = "10000000006", periode = periodeIngenOverlapp)
+
+            resend().antallSendt shouldBe 1
+        }
+
+        @Test
+        fun `skal ikke sende for AG-del innsendt etter cutoff`() {
+            lagAgDel(innsendtDato = etterCutoff)
+
+            resend().antallSendt shouldBe 0
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal ikke sende for med-fullmakt AG-del`() {
+            lagAgDel(representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT)
+
+            resend().antallSendt shouldBe 0
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal ikke sende naar arbeidstaker har paabegynt utkast`() {
+            val skjema = lagAgDel(fnr = "10000000007")
+            // Arbeidstaker har påbegynt sin del for samme juridiske enhet (utkast, ikke sendt)
+            skjemaRepository.save(
+                skjemaMedDefaultVerdier(
+                    fnr = skjema.fnr,
+                    status = SkjemaStatus.UTKAST,
+                    metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                        representasjonstype = Representasjonstype.DEG_SELV,
+                        skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                    )
+                )
+            )
+
+            resend().antallSendt shouldBe 0
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal telle bare de faktiske kandidatene blant en blanding`() {
+            lagAgDel(fnr = "10000000010")                                   // kandidat
+            lagAgDel(fnr = "10000000011")                                   // kandidat
+            lagAgDel(fnr = "10000000012", innsendtDato = etterCutoff)       // etter cutoff – nei
+            lagAgDel(fnr = "10000000013", representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT) // med fullmakt – nei
+            lagAgDel(fnr = "10000000014").also { lagAtDel(fnr = "10000000014") }   // AT-del sendt – nei
+
+            resend().antallSendt shouldBe 2
+            verify(exactly = 2) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            adminClient.post().uri("/admin/varsler/resend")
                 .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
                 .exchange()
                 .expectStatus().isForbidden

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.skjema.controller.admin
 
 import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -523,7 +524,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             fnr: String = "10000000001",
             periode: PeriodeDto = periodeA,
             innsendtDato: Instant = foerCutoff,
-            juridiskEnhet: String = korrektSyntetiskOrgnr
+            juridiskEnhet: String = korrektSyntetiskOrgnr,
+            saksnummer: String? = null
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
@@ -538,7 +540,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 )
             )
         ).also { skjema ->
-            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato))
+            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato, saksnummer = saksnummer))
         }
 
         /** Handlingspliktig AG-del (arbeidsgiver uten fullmakt) – standard resend-kandidat. */
@@ -547,8 +549,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             representasjonstype: Representasjonstype = Representasjonstype.ARBEIDSGIVER,
             periode: PeriodeDto = periodeA,
             innsendtDato: Instant = foerCutoff,
-            juridiskEnhet: String = korrektSyntetiskOrgnr
-        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet)
+            juridiskEnhet: String = korrektSyntetiskOrgnr,
+            saksnummer: String? = null
+        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet, saksnummer)
 
         /** Innsendt arbeidstaker-del for samme person/enhet (markerer at saken ikke lenger venter på AT-del). */
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
@@ -565,11 +568,12 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal sende varsel med SMS og ignorer-tekst for handlingspliktig AG-del foer cutoff som venter paa AT-del`() {
-            val skjema = lagAgDel()
+            val skjema = lagAgDel(saksnummer = "SAK-001")
 
             val body = resend()
 
             body.antallSendt shouldBe 1
+            body.saksnumre shouldBe listOf("SAK-001")
             verify(exactly = 1) {
                 brukervarselProducer.sendBrukervarsel(
                     match<BrukervarselMelding> { melding ->
@@ -579,6 +583,19 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                     }
                 )
             }
+        }
+
+        @Test
+        fun `skal returnere saksnumrene som faktisk fikk varsel, og skjema-id naar saksnummer mangler`() {
+            lagAgDel(fnr = "10000000020", saksnummer = "SAK-100")
+            val utenSaksnummer = lagAgDel(fnr = "10000000021", saksnummer = null)
+            // Ikke-kandidat (etter cutoff) – skal ikke dukke opp i listen
+            lagAgDel(fnr = "10000000022", innsendtDato = etterCutoff, saksnummer = "SAK-999")
+
+            val body = resend()
+
+            body.antallSendt shouldBe 2
+            body.saksnumre shouldContainExactlyInAnyOrder listOf("SAK-100", utenSaksnummer.id.toString())
         }
 
         @Test
@@ -642,13 +659,16 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
         @Test
         fun `skal telle bare de faktiske kandidatene blant en blanding`() {
-            lagAgDel(fnr = "10000000010")                                   // kandidat
-            lagAgDel(fnr = "10000000011")                                   // kandidat
+            lagAgDel(fnr = "10000000010", saksnummer = "SAK-A")            // kandidat
+            lagAgDel(fnr = "10000000011", saksnummer = "SAK-B")            // kandidat
             lagAgDel(fnr = "10000000012", innsendtDato = etterCutoff)       // etter cutoff – nei
             lagAgDel(fnr = "10000000013", representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT) // med fullmakt – nei
             lagAgDel(fnr = "10000000014").also { lagAtDel(fnr = "10000000014") }   // AT-del sendt – nei
 
-            resend().antallSendt shouldBe 2
+            val body = resend()
+
+            body.antallSendt shouldBe 2
+            body.saksnumre shouldContainExactlyInAnyOrder listOf("SAK-A", "SAK-B")
             verify(exactly = 2) { brukervarselProducer.sendBrukervarsel(any()) }
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -324,6 +324,24 @@ class ArbeidstakerVarslingServiceTest {
     }
 
     @Test
+    fun `resend - AG-metadata med arbeidstakers del skal hoppe over (guard mot feil skjemadel)`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+
+        val sendt = service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        sendt shouldBe false
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
     fun `resend - ikke-eksisterende skjemaId returnerer false uten exception`() {
         val skjemaId = UUID.randomUUID()
         every { skjemaRepository.findById(skjemaId) } returns Optional.empty()

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.skjema.service
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -227,6 +228,109 @@ class ArbeidstakerVarslingServiceTest {
         // Skal ikke kaste exception
         service.varsleArbeidstakerHvisAktuelt(skjemaId)
 
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
+    fun `resend - AG uten fullmakt og ingen AT-utkast skal sende varsel med SMS og ignorer-tekst`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns emptyList()
+
+        val sendt = service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        sendt shouldBe true
+        verify {
+            brukervarselProducer.sendBrukervarsel(
+                match<BrukervarselMelding> { melding ->
+                    melding.ident == skjema.fnr &&
+                        melding.sms &&
+                        melding.link == forventetLenke &&
+                        melding.tekster.first { it.språk == Språk.NORSK_BOKMAL }.tekst.contains("kan du se bort fra denne meldingen") &&
+                        melding.tekster.first { it.språk == Språk.ENGELSK }.tekst.contains("you can disregard this message")
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resend - AG uten fullmakt med eksisterende AT-utkast skal hoppe over`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+            )
+        )
+        val eksisterendeUtkast = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.UTKAST,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.DEG_SELV,
+                skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns listOf(eksisterendeUtkast)
+
+        val sendt = service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        sendt shouldBe false
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
+    fun `resend - AG med fullmakt er ikke handlingspliktig og skal hoppe over`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+
+        val sendt = service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        sendt shouldBe false
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
+    fun `resend - kombinert skjemadel skal hoppe over`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+
+        val sendt = service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        sendt shouldBe false
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
+    fun `resend - ikke-eksisterende skjemaId returnerer false uten exception`() {
+        val skjemaId = UUID.randomUUID()
+        every { skjemaRepository.findById(skjemaId) } returns Optional.empty()
+
+        val sendt = service.resendVarselTilArbeidstaker(skjemaId)
+
+        sendt shouldBe false
         verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
     }
 }


### PR DESCRIPTION
Nytt midlertidig admin-endepunkt som resender brukervarsel (nå med SMS) til arbeidstakere som fikk varsel på nav.no, men ikke SMS, før SMS ble aktivert.

Frem til SMS-prodsettingen var SMS-flagget for brukervarsler avslått, så mange arbeidstakere fikk nav.no-varsel om å sende inn «sin del», men ingen SMS – og har derfor ikke reagert. Kandidatene finnes i koden: handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) innsendt før 2026-06-29 10:41:46 UTC som fortsatt venter på arbeidstakers del. [MELOSYS-8168](https://nav.atlassian.net/browse/MELOSYS-8168)

- Nytt `POST /admin/varsler/resend` (uten parametere, `@AdminBeskyttet`), returnerer antall sendte
- DB-basert kandidatutvelgelse i `AdminService` (AG-del før cutoff som venter på AT-del, matchet på fnr + juridisk enhet + overlappende periode)
- `resendVarselTilArbeidstaker` sender med SMS + midlertidig «ignorer hvis allerede sendt»-tekst (nb + en), ny varselId per sending
- Beholder utkast-guarden, bypasser (og endrer ikke) brukervarsel-sendt-sjekken

## Testing
- [x] Enhetstester
- [x] Integrasjonstester