### PR TITLE
NOJIRA Fiks brutt main: arbeidsgiverOrgnr manglet i resend-varsel

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -117,7 +117,7 @@ class ArbeidstakerVarslingService(
         }
 
         return when (metadata) {
-            is ArbeidsgiverMetadata, is RadgiverMetadata -> resendUtenFullmakt(skjema.fnr, metadata)
+            is ArbeidsgiverMetadata, is RadgiverMetadata -> resendUtenFullmakt(skjema.fnr, skjema.orgnr, metadata)
             else -> {
                 log.info { "Resend: ${metadata.representasjonstype} (skjema $skjemaId) er ikke handlingspliktig, hopper over" }
                 false
@@ -125,7 +125,7 @@ class ArbeidstakerVarslingService(
         }
     }
 
-    private fun resendUtenFullmakt(fnr: String, metadata: UtsendtArbeidstakerMetadata): Boolean {
+    private fun resendUtenFullmakt(fnr: String, orgnr: String, metadata: UtsendtArbeidstakerMetadata): Boolean {
         if (harEksisterendeArbeidstakerUtkast(fnr, metadata.juridiskEnhetOrgnr)) {
             log.info { "Resend: arbeidstaker har eksisterende utkast, sender ikke varsel" }
             return false
@@ -133,7 +133,7 @@ class ArbeidstakerVarslingService(
 
         val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
         val tekster = lagResendVarselteksterUtenFullmakt(navn)
-        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke()))
+        brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke(orgnr)))
         log.info { "Resend: sendt varsel på nytt til arbeidstaker om AG-innsending (skjemadel=${metadata.skjemadel})" }
         return true
     }


### PR DESCRIPTION
Fikser kompileringsfeil på `main` i `ArbeidstakerVarslingService`.

En semantisk merge-konflikt brøt bygget: PR #331 gjorde parameteren
`arbeidsgiverOrgnr` påkrevd i `byggSkjemaLenke(...)`, mens PR #330
(merget etter #331) la til resend-endepunktet som fortsatt kalte
`byggSkjemaLenke()` uten argument. Begge merget rent, men resultatet
kompilerer ikke (`No value passed for parameter 'arbeidsgiverOrgnr'`).

- Tråder `skjema.orgnr` gjennom `resendUtenFullmakt(...)` til `byggSkjemaLenke(orgnr)`
- Speiler den eksisterende ikke-resend-flyten (`varsleUtenFullmakt`) nøyaktig

## Testing
- [x] `./gradlew build` (kompilering + tester) grønn lokalt

