### PR TITLE
G4P: Endre resend-cutoff fra SMS-aktivert til varsel-lenke-fikset

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -99,16 +99,16 @@ class AdminController(
 
     @PostMapping("/varsler/resend")
     @Operation(
-        summary = "Midlertidig (MELOSYS-8168): Resend brukervarsel med SMS til arbeidstakere som mangler SMS-varsel",
-        description = "Resender det handlingspliktige varselet (nå med SMS) til arbeidstakere som ikke fikk SMS " +
-            "før SMS-prodsettingen. Kandidatene finnes i koden: alle handlingspliktige AG-deler (arbeidsgiver/" +
-            "rådgiver uten fullmakt) som ble sendt inn før 2026-06-29 10:41:46 UTC og fortsatt venter på " +
-            "arbeidstakers del. Tar ingen parametere. Returnerer antall sendte varsler og saksnumrene som " +
-            "faktisk fikk et nytt varsel."
+        summary = "Midlertidig (MELOSYS-8168): Resend handlingspliktig brukervarsel med korrekt skjema-lenke",
+        description = "Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til arbeidstakere " +
+            "som fikk et varsel med feil lenke før lenken ble fikset. Kandidatene finnes i koden: alle " +
+            "handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn før " +
+            "2026-07-03 12:50:10 UTC og fortsatt venter på arbeidstakers del. Tar ingen parametere. " +
+            "Returnerer antall sendte varsler og saksnumrene som faktisk fikk et nytt varsel."
     )
     @ApiResponse(responseCode = "200", description = "Resending utført")
     fun resendVarsler(): ResendVarslerResultatDto {
-        log.info { "Admin: Resend varsler til arbeidstakere som mangler SMS-varsel" }
+        log.info { "Admin: Resend varsler til arbeidstakere som fikk varsel med feil lenke" }
         return adminService.resendVarsler()
     }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -317,12 +317,12 @@ class AdminService(
     }
 
     /**
-     * MELOSYS-8168 (midlertidig): Resender brukervarsel (nå med SMS) til arbeidstakere som ikke fikk SMS
-     * før SMS-prodsettingen. Kandidatene finnes i koden – ingen kuratert liste – og er bevisst litt
-     * over-inkluderende (kan treffe et par ekstra), men ingen som faktisk trenger SMS skal utelates:
+     * MELOSYS-8168 (midlertidig): Resender brukervarsel (nå med korrekt skjema-lenke) til arbeidstakere som
+     * fikk et varsel med feil lenke. Kandidatene finnes i koden – ingen kuratert liste – og er bevisst litt
+     * over-inkluderende (kan treffe et par ekstra), men ingen som faktisk fikk feil lenke skal utelates:
      *
      * Kandidat = handlingspliktig AG-del (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn FØR
-     * [SMS_AKTIVERT_TIDSPUNKT] og som fortsatt venter på arbeidstakers del (ingen innsendt arbeidstaker-/
+     * [VARSEL_LENKE_FIKSET_TIDSPUNKT] og som fortsatt venter på arbeidstakers del (ingen innsendt arbeidstaker-/
      * kombinert-del matcher på samme fnr + juridisk enhet + overlappende periode).
      *
      * Selve sendingen delegeres til [ArbeidstakerVarslingService.resendVarselTilArbeidstaker], som i tillegg
@@ -332,7 +332,7 @@ class AdminService(
      */
     fun resendVarsler(): ResendVarslerResultatDto {
         val kandidater = finnResendKandidater()
-        log.info { "Admin: Resend – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $SMS_AKTIVERT_TIDSPUNKT som venter på AT-del)" }
+        log.info { "Admin: Resend – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del)" }
 
         val sendteSaksnumre = mutableListOf<String>()
         kandidater.forEach { kandidat ->
@@ -361,7 +361,7 @@ class AdminService(
             .filter { innsending ->
                 innsending.skjema.id !in erstattedeIder &&
                     erHandlingspliktigAgDel(innsending) &&
-                    innsending.opprettetDato.isBefore(SMS_AKTIVERT_TIDSPUNKT) &&
+                    innsending.opprettetDato.isBefore(VARSEL_LENKE_FIKSET_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
             }
             .map { ResendKandidat(skjemaId = it.skjema.id!!, saksnummer = it.saksnummer) }
@@ -383,7 +383,7 @@ class AdminService(
     /**
      * AT-del mangler hvis ingen innsendt arbeidstaker-del matcher på samme fnr + juridisk enhet +
      * overlappende periode (samme matching som mottak/saksdekning bruker). Mangler periode på AG-delen
-     * regnes som "venter" (vi sender da heller én ekstra enn å utelate noen som trenger SMS).
+     * regnes som "venter" (vi sender da heller én ekstra enn å utelate noen som fikk feil lenke).
      */
     private fun venterPaaArbeidstakerDel(agDel: Innsending, arbeidstakerDeler: List<Innsending>): Boolean {
         val agMeta = agDel.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return false
@@ -424,10 +424,10 @@ class AdminService(
 
     companion object {
         /**
-         * MELOSYS-8168: Tidspunktet SMS ble aktivert for handlingspliktige varsler. Handlingspliktige
-         * AG-deler innsendt FØR dette fikk varsel på nav.no, men ingen SMS, og er kandidater for resend.
+         * MELOSYS-8168: Tidspunktet skjema-lenken i det handlingspliktige varselet ble fikset. Handlingspliktige
+         * AG-deler innsendt FØR dette fikk et varsel med feil lenke, og er kandidater for resend med korrekt lenke.
          */
-        private val SMS_AKTIVERT_TIDSPUNKT: Instant = Instant.parse("2026-06-29T10:41:46Z")
+        private val VARSEL_LENKE_FIKSET_TIDSPUNKT: Instant = Instant.parse("2026-07-03T12:50:10.504Z")
 
         /** Representasjonstyper der arbeidstaker selv må sende inn sin del (uten fullmakt). */
         private val HANDLINGSPLIKTIGE_REPRESENTASJONSTYPER = setOf(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -88,9 +88,9 @@ class ArbeidstakerVarslingService(
     }
 
     /**
-     * MELOSYS-8168 (midlertidig): Resender det handlingspliktige varselet (med SMS) til arbeidstaker
-     * for et gitt skjema. Brukes av admin-endepunktet for å nå AT-brukere som ikke fikk SMS før
-     * SMS-prodsettingen.
+     * MELOSYS-8168 (midlertidig): Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til
+     * arbeidstaker for et gitt skjema. Brukes av admin-endepunktet for å nå AT-brukere som fikk et varsel
+     * med feil lenke før lenken ble fikset.
      *
      * Sender KUN for handlingspliktige caser (arbeidsgiver/rådgiver uten fullmakt, skjemadel = ARBEIDSGIVERS_DEL).
      * Bypasser [no.nav.melosys.skjema.entity.Innsending.brukervarselSendt]-sjekken (resend er eksplisitt)

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -515,7 +515,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         private val periodeOverlapp = PeriodeDto(LocalDate.parse("2026-03-01"), LocalDate.parse("2026-08-31"))
         private val periodeIngenOverlapp = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-12-31"))
         private val foerCutoff = Instant.parse("2026-06-01T00:00:00Z")
-        private val etterCutoff = Instant.parse("2026-06-29T12:00:00Z")
+        private val etterCutoff = Instant.parse("2026-07-03T14:00:00Z")
 
         /** Lager en innsendt (SENDT) utsendt-arbeidstaker-del med kontroll på del, flyt, periode og innsendingsdato. */
         private fun lagInnsendtDel(
@@ -570,7 +570,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 .returnResult().responseBody.shouldNotBeNull()
 
         @Test
-        fun `skal sende varsel med SMS og ignorer-tekst for handlingspliktig AG-del foer cutoff som venter paa AT-del`() {
+        fun `skal sende varsel med korrekt lenke og ignorer-tekst for handlingspliktig AG-del foer cutoff som venter paa AT-del`() {
             val skjema = lagAgDel(saksnummer = "SAK-001")
 
             val body = resend()

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -234,7 +234,7 @@ class ArbeidstakerVarslingServiceTest {
     }
 
     @Test
-    fun `resend - AG uten fullmakt og ingen AT-utkast skal sende varsel med SMS og ignorer-tekst`() {
+    fun `resend - AG uten fullmakt og ingen AT-utkast skal sende varsel med korrekt lenke og ignorer-tekst`() {
         val skjema = skjemaMedDefaultVerdier(
             id = UUID.randomUUID(),
             status = SkjemaStatus.SENDT,


### PR DESCRIPTION
Endrer cutoff-kriteriet for det midlertidige MELOSYS-8168 resend-endepunktet fra «SMS ble aktivert» til «skjema-lenken i varselet ble fikset».

Det opprinnelige handlingspliktige varselet ble sendt med feil skjema-lenke. Lenken er nå fikset, og arbeidstakere som fikk et varsel med feil lenke før fiksen skal få varselet på nytt med korrekt lenke. Konstanten er derfor omdøpt og satt til fikse-tidspunktet.

- `SMS_AKTIVERT_TIDSPUNKT` → `VARSEL_LENKE_FIKSET_TIDSPUNKT` = `2026-07-03T12:50:10.504Z` (Oslo 14:50:10.504)
- Reframet doc-, logg- og `@Operation`-tekst i `AdminService`, `ArbeidstakerVarslingService` og `AdminController` fra «SMS» til «feil/korrekt lenke»
- Oppdatert testnavn og bumpet `etterCutoff` i integrasjonstesten forbi ny cutoff

## Testing
- [x] Enhetstester
- [x] Integrasjonstester

