### PR TITLE
G4P: Korriger varsel-lenke-fikset-tidspunkt til korrekt klokkeslett

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -103,7 +103,7 @@ class AdminController(
         description = "Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til arbeidstakere " +
             "som fikk et varsel med feil lenke før lenken ble fikset. Kandidatene finnes i koden: alle " +
             "handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn før " +
-            "2026-07-03 12:50:10 UTC og fortsatt venter på arbeidstakers del. Tar ingen parametere. " +
+            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Tar ingen parametere. " +
             "Returnerer antall sendte varsler og saksnumrene som faktisk fikk et nytt varsel."
     )
     @ApiResponse(responseCode = "200", description = "Resending utført")

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -470,7 +470,7 @@ class AdminService(
          * MELOSYS-8168: Tidspunktet skjema-lenken i det handlingspliktige varselet ble fikset. Handlingspliktige
          * AG-deler innsendt FØR dette fikk et varsel med feil lenke, og er kandidater for resend med korrekt lenke.
          */
-        private val VARSEL_LENKE_FIKSET_TIDSPUNKT: Instant = Instant.parse("2026-07-03T12:50:10.504Z")
+        private val VARSEL_LENKE_FIKSET_TIDSPUNKT: Instant = Instant.parse("2026-07-03T12:11:38Z")
 
         /** Representasjonstyper der arbeidstaker selv må sende inn sin del (uten fullmakt). */
         private val HANDLINGSPLIKTIGE_REPRESENTASJONSTYPER = setOf(

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -470,7 +470,7 @@ class AdminService(
          * MELOSYS-8168: Tidspunktet skjema-lenken i det handlingspliktige varselet ble fikset. Handlingspliktige
          * AG-deler innsendt FØR dette fikk et varsel med feil lenke, og er kandidater for resend med korrekt lenke.
          */
-        private val VARSEL_LENKE_FIKSET_TIDSPUNKT: Instant = Instant.parse("2026-07-03T12:11:38Z")
+        private val VARSEL_LENKE_FIKSET_TIDSPUNKT: Instant = Instant.parse("2026-07-03T12:10:38Z")
 
         /** Representasjonstyper der arbeidstaker selv må sende inn sin del (uten fullmakt). */
         private val HANDLINGSPLIKTIGE_REPRESENTASJONSTYPER = setOf(


### PR DESCRIPTION
Retter tidspunktet i `VARSEL_LENKE_FIKSET_TIDSPUNKT` etter at det ble satt litt feil i forrige PR (#344).

Riktig tidspunkt for at skjema-lenken ble fikset er 14:11:38 norsk tid, ikke 14:50:10.504. Cutoff-verdien og det tilhørende UTC-tidspunktet i `@Operation`-doc oppdateres tilsvarende.

- `VARSEL_LENKE_FIKSET_TIDSPUNKT`: `2026-07-03T12:50:10.504Z` → `2026-07-03T12:11:38Z` (Oslo 14:11:38)
- Oppdatert UTC-tidspunkt i `AdminController` sin `@Operation`-doc

## Testing
- [x] Enhetstester (`ArbeidstakerVarslingServiceTest`)
- [x] Integrasjonstester (`AdminControllerIntegrationTest`)

