### PR TITLE
NOJIRA Fiks stale PdlConsumer-referanse i repro-integrasjonstest

### DIFF
--- a/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerKoblingPdfReproIntegrationTest.kt
@@ -15,7 +15,7 @@ import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.extensions.utsendtArbeidstakerMetadataOrThrow
 import no.nav.melosys.skjema.getToken
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
-import no.nav.melosys.skjema.integrasjon.pdl.PdlConsumer
+import no.nav.melosys.skjema.integrasjon.pdl.PdlClient
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlFoedselsdato
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlNavn
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
@@ -90,7 +90,7 @@ class UtsendtArbeidstakerKoblingPdfReproIntegrationTest : ApiTestBase() {
     private lateinit var reprService: ReprService
 
     @MockkBean
-    private lateinit var pdlConsumer: PdlConsumer
+    private lateinit var pdlClient: PdlClient
 
     @BeforeEach
     fun setUp() {
@@ -101,7 +101,7 @@ class UtsendtArbeidstakerKoblingPdfReproIntegrationTest : ApiTestBase() {
         every { reprService.harSkriverettigheterForMedlemskap(any()) } returns true
         every { eregService.organisasjonsnummerEksisterer(any()) } returns true
         every { notificationService.sendNotificationToArbeidsgiver(any(), any(), any(), any()) } returns "beskjed-id"
-        every { pdlConsumer.hentPerson(any()) } returns PdlPerson(
+        every { pdlClient.hentPerson(any()) } returns PdlPerson(
             navn = listOf(PdlNavn("Våken", null, "Elefant")),
             foedselsdato = listOf(PdlFoedselsdato("1980-01-01"))
         )


### PR DESCRIPTION
`compileTestKotlin` feilet på `main` fordi `UtsendtArbeidstakerKoblingPdfReproIntegrationTest`
fortsatt refererte `PdlConsumer`, som ble døpt om til `PdlClient` i RestClient-migreringen
(MELOSYS-8134, #319). Testfila ble ikke oppdatert i den migreringen, så `Unresolved reference 'PdlConsumer'`
brøt hele test-kompileringen. Ingen andre filer henger igjen (kun denne).

Ren rename i testfila (`import` + `@MockkBean`-felt + `every { ... }`). `hentPerson(ident): PdlPerson`
er uendret på `PdlClient`, og `PdlService` injiserer allerede `PdlClient` — så `@MockkBean`-punktet stemmer.

- [x] `compileTestKotlin` grønn (var rød på `main` før fiks)
