### PR TITLE
BUGFIX: Fiks virusscanning av vedlegg etter RestClient-migrering

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/integrasjon/clamav/ClamAvClientNais.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/integrasjon/clamav/ClamAvClientNais.kt
@@ -4,9 +4,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.melosys.skjema.exception.VedleggVirusFunnetException
 import org.springframework.context.annotation.Profile
 import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import org.springframework.web.multipart.MultipartFile
@@ -22,14 +24,17 @@ class ClamAvClientNais(
     override fun scan(fil: MultipartFile) {
         log.info { "Scanner fil '${fil.originalFilename}' for virus via ClamAV" }
 
-        val bodyBuilder = MultipartBodyBuilder()
-        bodyBuilder.part("file1", object : ByteArrayResource(fil.bytes) {
+        val filDel = object : ByteArrayResource(fil.bytes) {
             override fun getFilename(): String = fil.originalFilename ?: "file"
-        }).contentType(MediaType.APPLICATION_OCTET_STREAM)
+        }
+        val delHeaders = HttpHeaders().apply { contentType = MediaType.APPLICATION_OCTET_STREAM }
+
+        val body = LinkedMultiValueMap<String, HttpEntity<*>>()
+        body.add("file1", HttpEntity(filDel, delHeaders))
 
         val response = clamAvRestClient.put()
             .contentType(MediaType.MULTIPART_FORM_DATA)
-            .body(bodyBuilder.build())
+            .body(body)
             .retrieve()
             .body<Array<ClamAvScanResult>>()
 

--- a/src/test/kotlin/no/nav/melosys/skjema/integrasjon/clamav/ClamAvClientNaisTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/integrasjon/clamav/ClamAvClientNaisTest.kt
@@ -1,0 +1,92 @@
+package no.nav.melosys.skjema.integrasjon.clamav
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.put
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.exception.VedleggVirusFunnetException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mock.web.MockMultipartFile
+
+class ClamAvClientNaisTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var clamAvClientNais: ClamAvClientNais
+
+    @Autowired
+    private lateinit var wireMockServer: WireMockServer
+
+    @AfterEach
+    fun teardown() {
+        wireMockServer.resetAll()
+    }
+
+    private fun testFil() = MockMultipartFile(
+        "fil",
+        "test.pdf",
+        "application/pdf",
+        "%PDF-1.4 test content".toByteArray()
+    )
+
+    @Test
+    fun `scan sender fil som multipart-request og godtar OK-respons`() {
+        wireMockServer.stubFor(
+            put(urlPathEqualTo("/api/v2/scan"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""[{"filename":"test.pdf","result":"OK"}]""")
+                )
+        )
+
+        shouldNotThrowAny { clamAvClientNais.scan(testFil()) }
+
+        // Verifiserer at requesten faktisk bygges som multipart/form-data med fil-delen.
+        // Dette er stien som tidligere krevde reactive-streams via MultipartBodyBuilder.
+        wireMockServer.verify(
+            putRequestedFor(urlPathEqualTo("/api/v2/scan"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("file1"))
+                .withRequestBody(containing("test.pdf"))
+        )
+    }
+
+    @Test
+    fun `scan kaster VedleggVirusFunnetException naar ClamAV melder FOUND`() {
+        wireMockServer.stubFor(
+            put(urlPathEqualTo("/api/v2/scan"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""[{"filename":"test.pdf","result":"FOUND"}]""")
+                )
+        )
+
+        shouldThrow<VedleggVirusFunnetException> { clamAvClientNais.scan(testFil()) }
+    }
+
+    @Test
+    fun `scan kaster VedleggVirusFunnetException ved tomt svar`() {
+        wireMockServer.stubFor(
+            put(urlPathEqualTo("/api/v2/scan"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[]")
+                )
+        )
+
+        shouldThrow<VedleggVirusFunnetException> { clamAvClientNais.scan(testFil()) }
+    }
+}
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,4 +37,4 @@ MELOSYS_CLIENT_ID: test-melosys-client-id
 MELOSYS_CONSOLE_AZP_NAMES: test-console-client-id
 MELOSYS_SKJEMA_ADMIN_APIKEY: test-admin-apikey
 VEDLEGG_BUCKET_NAME: test-vedlegg-bucket
-CLAMAV_URL: http://localhost:9999
+CLAMAV_URL: ${wiremock.server.url}


### PR DESCRIPTION
Retter en NoClassDefFoundError som brøt opplasting av vedlegg i produksjon etter overgangen fra WebClient til RestClient.

MultipartBodyBuilder refererer org.reactivestreams.Publisher, som fulgte med spring-boot-starter-webclient men ikke spring-boot-starter-restclient. Da starteren ble byttet forsvant reactive-streams fra runtime-classpathen, og virusscanningen kastet NoClassDefFoundError. Feilen slapp gjennom CI fordi ClamAvClient mockes i testene, og reactive-streams ligger fortsatt på test-classpathen via webtestclient.

- Bygger multipart-body med LinkedMultiValueMap + HttpEntity i stedet for MultipartBodyBuilder (ingen reactive-avhengighet)
- Beholder samme wire-format (part-navn `file1`, `application/octet-stream`)
- Ny WireMock-test som kjører den reelle ClamAvClientNais-stien og verifiserer multipart-requesten
- Peker CLAMAV_URL mot WireMock i test-profilen slik at den reelle klienten faktisk testes

## Testing
- [x] Enhetstester: ClamAvClientNaisTest, VedleggControllerIntegrationTest, VedleggServiceTest
- [x] Manuell verifisering
