### PR TITLE
NOJIRA BUGFIX: Fiks deflate-dekomprimering med Apache HttpClient 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
+    implementation("org.apache.httpcomponents.client5:httpclient5")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-aspectj")
     implementation("org.springframework.retry:spring-retry:2.0.13")

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/altinn/ArbeidsgiverAltinnTilgangerClientTest.kt
@@ -20,6 +20,8 @@ import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
 
 class ArbeidsgiverAltinnTilgangerClientTest: ApiTestBase() {
 
@@ -114,5 +116,41 @@ class ArbeidsgiverAltinnTilgangerClientTest: ApiTestBase() {
                 }
             """.trimIndent()))
         )
+    }
+
+    @Test
+    fun `hentTilganger skal dekomprimere deflate-komprimert respons`() {
+        // Apache HttpClient 5 må pakke ut rå deflate (RFC 1951); JDK-klienten feiler med ZipException.
+        every {
+            oAuth2AccessTokenService.getAccessToken(any())
+        } returns OAuth2AccessTokenResponse(access_token = "token")
+
+        wireMockServer.stubFor(post(urlPathMatching(".*"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withHeader("Content-Encoding", "deflate")
+                    .withBody(raaDeflate("""{"tilgangTilOrgNr":{"4936":["123456789"]}}"""))
+            )
+        )
+
+        val respons = arbeidsgiverAltinnTilgangerClient.hentTilganger()
+
+        respons.tilgangTilOrgNr shouldBeEqual mapOf("4936" to setOf("123456789"))
+    }
+
+    /** Komprimerer med rå DEFLATE (nowrap = true, RFC 1951) — uten zlib-header, slik enkelte tjenester svarer. */
+    private fun raaDeflate(data: String): ByteArray {
+        val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
+        deflater.setInput(data.toByteArray(Charsets.UTF_8))
+        deflater.finish()
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(1024)
+        while (!deflater.finished()) {
+            output.write(buffer, 0, deflater.deflate(buffer))
+        }
+        deflater.end()
+        return output.toByteArray()
     }
 }


### PR DESCRIPTION
Bytter RestClient sin HTTP-klient til Apache HttpClient 5 slik at komprimerte
responser (gzip/deflate) pakkes ut korrekt.

Etter WebClient-til-RestClient-migreringen (8134) lå det ingen HTTP-klient på
classpath, så RestClient falt tilbake til JDK-klienten. Spring 7 sin JDK-klient
har respons-dekomprimering på som standard og pakker ut `deflate` med
`InflaterInputStream`, som forventer zlib-innpakket deflate (RFC 1950).
arbeidsgiver-altinn-tilganger svarer med rå deflate (RFC 1951), som ga
`java.util.zip.ZipException: incorrect header check` og feilet
`hentBrukersTilganger`.

- Legger til `org.apache.httpcomponents.client5:httpclient5` (versjon styrt av Spring Boot BOM)
- RestClient auto-detekterer Apache-klienten, som dekomprimerer både rå og
  zlib-innpakket deflate samt gzip korrekt — komprimering beholdes
- Regresjonstest: Altinn-respons med `Content-Encoding: deflate` (rå deflate)

## Testing
- [x] Enhetstester — ny regresjonstest for rå deflate

## Notater
Klientbyttet gjelder alle RestClient-integrasjoner (pdl, repr, ereg,
arbeidsgiver-notifikasjon, clamav, storage), ikke bare Altinn — alle får korrekt
dekomprimering og en produksjonsklar HTTP-klient med connection pooling.
