### PR TITLE
Fjern nylig/recently fra resend-varseltekst til arbeidstaker

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -171,8 +171,8 @@ class ArbeidstakerVarslingService(
     private fun lagResendVarselteksterUtenFullmakt(arbeidsgiverNavn: String): List<Varseltekst> =
         lagVarselteksterUtenFullmakt(arbeidsgiverNavn).map { varseltekst ->
             val tillegg = when (varseltekst.språk) {
-                Språk.NORSK_BOKMAL -> " Hvis du allerede har fylt ut og sendt inn din del nylig, kan du se bort fra denne meldingen."
-                Språk.ENGELSK -> " If you have already submitted your part recently, you can disregard this message."
+                Språk.NORSK_BOKMAL -> " Hvis du allerede har fylt ut og sendt inn din del, kan du se bort fra denne meldingen."
+                Språk.ENGELSK -> " If you have already submitted your part, you can disregard this message."
                 else -> ""
             }
             varseltekst.copy(tekst = varseltekst.tekst + tillegg)


### PR DESCRIPTION
Fjerner ordene «nylig»/«recently» fra tilleggssetningen i resend-varselet til arbeidstaker, slik at teksten blir mer tidsnøytral.

Tillegget som resender det handlingspliktige varselet (MELOSYS-8168) inneholdt «din del nylig» / «your part recently». Ordet er unødvendig og kan virke forvirrende for brukere som sendte inn for en stund siden, så det fjernes.

- Norsk tekst: «...sendt inn din del nylig, kan du...» → «...sendt inn din del, kan du...»
- Engelsk tekst: «...submitted your part recently, you...» → «...submitted your part, you...»

## Testing
- [x] Enhetstester (ArbeidstakerVarslingServiceTest)
- [ ] Manuell testing lokalt
