### PR TITLE
G4P: Erstatt langt arbeidsgivernavn med orgnr i resend-varsel

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -131,12 +131,21 @@ class ArbeidstakerVarslingService(
             return false
         }
 
-        val navn = metadata.arbeidsgiverNavn.take(MAX_ARBEIDSGIVERNAVN_LENGDE)
+        val navn = arbeidsgiverVisningsnavnForResend(metadata, orgnr)
         val tekster = lagResendVarselteksterUtenFullmakt(navn)
         brukervarselProducer.sendBrukervarsel(BrukervarselMelding(fnr, tekster, byggSkjemaLenke(orgnr)))
         log.info { "Resend: sendt varsel på nytt til arbeidstaker om AG-innsending (skjemadel=${metadata.skjemadel})" }
         return true
     }
+
+    /**
+     * MELOSYS-8168 (midlertidig): Returnerer navnet som skal vises i resend-varselteksten.
+     * Resend-teksten har en ekstra setning, og lange arbeidsgivernavn kan gjøre at teksten
+     * overstiger min-side sin maksgrense på 300 tegn. Navn over
+     * [RESEND_MAX_ARBEIDSGIVERNAVN_LENGDE] tegn erstattes derfor med organisasjonsnummeret.
+     */
+    private fun arbeidsgiverVisningsnavnForResend(metadata: UtsendtArbeidstakerMetadata, orgnr: String): String =
+        if (metadata.arbeidsgiverNavn.length > RESEND_MAX_ARBEIDSGIVERNAVN_LENGDE) orgnr else metadata.arbeidsgiverNavn
 
     private fun harEksisterendeArbeidstakerUtkast(fnr: String, juridiskEnhetOrgnr: String): Boolean =
         skjemaRepository.findByFnrAndTypeAndStatus(fnr, SkjemaType.UTSENDT_ARBEIDSTAKER, SkjemaStatus.UTKAST).any { utkast ->
@@ -195,6 +204,7 @@ class ArbeidstakerVarslingService(
 
     companion object {
         private const val MAX_ARBEIDSGIVERNAVN_LENGDE = 100
+        private const val RESEND_MAX_ARBEIDSGIVERNAVN_LENGDE = 30
         private const val ARBEIDSTAKER_SKJEMA_PATH = "/medlemskap-lovvalg/soknad/oversikt"
     }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -353,4 +353,56 @@ class ArbeidstakerVarslingServiceTest {
         sendt shouldBe false
         verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
     }
+
+    @Test
+    fun `resend - langt arbeidsgiverNavn skal erstattes med orgnr i varseltekst`() {
+        val langtNavn = "A".repeat(31)
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+                arbeidsgiverNavn = langtNavn
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns emptyList()
+
+        service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        verify {
+            brukervarselProducer.sendBrukervarsel(
+                match<BrukervarselMelding> { melding ->
+                    melding.tekster.all { !it.tekst.contains(langtNavn) && it.tekst.contains(skjema.orgnr) }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resend - arbeidsgivernavn paa grensen skal beholdes i varseltekst`() {
+        val navnPaaGrensen = "A".repeat(30)
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+                arbeidsgiverNavn = navnPaaGrensen
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns emptyList()
+
+        service.resendVarselTilArbeidstaker(skjema.id!!)
+
+        verify {
+            brukervarselProducer.sendBrukervarsel(
+                match<BrukervarselMelding> { melding ->
+                    melding.tekster.first { it.språk == Språk.NORSK_BOKMAL }.tekst.contains(navnPaaGrensen)
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
Erstatter for lange arbeidsgivernavn med organisasjonsnummer i resend-varselet slik at teksten ikke overstiger min-side sin maksgrense på 300 tegn.

Resend-varselet (MELOSYS-8168) legger til en ekstra setning i tillegg til grunnteksten. Med lange arbeidsgivernavn kunne den samlede teksten passere 300 tegn, som er min-side sin grense. Grensen valideres ikke i koden, så en for lang tekst ville feilet nedstrøms. Arbeidsgivernavn over 30 tegn erstattes derfor med organisasjonsnummeret i resend-flyten.

- Ny `arbeidsgiverVisningsnavnForResend` bytter til orgnr når navnet er over 30 tegn
- Kun resend-flyten er berørt — den vanlige varslingsflyten er uendret
- Enhetstester for grense (30 tegn beholdes), over grense (erstattes med orgnr), og at vanlig varsel ikke påvirkes

## Testing
- [x] Enhetstester
- [ ] Manuell testing lokalt
