### PR TITLE
8170 Legg arbeidsgivers orgnr i varsel-lenke til arbeidstaker

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -14,6 +14,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsgiverMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.DegSelvMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMedFullmaktMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMetadata
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
 import no.nav.melosys.skjema.types.common.SkjemaStatus
@@ -74,7 +75,7 @@ class ArbeidstakerVarslingService(
 
         val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
         val tekster = lagVarselteksterUtenFullmakt(navn)
-        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke()))
+        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke(orgnr)))
         log.info { "Sendt varsel til arbeidstaker om AG-innsending (skjemadel=${metadata.skjemadel})" }
     }
 
@@ -92,8 +93,9 @@ class ArbeidstakerVarslingService(
             m != null && m.juridiskEnhetOrgnr == juridiskEnhetOrgnr && m.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL
         }
 
-    private fun byggSkjemaLenke(): String =
-        skjemaLenke + ARBEIDSTAKER_SKJEMA_PATH
+    // Ruter arbeidstaker rett til DEG_SELV-forsiden med arbeidsgivers orgnr forhåndsutfylt
+    private fun byggSkjemaLenke(arbeidsgiverOrgnr: String): String =
+        "$skjemaLenke$ARBEIDSTAKER_SKJEMA_PATH?representasjonstype=${Representasjonstype.DEG_SELV}&arbeidsgiverOrgnr=$arbeidsgiverOrgnr"
 
     private fun lagVarselteksterUtenFullmakt(arbeidsgiverNavn: String): List<Varseltekst> {
         return listOf(
@@ -127,6 +129,6 @@ class ArbeidstakerVarslingService(
 
     companion object {
         private const val MAX_ARBEIDSGIVERNAVN_LENGDE = 100
-        private const val ARBEIDSTAKER_SKJEMA_PATH = "/medlemskap-lovvalg/soknad"
+        private const val ARBEIDSTAKER_SKJEMA_PATH = "/medlemskap-lovvalg/soknad/oversikt"
     }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -8,6 +8,7 @@ import java.util.Optional
 import java.util.UUID
 import no.nav.melosys.skjema.kafka.BrukervarselMelding
 import no.nav.melosys.skjema.kafka.BrukervarselProducer
+import no.nav.melosys.skjema.korrektSyntetiskOrgnr
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
@@ -22,7 +23,8 @@ class ArbeidstakerVarslingServiceTest {
     private val brukervarselProducer: BrukervarselProducer = mockk(relaxed = true)
     private val skjemaRepository: SkjemaRepository = mockk()
     private val skjemaLenke = "https://test.nav.no"
-    private val forventetLenke = "https://test.nav.no/medlemskap-lovvalg/soknad"
+    private val forventetLenke =
+        "https://test.nav.no/medlemskap-lovvalg/soknad/oversikt?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=$korrektSyntetiskOrgnr"
 
     private val service = ArbeidstakerVarslingService(brukervarselProducer, skjemaRepository, skjemaLenke)
 


### PR DESCRIPTION
Varsel-lenken til arbeidstaker peker nå rett på DEG_SELV-forsiden med arbeidsgivers
organisasjonsnummer forhåndsutfylt, slik at arbeidstaker slipper å taste det inn selv.

Når arbeidsgiver/rådgiver sender inn sin del uten fullmakt, må arbeidstaker fylle ut sin
egen del. Lenken i varselet rutet tidligere bare til den generiske forsiden. Nå bærer den
`representasjonstype=DEG_SELV` + arbeidsgivers orgnr (som allerede er tilgjengelig på
AG-innsendingen), slik at arbeidstaker kommer rett inn på riktig skjemautfylling med riktig
arbeidsgiver koblet.
[MELOSYS-8170](https://nav.atlassian.net/browse/MELOSYS-8170)

- `byggSkjemaLenke` legger på `?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=<orgnr>`
- `ARBEIDSTAKER_SKJEMA_PATH` peker nå på `/medlemskap-lovvalg/soknad/oversikt`
- Oppdatert `ArbeidstakerVarslingServiceTest` for ny lenke

### Testing
- [x] Enhetstester (`ArbeidstakerVarslingServiceTest` grønn)
- [ ] E2E-tester — reell varsling/SMS sendes kun i dev-gcp (lokalt brukes `BrukervarselProducerLocal`-stub)
