### PR TITLE
MELOSYS-8084 Saksstatus på innsending med M2M-synkendepunkter

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/common/Saksstatus.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/common/Saksstatus.kt
@@ -1,0 +1,16 @@
+package no.nav.melosys.skjema.types.common
+
+/**
+ * Brukervendt status for saken i melosys-api, synkronisert til melosys-skjema-api via M2M-kall.
+ *
+ * Bevisst begrenset til to verdier inntil faglig/juridisk avklaring åpner for mer detaljert
+ * statusvisning. melosys-api mapper sine interne saksstatuser til disse (kun OPPRETTET
+ * regnes som MOTTATT; alt annet, inkludert LOVVALG_AVKLART og henlagt/annullert, er AVSLUTTET).
+ */
+enum class Saksstatus {
+    /** Saken er aktiv/under behandling i melosys-api */
+    MOTTATT,
+
+    /** Saken er ferdigbehandlet (avsluttet, lovvalg avklart, henlagt, annullert m.m.) */
+    AVSLUTTET
+}

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/felles/GyldigSaksnummer.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/felles/GyldigSaksnummer.kt
@@ -1,0 +1,22 @@
+package no.nav.melosys.skjema.types.felles
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import kotlin.reflect.KClass
+
+/**
+ * Felles validering av saksnummer fra melosys-api. Maks-lengden må matche
+ * kolonnen innsending.saksnummer (VARCHAR(99), V16).
+ */
+@NotBlank(message = "Saksnummer kan ikke være tomt")
+@Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+@Constraint(validatedBy = [])
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class GyldigSaksnummer(
+    val message: String = "Ugyldig saksnummer",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
@@ -1,0 +1,23 @@
+package no.nav.melosys.skjema.types.m2m
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+import java.util.UUID
+import no.nav.melosys.skjema.types.common.Saksstatus
+
+/** Massesynk av saksstatus fra melosys-api (historiske og aktive saker). */
+data class BulkOppdaterSaksstatusRequest(
+    @field:NotEmpty(message = "Oppdateringer kan ikke være tom")
+    @field:Valid
+    val oppdateringer: List<SaksstatusOppdatering>
+)
+
+data class SaksstatusOppdatering(
+    val skjemaId: UUID,
+    @field:NotBlank(message = "Saksnummer kan ikke være tomt")
+    @field:Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+    val saksnummer: String,
+    val saksstatus: Saksstatus
+)

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
@@ -1,11 +1,11 @@
 package no.nav.melosys.skjema.types.m2m
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 import java.util.UUID
 import no.nav.melosys.skjema.types.common.Saksstatus
+import no.nav.melosys.skjema.types.felles.GyldigSaksnummer
 
 /** Massesynk av saksstatus fra melosys-api (historiske og aktive saker). Kaller paginerer i batcher. */
 data class BulkOppdaterSaksstatusRequest(
@@ -17,8 +17,7 @@ data class BulkOppdaterSaksstatusRequest(
 
 data class SaksstatusOppdatering(
     val skjemaId: UUID,
-    @field:NotBlank(message = "Saksnummer kan ikke være tomt")
-    @field:Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+    @field:GyldigSaksnummer
     val saksnummer: String,
     val saksstatus: Saksstatus
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusRequest.kt
@@ -7,9 +7,10 @@ import jakarta.validation.constraints.Size
 import java.util.UUID
 import no.nav.melosys.skjema.types.common.Saksstatus
 
-/** Massesynk av saksstatus fra melosys-api (historiske og aktive saker). */
+/** Massesynk av saksstatus fra melosys-api (historiske og aktive saker). Kaller paginerer i batcher. */
 data class BulkOppdaterSaksstatusRequest(
     @field:NotEmpty(message = "Oppdateringer kan ikke være tom")
+    @field:Size(max = 1000, message = "Maks 1000 oppdateringer per batch")
     @field:Valid
     val oppdateringer: List<SaksstatusOppdatering>
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
@@ -3,10 +3,10 @@ package no.nav.melosys.skjema.types.m2m
 import java.util.UUID
 
 /**
- * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som ble skrevet – også når
- * verdien var uendret, så en idempotent retry gir samme tall. Kan være høyere enn antall rader i
- * requesten, siden alle innsendinger på samme saksnummer oppdateres. [ukjenteSkjemaIder] er
- * skjema-id-er uten tilhørende innsending.
+ * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som faktisk fikk ENDRET
+ * saksstatus – allerede synkede rader røres ikke, så en gjentatt synk rapporterer 0. Kan være
+ * høyere enn antall rader i requesten, siden alle innsendinger på samme saksnummer oppdateres.
+ * [ukjenteSkjemaIder] er skjema-id-er uten tilhørende innsending.
  */
 data class BulkOppdaterSaksstatusResultat(
     val antallOppdatert: Int,

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
@@ -1,0 +1,13 @@
+package no.nav.melosys.skjema.types.m2m
+
+import java.util.UUID
+
+/**
+ * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som fikk ny status
+ * (kan være høyere enn antall rader i requesten, siden alle innsendinger på samme saksnummer
+ * oppdateres). [ukjenteSkjemaIder] er skjema-id-er uten tilhørende innsending.
+ */
+data class BulkOppdaterSaksstatusResultat(
+    val antallOppdatert: Int,
+    val ukjenteSkjemaIder: List<UUID>
+)

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
@@ -3,9 +3,10 @@ package no.nav.melosys.skjema.types.m2m
 import java.util.UUID
 
 /**
- * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som fikk ny status
- * (kan være høyere enn antall rader i requesten, siden alle innsendinger på samme saksnummer
- * oppdateres). [ukjenteSkjemaIder] er skjema-id-er uten tilhørende innsending.
+ * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som ble skrevet – også når
+ * verdien var uendret, så en idempotent retry gir samme tall. Kan være høyere enn antall rader i
+ * requesten, siden alle innsendinger på samme saksnummer oppdateres. [ukjenteSkjemaIder] er
+ * skjema-id-er uten tilhørende innsending.
  */
 data class BulkOppdaterSaksstatusResultat(
     val antallOppdatert: Int,

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/BulkOppdaterSaksstatusResultat.kt
@@ -3,12 +3,16 @@ package no.nav.melosys.skjema.types.m2m
 import java.util.UUID
 
 /**
- * Resultat av massesynk. [antallOppdatert] teller unike innsendinger som faktisk fikk ENDRET
- * saksstatus – allerede synkede rader røres ikke, så en gjentatt synk rapporterer 0. Kan være
- * høyere enn antall rader i requesten, siden alle innsendinger på samme saksnummer oppdateres.
+ * Resultat av massesynk. [antallOppdatert] teller innsendinger som faktisk fikk ENDRET
+ * saksstatus – allerede synkede rader røres ikke, så en gjentatt synk rapporterer 0.
+ * Hver rad oppdaterer kun sin egen innsending (per skjema-id).
  * [ukjenteSkjemaIder] er skjema-id-er uten tilhørende innsending.
+ * [konfliktSkjemaIder] er rader der innsendingen allerede har et ANNET saksnummer enn
+ * requesten oppga (saksnummer er immutabelt) – raden hoppes over uten å feile batchen.
+ * Feltet har default tom liste slik at eldre konsumenter deserialiserer trygt.
  */
 data class BulkOppdaterSaksstatusResultat(
     val antallOppdatert: Int,
-    val ukjenteSkjemaIder: List<UUID>
+    val ukjenteSkjemaIder: List<UUID>,
+    val konfliktSkjemaIder: List<UUID> = emptyList()
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/OppdaterSaksstatusRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/OppdaterSaksstatusRequest.kt
@@ -1,0 +1,12 @@
+package no.nav.melosys.skjema.types.m2m
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import no.nav.melosys.skjema.types.common.Saksstatus
+
+data class OppdaterSaksstatusRequest(
+    @field:NotBlank(message = "Saksnummer kan ikke være tomt")
+    @field:Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+    val saksnummer: String,
+    val saksstatus: Saksstatus
+)

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/OppdaterSaksstatusRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/OppdaterSaksstatusRequest.kt
@@ -1,12 +1,10 @@
 package no.nav.melosys.skjema.types.m2m
 
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Size
 import no.nav.melosys.skjema.types.common.Saksstatus
+import no.nav.melosys.skjema.types.felles.GyldigSaksnummer
 
 data class OppdaterSaksstatusRequest(
-    @field:NotBlank(message = "Saksnummer kan ikke være tomt")
-    @field:Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+    @field:GyldigSaksnummer
     val saksnummer: String,
     val saksstatus: Saksstatus
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/RegistrerSaksnummerRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/m2m/RegistrerSaksnummerRequest.kt
@@ -1,10 +1,8 @@
 package no.nav.melosys.skjema.types.m2m
 
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Size
+import no.nav.melosys.skjema.types.felles.GyldigSaksnummer
 
 data class RegistrerSaksnummerRequest(
-    @field:NotBlank(message = "Saksnummer kan ikke være tomt")
-    @field:Size(max = 99, message = "Saksnummer kan ikke være lengre enn 99 tegn")
+    @field:GyldigSaksnummer
     val saksnummer: String
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/M2mConfigProperties.kt
@@ -13,6 +13,8 @@ data class M2mConfigProperties(
     @field:Valid
     val readSkjemadata: ClientConfig = ClientConfig(),
     @field:Valid
+    val writeSkjemadata: ClientConfig = ClientConfig(),
+    @field:Valid
     val admin: AdminConfig = AdminConfig()
 ) {
     data class ClientConfig(
@@ -33,7 +35,7 @@ data class M2mConfigProperties(
 
     @PostConstruct
     fun validateNoUnresolvedPlaceholders() {
-        (readSkjemadata.clients + admin.clients + admin.apikey).forEach { verdi ->
+        (readSkjemadata.clients + writeSkjemadata.clients + admin.clients + admin.apikey).forEach { verdi ->
             require(!verdi.contains("\${")) {
                 "Uoppløst placeholder i m2m-konfigurasjon: '$verdi'. Sjekk at miljøvariabelen er satt."
             }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.melosys.skjema.config.RateLimitConfig
 import no.nav.melosys.skjema.controller.dto.ErrorResponse
 import no.nav.melosys.skjema.exception.AccessDeniedException
+import no.nav.melosys.skjema.exception.SaksnummerKonfliktException
 import no.nav.melosys.skjema.exception.SkjemaErIkkeRedigerbartException
 import no.nav.melosys.skjema.exception.SkjemaTypeMismatchException
 import no.nav.melosys.skjema.exception.VedleggVirusFunnetException
@@ -83,6 +84,15 @@ class GlobalExceptionHandler(
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
             .body(ErrorResponse(message = e.message ?: ""))
+    }
+
+    @ExceptionHandler(SaksnummerKonfliktException::class)
+    fun handleSaksnummerKonflikt(e: SaksnummerKonfliktException): ResponseEntity<ErrorResponse> {
+        log.warn(e) { "Saksnummer-konflikt: ${e.message}" }
+
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(ErrorResponse(message = e.message ?: "Saksnummer-konflikt"))
     }
 
     @ExceptionHandler(PersonVerifiseringException::class)

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
@@ -62,9 +62,10 @@ class M2MSkjemaController(
 
     @PostMapping("/{id}/saksnummer")
     @M2MWriteSkjemadata
-    @Operation(summary = "Registrer saksnummer fra melosys-api på innsendt skjema (M2M)")
+    @Operation(summary = "Registrer saksnummer fra melosys-api på innsendt skjema. Saksnummer er immutabelt når først satt (M2M)")
     @ApiResponse(responseCode = "204", description = "Saksnummer registrert")
     @ApiResponse(responseCode = "404", description = "Skjema ikke funnet")
+    @ApiResponse(responseCode = "409", description = "Innsendingen har allerede et annet saksnummer")
     fun registrerSaksnummer(
         @PathVariable id: UUID,
         @Valid @RequestBody request: RegistrerSaksnummerRequest
@@ -76,9 +77,10 @@ class M2MSkjemaController(
 
     @PutMapping("/{id}/saksstatus")
     @M2MWriteSkjemadata
-    @Operation(summary = "Oppdater saksstatus fra melosys-api. Oppdaterer alle innsendinger på samme saksnummer (M2M)")
+    @Operation(summary = "Oppdater saksstatus fra melosys-api. Oppdaterer kun innsendingen for gitt skjema-id (M2M)")
     @ApiResponse(responseCode = "204", description = "Saksstatus oppdatert")
     @ApiResponse(responseCode = "404", description = "Skjema ikke funnet")
+    @ApiResponse(responseCode = "409", description = "Innsendingen har allerede et annet saksnummer")
     fun oppdaterSaksstatus(
         @PathVariable id: UUID,
         @Valid @RequestBody request: OppdaterSaksstatusRequest
@@ -89,7 +91,7 @@ class M2MSkjemaController(
 
     @PutMapping("/saksstatus/bulk")
     @M2MWriteSkjemadata
-    @Operation(summary = "Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i resultatet (M2M)")
+    @Operation(summary = "Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er og saksnummer-konflikter rapporteres i resultatet (M2M)")
     @ApiResponse(responseCode = "200", description = "Massesynk utført")
     fun bulkOppdaterSaksstatus(
         @Valid @RequestBody request: BulkOppdaterSaksstatusRequest

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
@@ -9,6 +9,9 @@ import no.nav.melosys.skjema.service.M2MSkjemaService
 import no.nav.melosys.skjema.sikkerhet.M2MReadSkjemadata
 import no.nav.melosys.skjema.sikkerhet.M2MWriteSkjemadata
 import jakarta.validation.Valid
+import no.nav.melosys.skjema.types.m2m.BulkOppdaterSaksstatusRequest
+import no.nav.melosys.skjema.types.m2m.BulkOppdaterSaksstatusResultat
+import no.nav.melosys.skjema.types.m2m.OppdaterSaksstatusRequest
 import no.nav.melosys.skjema.types.m2m.RegistrerSaksnummerRequest
 import no.nav.melosys.skjema.types.m2m.UtsendtArbeidstakerSkjemaM2MDto
 import org.springframework.http.ContentDisposition
@@ -18,6 +21,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -68,6 +72,31 @@ class M2MSkjemaController(
         log.info { "M2M: Registrerer saksnummer ${request.saksnummer} for skjema $id" }
         m2mSkjemaService.registrerSaksnummer(id, request.saksnummer)
         return ResponseEntity.noContent().build()
+    }
+
+    @PutMapping("/{id}/saksstatus")
+    @M2MWriteSkjemadata
+    @Operation(summary = "Oppdater saksstatus fra melosys-api. Oppdaterer alle innsendinger på samme saksnummer (M2M)")
+    @ApiResponse(responseCode = "204", description = "Saksstatus oppdatert")
+    @ApiResponse(responseCode = "404", description = "Skjema ikke funnet")
+    fun oppdaterSaksstatus(
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: OppdaterSaksstatusRequest
+    ): ResponseEntity<Void> {
+        log.info { "M2M: Oppdaterer saksstatus til ${request.saksstatus} for skjema $id (sak ${request.saksnummer})" }
+        m2mSkjemaService.oppdaterSaksstatus(id, request.saksnummer, request.saksstatus)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PutMapping("/saksstatus/bulk")
+    @M2MWriteSkjemadata
+    @Operation(summary = "Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i resultatet (M2M)")
+    @ApiResponse(responseCode = "200", description = "Massesynk utført")
+    fun bulkOppdaterSaksstatus(
+        @Valid @RequestBody request: BulkOppdaterSaksstatusRequest
+    ): ResponseEntity<BulkOppdaterSaksstatusResultat> {
+        log.info { "M2M: Bulk-oppdaterer saksstatus for ${request.oppdateringer.size} skjema" }
+        return ResponseEntity.ok(m2mSkjemaService.bulkOppdaterSaksstatus(request.oppdateringer))
     }
 
     @GetMapping("/{skjemaId}/vedlegg/{vedleggId}/innhold")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaController.kt
@@ -83,7 +83,6 @@ class M2MSkjemaController(
         @PathVariable id: UUID,
         @Valid @RequestBody request: OppdaterSaksstatusRequest
     ): ResponseEntity<Void> {
-        log.info { "M2M: Oppdaterer saksstatus til ${request.saksstatus} for skjema $id (sak ${request.saksnummer})" }
         m2mSkjemaService.oppdaterSaksstatus(id, request.saksnummer, request.saksstatus)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
@@ -24,7 +25,9 @@ data class InnsendingAdminDto(
     val feilmelding: String?,
     val sisteForsoekTidspunkt: Instant?,
     val opprettetDato: Instant,
-    val saksnummer: String?
+    val saksnummer: String?,
+    val saksstatus: Saksstatus?,
+    val saksstatusOppdatert: Instant?
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/entity/Innsending.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/entity/Innsending.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 import no.nav.melosys.skjema.config.observability.MDCOperations
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.service.skjemadefinisjon.SpråkConverter
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.Språk
 
 /**
@@ -81,5 +82,13 @@ class Innsending(
 
     /** Saksnummer i melosys-api, satt via M2M-kall etter sak er opprettet */
     @Column(name = "saksnummer")
-    var saksnummer: String? = null
+    var saksnummer: String? = null,
+
+    /** Saksstatus i melosys-api, synkronisert via M2M-kall. Null = ikke synket ennå (behandles som MOTTATT). */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "saksstatus")
+    var saksstatus: Saksstatus? = null,
+
+    @Column(name = "saksstatus_oppdatert")
+    var saksstatusOppdatert: Instant? = null
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/exception/SaksnummerKonfliktException.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/exception/SaksnummerKonfliktException.kt
@@ -1,0 +1,13 @@
+package no.nav.melosys.skjema.exception
+
+import java.util.UUID
+
+/**
+ * Saksnummer er immutabelt når det først er satt på en innsending: melosys-api forsøkte å
+ * knytte skjemaet til et annet saksnummer enn det som allerede er registrert.
+ */
+class SaksnummerKonfliktException(skjemaId: UUID, eksisterendeSaksnummer: String, oppgittSaksnummer: String) :
+    RuntimeException(
+        "Innsending for skjema $skjemaId har allerede saksnummer $eksisterendeSaksnummer " +
+            "og kan ikke endres til $oppgittSaksnummer"
+    )

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -39,6 +39,9 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
 
     fun existsByReferanseId(referanseId: String): Boolean
 
+    /** Alle innsendinger på samme sak i melosys-api (motpart-deler og nye versjoner deler saksnummer). */
+    fun findBySaksnummer(saksnummer: String): List<Innsending>
+
     /**
      * Henter innsendinger med gitt status og laster tilhørende skjema i samme spørring
      * (JOIN FETCH) for å unngå N+1 når admin-DTO-er mappes – viktig når mange innsendinger

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -39,9 +39,6 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
 
     fun existsByReferanseId(referanseId: String): Boolean
 
-    /** Alle innsendinger på samme sak i melosys-api (motpart-deler og nye versjoner deler saksnummer). */
-    fun findBySaksnummer(saksnummer: String): List<Innsending>
-
     /**
      * Henter innsendinger med gitt status og laster tilhørende skjema i samme spørring
      * (JOIN FETCH) for å unngå N+1 når admin-DTO-er mappes – viktig når mange innsendinger

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -329,7 +329,8 @@ class AdminService(
      * [VARSEL_LENKE_FIKSET_TIDSPUNKT] og som fortsatt venter på arbeidstakers del (ingen innsendt arbeidstaker-/
      * kombinert-del matcher på samme fnr + juridisk enhet + overlappende periode). Innsendinger der saken er
      * AVSLUTTET i melosys-api ekskluderes – der er det ingenting å varsle om (motpart-delen kom typisk via
-     * en annen kanal).
+     * en annen kanal). NB: filteret forutsetter at saksstatus-massesynken fra melosys-api er kjørt først;
+     * innsendinger uten synket status (null) behandles som aktive og kan få varsel.
      *
      * Selve sendingen delegeres til [ArbeidstakerVarslingService.resendVarselTilArbeidstaker], som i tillegg
      * hopper over arbeidstakere med påbegynt utkast. Sendingen skjer utenfor lese-transaksjonen (jf.
@@ -466,7 +467,9 @@ class AdminService(
         feilmelding = feilmelding,
         sisteForsoekTidspunkt = sisteForsoekTidspunkt,
         opprettetDato = opprettetDato,
-        saksnummer = saksnummer
+        saksnummer = saksnummer,
+        saksstatus = saksstatus,
+        saksstatusOppdatert = saksstatusOppdatert
     )
 
     companion object {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -24,6 +24,7 @@ import no.nav.melosys.skjema.integrasjon.storage.VedleggStorageClient
 import no.nav.melosys.skjema.repository.AdminStatistikkRepository
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.felles.PeriodeDto
@@ -326,7 +327,9 @@ class AdminService(
      *
      * Kandidat = handlingspliktig AG-del (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn FØR
      * [VARSEL_LENKE_FIKSET_TIDSPUNKT] og som fortsatt venter på arbeidstakers del (ingen innsendt arbeidstaker-/
-     * kombinert-del matcher på samme fnr + juridisk enhet + overlappende periode).
+     * kombinert-del matcher på samme fnr + juridisk enhet + overlappende periode). Innsendinger der saken er
+     * AVSLUTTET i melosys-api ekskluderes – der er det ingenting å varsle om (motpart-delen kom typisk via
+     * en annen kanal).
      *
      * Selve sendingen delegeres til [ArbeidstakerVarslingService.resendVarselTilArbeidstaker], som i tillegg
      * hopper over arbeidstakere med påbegynt utkast. Sendingen skjer utenfor lese-transaksjonen (jf.
@@ -363,6 +366,7 @@ class AdminService(
         return alleInnsendte
             .filter { innsending ->
                 innsending.skjema.id !in erstattedeIder &&
+                    innsending.saksstatus != Saksstatus.AVSLUTTET &&
                     erHandlingspliktigAgDel(innsending) &&
                     innsending.opprettetDato.isBefore(VARSEL_LENKE_FIKSET_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -364,7 +364,7 @@ class AdminService(
         val erstattedeIder: Set<UUID> = alleInnsendte
             .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
             .toSet()
-        return alleInnsendte
+        val kandidater = alleInnsendte
             .filter { innsending ->
                 innsending.skjema.id !in erstattedeIder &&
                     innsending.saksstatus != Saksstatus.AVSLUTTET &&
@@ -372,7 +372,13 @@ class AdminService(
                     innsending.opprettetDato.isBefore(VARSEL_LENKE_FIKSET_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
             }
-            .map { ResendKandidat(skjemaId = it.skjema.id!!, saksnummer = it.saksnummer) }
+        kandidater.count { it.saksstatus == null }.takeIf { it > 0 }?.let { antallUtenStatus ->
+            log.warn {
+                "Admin: Resend – $antallUtenStatus av ${kandidater.size} kandidat(er) mangler synket saksstatus " +
+                    "og kan gjelde avsluttede saker. Er saksstatus-massesynken fra melosys-api kjørt?"
+            }
+        }
+        return kandidater.map { ResendKandidat(skjemaId = it.skjema.id!!, saksnummer = it.saksnummer) }
     }
 
     /** Handlingspliktig AG/rådgiver-del uten fullmakt – arbeidstaker må sende inn sin egen del. */

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -372,7 +372,8 @@ class AdminService(
                     innsending.opprettetDato.isBefore(VARSEL_LENKE_FIKSET_TIDSPUNKT) &&
                     venterPaaArbeidstakerDel(innsending, arbeidstakerDeler)
             }
-        kandidater.count { it.saksstatus == null }.takeIf { it > 0 }?.let { antallUtenStatus ->
+        val antallUtenStatus = kandidater.count { it.saksstatus == null }
+        if (antallUtenStatus > 0) {
             log.warn {
                 "Admin: Resend – $antallUtenStatus av ${kandidater.size} kandidat(er) mangler synket saksstatus " +
                     "og kan gjelde avsluttede saker. Er saksstatus-massesynken fra melosys-api kjørt?"

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -141,10 +141,6 @@ class M2MSkjemaService(
                 ukjenteSkjemaIder += oppdatering.skjemaId
                 return@forEach
             }
-            // Rader som deler saksnummer oppdaterer hverandre – hopp over de som allerede er dekket
-            if (innsending.id in oppdaterteInnsendingIder && innsending.saksstatus == oppdatering.saksstatus) {
-                return@forEach
-            }
             oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)
                 .forEach { oppdaterteInnsendingIder += it.id!! }
         }
@@ -180,7 +176,8 @@ class M2MSkjemaService(
 
         val gjeldendeSaksnummer = innsending.saksnummer!!
         val oppdatertTidspunkt = Instant.now()
-        val skalOppdateres = (innsendingRepository.findBySaksnummer(gjeldendeSaksnummer) + innsending).distinctBy { it.id }
+        // Auto-flush før JPQL-spørringen gjør at innsendingen selv (med ev. nysatt saksnummer) er med i resultatet
+        val skalOppdateres = innsendingRepository.findBySaksnummer(gjeldendeSaksnummer)
         skalOppdateres.forEach {
             it.saksstatus = saksstatus
             it.saksstatusOppdatert = oppdatertTidspunkt

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -99,7 +99,17 @@ class M2MSkjemaService(
 
     @Transactional
     fun registrerSaksnummer(skjemaId: UUID, saksnummer: String) {
-        hentInnsending(skjemaId).saksnummer = saksnummer
+        val innsending = hentInnsending(skjemaId)
+        innsending.saksnummer = saksnummer
+
+        // Kobles innsendingen til en sak som allerede har synket status, arves den – ellers
+        // ville den stått som MOTTATT (null) mens søsknene viser noe annet, frem til neste synk.
+        innsendingRepository.findBySaksnummer(saksnummer)
+            .firstOrNull { it.id != innsending.id && it.saksstatus != null }
+            ?.let {
+                innsending.saksstatus = it.saksstatus
+                innsending.saksstatusOppdatert = it.saksstatusOppdatert
+            }
         log.info { "Registrert saksnummer $saksnummer for skjema $skjemaId" }
     }
 
@@ -154,6 +164,9 @@ class M2MSkjemaService(
      * til innsendingens AVSTEMTE saksnummer. Ved avvik beholdes eksisterende saksnummer – en
      * statusoppdatering skal ikke overskrive en etablert sakskobling, og skal heller ikke røre
      * innsendinger på det oppgitte (avvikende) saksnummeret.
+     *
+     * NB: innsendinger på samme sak som selv mangler saksnummer fanges ikke av sweepen – de
+     * dekkes av massesynken fra melosys-api, som sender oppdatering per skjemaId.
      */
     private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): List<Innsending> {
         if (innsending.saksnummer == null) {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.util.UUID
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.entity.Skjema
+import no.nav.melosys.skjema.exception.SaksnummerKonfliktException
 import no.nav.melosys.skjema.extensions.toOsloLocalDateTime
 import no.nav.melosys.skjema.extensions.toUtsendtArbeidstakerDto
 import no.nav.melosys.skjema.integrasjon.pdl.PdlClient
@@ -97,43 +98,46 @@ class M2MSkjemaService(
         }
     }
 
+    /**
+     * Registrerer saksnummer fra melosys-api på innsendingen. Saksnummer er immutabelt når det
+     * først er satt: samme verdi på nytt er idempotent OK, en annen verdi gir
+     * [SaksnummerKonfliktException] (409). Backfill (null → verdi) er alltid OK.
+     *
+     * Den nye innsendingen beholder `saksstatus = null` (vises som Mottatt) uavhengig av andre
+     * innsendinger på samme sak: Melosys oppretter ny behandling for den, så den er per
+     * definisjon under behandling.
+     */
     @Transactional
     fun registrerSaksnummer(skjemaId: UUID, saksnummer: String) {
         val innsending = hentInnsending(skjemaId)
+        validerSaksnummerUendret(innsending, saksnummer)
         innsending.saksnummer = saksnummer
-
-        // Kobles innsendingen til en sak som allerede har synket status, arves den – ellers
-        // ville den stått som MOTTATT (null) mens søsknene viser noe annet, frem til neste synk.
-        innsendingRepository.findBySaksnummer(saksnummer)
-            .firstOrNull { it.id != innsending.id && it.saksstatus != null }
-            ?.let {
-                innsending.saksstatus = it.saksstatus
-                innsending.saksstatusOppdatert = it.saksstatusOppdatert
-            }
         log.info { "Registrert saksnummer $saksnummer for skjema $skjemaId" }
     }
 
     /**
-     * Oppdaterer saksstatus for innsendingen med gitt skjema-id, og for alle andre innsendinger
-     * på samme saksnummer (motpart-deler og nye versjoner skal vise samme status).
-     * Saksnummer settes/oppdateres alltid fra requesten (backfill for historiske innsendinger,
-     * re-kobling hvis melosys-api har flyttet skjemaet til en annen sak).
+     * Oppdaterer saksstatus for innsendingen med gitt skjema-id. Kun den identifiserte
+     * innsendingen oppdateres – andre innsendinger på samme saksnummer røres ikke.
+     * Saksnummer-avvik mot allerede satt saksnummer gir [SaksnummerKonfliktException] (409).
      */
     @Transactional
     fun oppdaterSaksstatus(skjemaId: UUID, saksnummer: String, saksstatus: Saksstatus) {
         val innsending = hentInnsending(skjemaId)
-        val oppdaterte = oppdaterSaksstatusForInnsending(innsending, saksnummer, saksstatus)
-        log.info { "Oppdatert saksstatus til $saksstatus for sak ${innsending.saksnummer} (${oppdaterte.size} innsending(er))" }
+        val oppdatert = oppdaterSaksstatusForInnsending(innsending, saksnummer, saksstatus)
+        log.info { "Oppdatert saksstatus til $saksstatus for sak $saksnummer (endret: $oppdatert)" }
     }
 
     /**
      * Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i stedet for å
-     * feile. Hele batchen kjører i én transaksjon: én uventet feil ruller tilbake alt, og
-     * melosys-api reprøver hele batchen (operasjonen er idempotent).
+     * feile. Rader med saksnummer-konflikt (innsendingen har allerede et annet saksnummer)
+     * hoppes over og rapporteres i [BulkOppdaterSaksstatusResultat.konfliktSkjemaIder] uten å
+     * feile batchen. Hele batchen kjører i én transaksjon: én uventet feil ruller tilbake alt,
+     * og melosys-api reprøver hele batchen (operasjonen er idempotent).
      */
     @Transactional
     fun bulkOppdaterSaksstatus(oppdateringer: List<SaksstatusOppdatering>): BulkOppdaterSaksstatusResultat {
         val ukjenteSkjemaIder = mutableSetOf<UUID>()
+        val konfliktSkjemaIder = mutableSetOf<UUID>()
         val oppdaterteInnsendingIder = mutableSetOf<UUID>()
 
         oppdateringer.forEach { oppdatering ->
@@ -142,51 +146,62 @@ class M2MSkjemaService(
                 ukjenteSkjemaIder += oppdatering.skjemaId
                 return@forEach
             }
-            oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)
-                .forEach { oppdaterteInnsendingIder += it.id!! }
+            try {
+                if (oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)) {
+                    oppdaterteInnsendingIder += innsending.id!!
+                }
+            } catch (e: SaksnummerKonfliktException) {
+                log.warn(e) { "Hopper over rad med saksnummer-konflikt i massesynk" }
+                konfliktSkjemaIder += oppdatering.skjemaId
+            }
         }
 
         log.info {
             "Bulk-oppdatert saksstatus: ${oppdateringer.size} rader, ${oppdaterteInnsendingIder.size} innsending(er) oppdatert, " +
-                "${ukjenteSkjemaIder.size} ukjente skjema-id-er"
+                "${ukjenteSkjemaIder.size} ukjente skjema-id-er, ${konfliktSkjemaIder.size} saksnummer-konflikter"
         }
         return BulkOppdaterSaksstatusResultat(
             antallOppdatert = oppdaterteInnsendingIder.size,
-            ukjenteSkjemaIder = ukjenteSkjemaIder.toList()
+            ukjenteSkjemaIder = ukjenteSkjemaIder.toList(),
+            konfliktSkjemaIder = konfliktSkjemaIder.toList()
         )
     }
 
     /**
-     * Setter saksnummer fra melosys-api (autoritativ for skjema→sak-koblingen, akkurat som i
-     * [registrerSaksnummer] – avvik betyr at skjemaet er re-koblet til en annen sak, og logges),
-     * og oppdaterer saksstatus på alle innsendinger på samme saksnummer. Kohorten holdes dermed
-     * alltid konsistent: statusen gjelder saken, og alle som peker på den får samme verdi.
+     * Oppdaterer saksstatus for KUN denne innsendingen. Saksnummer er immutabelt når det først
+     * er satt ([validerSaksnummerUendret]); backfill (null → verdi) er OK.
      *
-     * Innsendinger som allerede har riktig saksstatus røres ikke – returverdien teller kun
-     * faktiske endringer, slik at en gjentatt synk rapporterer 0 og [Innsending.saksstatusOppdatert]
-     * betyr «sist endret», ikke «sist skrevet».
+     * Monotoni-guard: Avsluttet er terminal for en innsending; en revurdering i Melosys skal
+     * ikke resette ferdigbehandlede innsendinger (produkteierbeslutning 2026-07-21). Forsøk på
+     * nedgradering AVSLUTTET → MOTTATT hoppes derfor over med warn-logg og telles ikke som
+     * oppdatert.
      *
-     * NB: innsendinger på samme sak som selv mangler saksnummer fanges ikke av sweepen – de
-     * dekkes av massesynken fra melosys-api, som sender oppdatering per skjemaId.
+     * Skriver kun ved faktisk endring – returverdien er `false` når status er uendret, slik at
+     * en gjentatt synk rapporterer 0 og [Innsending.saksstatusOppdatert] betyr «sist endret»,
+     * ikke «sist skrevet».
      */
-    private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): List<Innsending> {
-        if (innsending.saksnummer != null && innsending.saksnummer != saksnummer) {
-            log.warn {
-                "Saksstatus-oppdatering for skjema ${innsending.skjema.id} oppga saksnummer $saksnummer, " +
-                    "men innsendingen hadde saksnummer ${innsending.saksnummer} - skjemaet er re-koblet i melosys-api"
-            }
-        }
+    private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): Boolean {
+        validerSaksnummerUendret(innsending, saksnummer)
         innsending.saksnummer = saksnummer
 
-        val oppdatertTidspunkt = Instant.now()
-        // Auto-flush før JPQL-spørringen gjør at innsendingen selv (med ev. nysatt saksnummer) er med i resultatet
-        val endres = innsendingRepository.findBySaksnummer(saksnummer)
-            .filter { it.saksstatus != saksstatus }
-        endres.forEach {
-            it.saksstatus = saksstatus
-            it.saksstatusOppdatert = oppdatertTidspunkt
+        if (innsending.saksstatus == saksstatus) {
+            return false
         }
-        return endres
+        if (innsending.saksstatus == Saksstatus.AVSLUTTET && saksstatus == Saksstatus.MOTTATT) {
+            log.warn { "Ignorerer nedgradering AVSLUTTET → MOTTATT for skjema ${innsending.skjema.id} på sak $saksnummer" }
+            return false
+        }
+
+        innsending.saksstatus = saksstatus
+        innsending.saksstatusOppdatert = Instant.now()
+        return true
+    }
+
+    private fun validerSaksnummerUendret(innsending: Innsending, saksnummer: String) {
+        val eksisterende = innsending.saksnummer ?: return
+        if (eksisterende != saksnummer) {
+            throw SaksnummerKonfliktException(innsending.skjema.id!!, eksisterende, saksnummer)
+        }
     }
 
     private fun hentInnsending(skjemaId: UUID): Innsending =

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -49,8 +49,7 @@ class M2MSkjemaService(
         val skjema = skjemaRepository.findByIdAndStatusSendt(id)
             ?: throw NoSuchElementException("Skjema med id $id ikke funnet")
 
-        val innsending = innsendingRepository.findBySkjemaId(skjema.id!!)
-            ?: throw NoSuchElementException("Innsending for skjema med id $id ikke funnet")
+        val innsending = hentInnsending(skjema.id!!)
 
         val skjemaDto = skjema.toUtsendtArbeidstakerDto()
 
@@ -100,11 +99,7 @@ class M2MSkjemaService(
 
     @Transactional
     fun registrerSaksnummer(skjemaId: UUID, saksnummer: String) {
-        val innsending = innsendingRepository.findBySkjemaId(skjemaId)
-            ?: throw NoSuchElementException("Innsending for skjema med id $skjemaId ikke funnet")
-
-        innsending.saksnummer = saksnummer
-        innsendingRepository.save(innsending)
+        hentInnsending(skjemaId).saksnummer = saksnummer
         log.info { "Registrert saksnummer $saksnummer for skjema $skjemaId" }
     }
 
@@ -115,36 +110,52 @@ class M2MSkjemaService(
      */
     @Transactional
     fun oppdaterSaksstatus(skjemaId: UUID, saksnummer: String, saksstatus: Saksstatus) {
-        val innsending = innsendingRepository.findBySkjemaId(skjemaId)
-            ?: throw NoSuchElementException("Innsending for skjema med id $skjemaId ikke funnet")
-
-        val antallOppdatert = oppdaterSaksstatusForInnsending(innsending, saksnummer, saksstatus)
-        log.info { "Oppdatert saksstatus til $saksstatus for sak $saksnummer ($antallOppdatert innsending(er))" }
+        val innsending = hentInnsending(skjemaId)
+        val oppdaterte = oppdaterSaksstatusForInnsending(innsending, saksnummer, saksstatus)
+        log.info { "Oppdatert saksstatus til $saksstatus for sak ${innsending.saksnummer} (${oppdaterte.size} innsending(er))" }
     }
 
-    /** Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i stedet for å feile. */
+    /**
+     * Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i stedet for å
+     * feile. Hele batchen kjører i én transaksjon: én uventet feil ruller tilbake alt, og
+     * melosys-api reprøver hele batchen (operasjonen er idempotent).
+     */
     @Transactional
     fun bulkOppdaterSaksstatus(oppdateringer: List<SaksstatusOppdatering>): BulkOppdaterSaksstatusResultat {
         val ukjenteSkjemaIder = mutableListOf<UUID>()
-        var antallOppdatert = 0
+        val oppdaterteInnsendingIder = mutableSetOf<UUID>()
 
         oppdateringer.forEach { oppdatering ->
             val innsending = innsendingRepository.findBySkjemaId(oppdatering.skjemaId)
             if (innsending == null) {
                 ukjenteSkjemaIder += oppdatering.skjemaId
-            } else {
-                antallOppdatert += oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)
+                return@forEach
             }
+            // Rader som deler saksnummer oppdaterer hverandre – hopp over de som allerede er dekket
+            if (innsending.id in oppdaterteInnsendingIder && innsending.saksstatus == oppdatering.saksstatus) {
+                return@forEach
+            }
+            oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)
+                .forEach { oppdaterteInnsendingIder += it.id!! }
         }
 
         log.info {
-            "Bulk-oppdatert saksstatus: ${oppdateringer.size} rader, $antallOppdatert innsending(er) oppdatert, " +
+            "Bulk-oppdatert saksstatus: ${oppdateringer.size} rader, ${oppdaterteInnsendingIder.size} innsending(er) oppdatert, " +
                 "${ukjenteSkjemaIder.size} ukjente skjema-id-er"
         }
-        return BulkOppdaterSaksstatusResultat(antallOppdatert = antallOppdatert, ukjenteSkjemaIder = ukjenteSkjemaIder)
+        return BulkOppdaterSaksstatusResultat(
+            antallOppdatert = oppdaterteInnsendingIder.size,
+            ukjenteSkjemaIder = ukjenteSkjemaIder
+        )
     }
 
-    private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): Int {
+    /**
+     * Setter saksnummer hvis det mangler, og oppdaterer saksstatus på alle innsendinger som hører
+     * til innsendingens AVSTEMTE saksnummer. Ved avvik beholdes eksisterende saksnummer – en
+     * statusoppdatering skal ikke overskrive en etablert sakskobling, og skal heller ikke røre
+     * innsendinger på det oppgitte (avvikende) saksnummeret.
+     */
+    private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): List<Innsending> {
         if (innsending.saksnummer == null) {
             innsending.saksnummer = saksnummer
         } else if (innsending.saksnummer != saksnummer) {
@@ -154,15 +165,19 @@ class M2MSkjemaService(
             }
         }
 
+        val gjeldendeSaksnummer = innsending.saksnummer!!
         val oppdatertTidspunkt = Instant.now()
-        val skalOppdateres = (innsendingRepository.findBySaksnummer(saksnummer) + innsending).distinctBy { it.id }
+        val skalOppdateres = (innsendingRepository.findBySaksnummer(gjeldendeSaksnummer) + innsending).distinctBy { it.id }
         skalOppdateres.forEach {
             it.saksstatus = saksstatus
             it.saksstatusOppdatert = oppdatertTidspunkt
         }
-        innsendingRepository.saveAll(skalOppdateres)
-        return skalOppdateres.size
+        return skalOppdateres
     }
+
+    private fun hentInnsending(skjemaId: UUID): Innsending =
+        innsendingRepository.findBySkjemaId(skjemaId)
+            ?: throw NoSuchElementException("Innsending for skjema med id $skjemaId ikke funnet")
 
     fun hentVedleggInnhold(skjemaId: UUID, vedleggId: UUID): VedleggInnhold {
         log.info { "M2M: Henter vedlegg $vedleggId for skjema $skjemaId" }
@@ -176,8 +191,7 @@ class M2MSkjemaService(
         val skjema = skjemaRepository.findByIdAndStatusSendt(skjemaId)
             ?: throw NoSuchElementException("Skjema med id $skjemaId ikke funnet")
 
-        val innsending = innsendingRepository.findBySkjemaId(skjema.id!!)
-            ?: throw NoSuchElementException("Innsending for skjema med id $skjemaId ikke funnet")
+        val innsending = hentInnsending(skjema.id!!)
 
         return when (skjema.type) {
             SkjemaType.UTSENDT_ARBEIDSTAKER -> {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -116,7 +116,8 @@ class M2MSkjemaService(
     /**
      * Oppdaterer saksstatus for innsendingen med gitt skjema-id, og for alle andre innsendinger
      * på samme saksnummer (motpart-deler og nye versjoner skal vise samme status).
-     * Setter også saksnummer på innsendingen hvis det mangler (backfill for historiske innsendinger).
+     * Saksnummer settes/oppdateres alltid fra requesten (backfill for historiske innsendinger,
+     * re-kobling hvis melosys-api har flyttet skjemaet til en annen sak).
      */
     @Transactional
     fun oppdaterSaksstatus(skjemaId: UUID, saksnummer: String, saksstatus: Saksstatus) {
@@ -156,33 +157,26 @@ class M2MSkjemaService(
     }
 
     /**
-     * Setter saksnummer hvis det mangler, og oppdaterer saksstatus på alle innsendinger på samme
-     * saksnummer. Ved saksnummer-avvik (innsendingen er koblet til en annen sak enn requesten
-     * oppgir) oppdateres KUN den identifiserte innsendingen – statusen gjelder skjemaet
-     * (skjema_sak_mapping i melosys-api er per skjemaId), men å sweepe noen av sak-kohortene
-     * ville smittet status på tvers av saker.
+     * Setter saksnummer fra melosys-api (autoritativ for skjema→sak-koblingen, akkurat som i
+     * [registrerSaksnummer] – avvik betyr at skjemaet er re-koblet til en annen sak, og logges),
+     * og oppdaterer saksstatus på alle innsendinger på samme saksnummer. Kohorten holdes dermed
+     * alltid konsistent: statusen gjelder saken, og alle som peker på den får samme verdi.
      *
      * NB: innsendinger på samme sak som selv mangler saksnummer fanges ikke av sweepen – de
      * dekkes av massesynken fra melosys-api, som sender oppdatering per skjemaId.
      */
     private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): List<Innsending> {
-        val oppdatertTidspunkt = Instant.now()
-
-        if (innsending.saksnummer == null) {
-            innsending.saksnummer = saksnummer
-        } else if (innsending.saksnummer != saksnummer) {
+        if (innsending.saksnummer != null && innsending.saksnummer != saksnummer) {
             log.warn {
                 "Saksstatus-oppdatering for skjema ${innsending.skjema.id} oppga saksnummer $saksnummer, " +
-                    "men innsendingen har allerede saksnummer ${innsending.saksnummer} - beholder eksisterende " +
-                    "og oppdaterer kun denne innsendingen"
+                    "men innsendingen hadde saksnummer ${innsending.saksnummer} - skjemaet er re-koblet i melosys-api"
             }
-            innsending.saksstatus = saksstatus
-            innsending.saksstatusOppdatert = oppdatertTidspunkt
-            return listOf(innsending)
         }
+        innsending.saksnummer = saksnummer
 
+        val oppdatertTidspunkt = Instant.now()
         // Auto-flush før JPQL-spørringen gjør at innsendingen selv (med ev. nysatt saksnummer) er med i resultatet
-        val skalOppdateres = innsendingRepository.findBySaksnummer(innsending.saksnummer!!)
+        val skalOppdateres = innsendingRepository.findBySaksnummer(saksnummer)
         skalOppdateres.forEach {
             it.saksstatus = saksstatus
             it.saksstatusOppdatert = oppdatertTidspunkt

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -132,7 +132,7 @@ class M2MSkjemaService(
      */
     @Transactional
     fun bulkOppdaterSaksstatus(oppdateringer: List<SaksstatusOppdatering>): BulkOppdaterSaksstatusResultat {
-        val ukjenteSkjemaIder = mutableListOf<UUID>()
+        val ukjenteSkjemaIder = mutableSetOf<UUID>()
         val oppdaterteInnsendingIder = mutableSetOf<UUID>()
 
         oppdateringer.forEach { oppdatering ->
@@ -151,33 +151,38 @@ class M2MSkjemaService(
         }
         return BulkOppdaterSaksstatusResultat(
             antallOppdatert = oppdaterteInnsendingIder.size,
-            ukjenteSkjemaIder = ukjenteSkjemaIder
+            ukjenteSkjemaIder = ukjenteSkjemaIder.toList()
         )
     }
 
     /**
-     * Setter saksnummer hvis det mangler, og oppdaterer saksstatus på alle innsendinger som hører
-     * til innsendingens AVSTEMTE saksnummer. Ved avvik beholdes eksisterende saksnummer – en
-     * statusoppdatering skal ikke overskrive en etablert sakskobling, og skal heller ikke røre
-     * innsendinger på det oppgitte (avvikende) saksnummeret.
+     * Setter saksnummer hvis det mangler, og oppdaterer saksstatus på alle innsendinger på samme
+     * saksnummer. Ved saksnummer-avvik (innsendingen er koblet til en annen sak enn requesten
+     * oppgir) oppdateres KUN den identifiserte innsendingen – statusen gjelder skjemaet
+     * (skjema_sak_mapping i melosys-api er per skjemaId), men å sweepe noen av sak-kohortene
+     * ville smittet status på tvers av saker.
      *
      * NB: innsendinger på samme sak som selv mangler saksnummer fanges ikke av sweepen – de
      * dekkes av massesynken fra melosys-api, som sender oppdatering per skjemaId.
      */
     private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): List<Innsending> {
+        val oppdatertTidspunkt = Instant.now()
+
         if (innsending.saksnummer == null) {
             innsending.saksnummer = saksnummer
         } else if (innsending.saksnummer != saksnummer) {
             log.warn {
                 "Saksstatus-oppdatering for skjema ${innsending.skjema.id} oppga saksnummer $saksnummer, " +
-                    "men innsendingen har allerede saksnummer ${innsending.saksnummer} - beholder eksisterende"
+                    "men innsendingen har allerede saksnummer ${innsending.saksnummer} - beholder eksisterende " +
+                    "og oppdaterer kun denne innsendingen"
             }
+            innsending.saksstatus = saksstatus
+            innsending.saksstatusOppdatert = oppdatertTidspunkt
+            return listOf(innsending)
         }
 
-        val gjeldendeSaksnummer = innsending.saksnummer!!
-        val oppdatertTidspunkt = Instant.now()
         // Auto-flush før JPQL-spørringen gjør at innsendingen selv (med ev. nysatt saksnummer) er med i resultatet
-        val skalOppdateres = innsendingRepository.findBySaksnummer(gjeldendeSaksnummer)
+        val skalOppdateres = innsendingRepository.findBySaksnummer(innsending.saksnummer!!)
         skalOppdateres.forEach {
             it.saksstatus = saksstatus
             it.saksstatusOppdatert = oppdatertTidspunkt

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -162,6 +162,10 @@ class M2MSkjemaService(
      * og oppdaterer saksstatus på alle innsendinger på samme saksnummer. Kohorten holdes dermed
      * alltid konsistent: statusen gjelder saken, og alle som peker på den får samme verdi.
      *
+     * Innsendinger som allerede har riktig saksstatus røres ikke – returverdien teller kun
+     * faktiske endringer, slik at en gjentatt synk rapporterer 0 og [Innsending.saksstatusOppdatert]
+     * betyr «sist endret», ikke «sist skrevet».
+     *
      * NB: innsendinger på samme sak som selv mangler saksnummer fanges ikke av sweepen – de
      * dekkes av massesynken fra melosys-api, som sender oppdatering per skjemaId.
      */
@@ -176,12 +180,13 @@ class M2MSkjemaService(
 
         val oppdatertTidspunkt = Instant.now()
         // Auto-flush før JPQL-spørringen gjør at innsendingen selv (med ev. nysatt saksnummer) er med i resultatet
-        val skalOppdateres = innsendingRepository.findBySaksnummer(saksnummer)
-        skalOppdateres.forEach {
+        val endres = innsendingRepository.findBySaksnummer(saksnummer)
+            .filter { it.saksstatus != saksstatus }
+        endres.forEach {
             it.saksstatus = saksstatus
             it.saksstatusOppdatert = oppdatertTidspunkt
         }
-        return skalOppdateres
+        return endres
     }
 
     private fun hentInnsending(skjemaId: UUID): Innsending =

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.skjema.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Instant
 import java.util.UUID
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.entity.Skjema
@@ -25,7 +26,10 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMedFullmaktMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaDto
+import no.nav.melosys.skjema.types.m2m.BulkOppdaterSaksstatusResultat
+import no.nav.melosys.skjema.types.m2m.SaksstatusOppdatering
 import no.nav.melosys.skjema.types.m2m.UtsendtArbeidstakerSkjemaM2MDto
+import no.nav.melosys.skjema.types.common.Saksstatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -102,6 +106,62 @@ class M2MSkjemaService(
         innsending.saksnummer = saksnummer
         innsendingRepository.save(innsending)
         log.info { "Registrert saksnummer $saksnummer for skjema $skjemaId" }
+    }
+
+    /**
+     * Oppdaterer saksstatus for innsendingen med gitt skjema-id, og for alle andre innsendinger
+     * på samme saksnummer (motpart-deler og nye versjoner skal vise samme status).
+     * Setter også saksnummer på innsendingen hvis det mangler (backfill for historiske innsendinger).
+     */
+    @Transactional
+    fun oppdaterSaksstatus(skjemaId: UUID, saksnummer: String, saksstatus: Saksstatus) {
+        val innsending = innsendingRepository.findBySkjemaId(skjemaId)
+            ?: throw NoSuchElementException("Innsending for skjema med id $skjemaId ikke funnet")
+
+        val antallOppdatert = oppdaterSaksstatusForInnsending(innsending, saksnummer, saksstatus)
+        log.info { "Oppdatert saksstatus til $saksstatus for sak $saksnummer ($antallOppdatert innsending(er))" }
+    }
+
+    /** Massesynk av saksstatus fra melosys-api. Ukjente skjema-id-er rapporteres i stedet for å feile. */
+    @Transactional
+    fun bulkOppdaterSaksstatus(oppdateringer: List<SaksstatusOppdatering>): BulkOppdaterSaksstatusResultat {
+        val ukjenteSkjemaIder = mutableListOf<UUID>()
+        var antallOppdatert = 0
+
+        oppdateringer.forEach { oppdatering ->
+            val innsending = innsendingRepository.findBySkjemaId(oppdatering.skjemaId)
+            if (innsending == null) {
+                ukjenteSkjemaIder += oppdatering.skjemaId
+            } else {
+                antallOppdatert += oppdaterSaksstatusForInnsending(innsending, oppdatering.saksnummer, oppdatering.saksstatus)
+            }
+        }
+
+        log.info {
+            "Bulk-oppdatert saksstatus: ${oppdateringer.size} rader, $antallOppdatert innsending(er) oppdatert, " +
+                "${ukjenteSkjemaIder.size} ukjente skjema-id-er"
+        }
+        return BulkOppdaterSaksstatusResultat(antallOppdatert = antallOppdatert, ukjenteSkjemaIder = ukjenteSkjemaIder)
+    }
+
+    private fun oppdaterSaksstatusForInnsending(innsending: Innsending, saksnummer: String, saksstatus: Saksstatus): Int {
+        if (innsending.saksnummer == null) {
+            innsending.saksnummer = saksnummer
+        } else if (innsending.saksnummer != saksnummer) {
+            log.warn {
+                "Saksstatus-oppdatering for skjema ${innsending.skjema.id} oppga saksnummer $saksnummer, " +
+                    "men innsendingen har allerede saksnummer ${innsending.saksnummer} - beholder eksisterende"
+            }
+        }
+
+        val oppdatertTidspunkt = Instant.now()
+        val skalOppdateres = (innsendingRepository.findBySaksnummer(saksnummer) + innsending).distinctBy { it.id }
+        skalOppdateres.forEach {
+            it.saksstatus = saksstatus
+            it.saksstatusOppdatert = oppdatertTidspunkt
+        }
+        innsendingRepository.saveAll(skalOppdateres)
+        return skalOppdateres.size
     }
 
     fun hentVedleggInnhold(skjemaId: UUID, vedleggId: UUID): VedleggInnhold {

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MProtectedAspect.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MProtectedAspect.kt
@@ -28,7 +28,7 @@ class M2MProtectedAspect(
 
     @Before("@annotation(no.nav.melosys.skjema.sikkerhet.M2MWriteSkjemadata)")
     fun validateWriteSkjemadataAccess() {
-        validateClientAccess(m2mConfigProperties.readSkjemadata.clients)
+        validateClientAccess(m2mConfigProperties.writeSkjemadata.clients)
     }
 
     @Before(

--- a/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MWriteSkjemadata.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/sikkerhet/M2MWriteSkjemadata.kt
@@ -6,8 +6,8 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
  * Annotasjon for M2M-beskyttede endepunkter som gir skrivetilgang til skjemadata.
  * Kombinerer Azure AD token-validering med klient-tilgangsstyring.
  *
- * Bruker samme klientliste som lesetilgang (m2m.read-skjemadata.clients),
- * men er skilt ut som egen annotasjon for å tydeliggjøre at endepunktet muterer data.
+ * Valideres mot egen klientliste (m2m.write-skjemadata.clients), adskilt fra
+ * lesetilgangen, siden endepunktet muterer data.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -190,6 +190,9 @@ m2m:
   read-skjemadata:
     clients:
       - ${MELOSYS_CLIENT_ID}
+  write-skjemadata:
+    clients:
+      - ${MELOSYS_CLIENT_ID}
   # Tilgang til admin-endepunktene (/admin/**): både azp_name-allowlist og delt
   # API-nøkkel må stemme (i tillegg til gyldig Azure AD-token).
   # clients: typisk melosys-console på formatet `<cluster>:teammelosys:melosys-console`.

--- a/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
+++ b/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
@@ -1,2 +1,5 @@
 ALTER TABLE innsending ADD COLUMN saksstatus VARCHAR(20);
 ALTER TABLE innsending ADD COLUMN saksstatus_oppdatert TIMESTAMP WITH TIME ZONE;
+
+-- Saksstatus-synk slår opp alle innsendinger på samme sak
+CREATE INDEX idx_innsending_saksnummer ON innsending (saksnummer);

--- a/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
+++ b/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
@@ -1,5 +1,5 @@
 ALTER TABLE innsending ADD COLUMN saksstatus VARCHAR(20);
 ALTER TABLE innsending ADD COLUMN saksstatus_oppdatert TIMESTAMP WITH TIME ZONE;
 
--- Saksstatus-synk slår opp alle innsendinger på samme sak
+-- Oppslag på saksnummer (visning/admin - synken selv oppdaterer per skjema-id)
 CREATE INDEX idx_innsending_saksnummer ON innsending (saksnummer);

--- a/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
+++ b/src/main/resources/db/migration/V17__Add_saksstatus_to_innsending.sql
@@ -1,0 +1,2 @@
+ALTER TABLE innsending ADD COLUMN saksstatus VARCHAR(20);
+ALTER TABLE innsending ADD COLUMN saksstatus_oppdatert TIMESTAMP WITH TIME ZONE;

--- a/src/test/kotlin/no/nav/melosys/skjema/MockOAuth2ServerExtensions.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/MockOAuth2ServerExtensions.kt
@@ -7,6 +7,7 @@ import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 const val ACCEPTED_AUDIENCE = "test-client-id"
 const val ACCEPTED_AZURE_AUDIENCE = "test-azure-client-id"
 const val MELOSYS_CLIENT_ID = "test-melosys-client-id"
+const val READ_ONLY_CLIENT_ID = "test-read-only-client-id"
 const val MELOSYS_CONSOLE_CLIENT_ID = "test-console-client-id"
 const val ISSUER_ID = "tokenx"
 const val AZURE_ISSUER_ID = "azure"
@@ -37,6 +38,9 @@ fun MockOAuth2Server.tokenWithAzpClaim(azpName: String): String = getToken(
 )
 
 fun MockOAuth2Server.m2mTokenWithReadSkjemaDataAccess(): String = tokenWithAzpClaim(MELOSYS_CLIENT_ID)
+
+/** Klient som kun står i read-allowlisten (se application-test.yml) – for å teste read/write-skillet. */
+fun MockOAuth2Server.m2mTokenWithOnlyReadSkjemaDataAccess(): String = tokenWithAzpClaim(READ_ONLY_CLIENT_ID)
 
 fun MockOAuth2Server.m2mTokenWithoutAccess(): String = tokenWithAzpClaim("ukjent-klient-id")
 

--- a/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
@@ -53,6 +53,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidssituasjonDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.FamiliemedlemmerDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.SkatteforholdOgInntektDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendingsperiodeOgLandDto
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.felles.Ansettelsesform
@@ -472,7 +473,8 @@ fun innsendingMedDefaultVerdier(
     skjemaDefinisjonVersjon: String = "1",
     innsendtSprak: Språk = Språk.NORSK_BOKMAL,
     innsenderFnr: String = "12345678901",
-    saksnummer: String? = null
+    saksnummer: String? = null,
+    saksstatus: Saksstatus? = null
 ) = Innsending(
     id = id,
     skjema = skjema,
@@ -487,4 +489,5 @@ fun innsendingMedDefaultVerdier(
     innsenderFnr = innsenderFnr
 ).apply {
     this.saksnummer = saksnummer
+    this.saksstatus = saksstatus
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -455,7 +455,7 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal ved saksnummer-avvik beholde eksisterende saksnummer og oppdatere den saken - ikke den oppgitte`() {
+        fun `skal ved saksnummer-avvik kun oppdatere den identifiserte innsendingen`() {
             val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
             val soskenPaaEgenSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
             val innsendingPaaOppgittSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-301")
@@ -463,12 +463,12 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
             oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "AVSLUTTET"}""")
                 .expectStatus().isNoContent
 
+            // Statusen gjelder skjemaet (per skjemaId i melosys-api) og settes på innsendingen...
             val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
             oppdatert.saksnummer shouldBe "MEL-300"
             oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
-            // Søsken på innsendingens reelle sak oppdateres...
-            innsendingRepository.findBySkjemaId(soskenPaaEgenSak.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
-            // ...mens innsendinger på det oppgitte (avvikende) saksnummeret ikke røres
+            // ...men ingen av sak-kohortene sweepes - verken egen sak eller den oppgitte
+            innsendingRepository.findBySkjemaId(soskenPaaEgenSak.id!!)!!.saksstatus.shouldBeNull()
             innsendingRepository.findBySkjemaId(innsendingPaaOppgittSak.id!!)!!.saksstatus.shouldBeNull()
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -289,11 +289,10 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal arve saksstatus naar saken allerede er synket for andre innsendinger`() {
-            val sosken = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-600")
-            innsendingRepository.save(
-                innsendingRepository.findBySkjemaId(sosken.id!!)!!.apply { saksstatus = Saksstatus.AVSLUTTET }
-            )
+        fun `skal ikke arve saksstatus fra soesken - ny innsending forblir null (Mottatt)`() {
+            // Søsken på samme sak er AVSLUTTET, men Melosys oppretter ny behandling for den nye
+            // innsendingen – den skal derfor stå som null (Mottatt), ikke arve søskenens status.
+            lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-600", saksstatus = Saksstatus.AVSLUTTET)
             val nyttSkjema = lagInnsendtSkjemaMedInnsending(saksnummer = null)
 
             val token = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
@@ -305,7 +304,42 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
                 .exchange()
                 .expectStatus().isNoContent
 
-            innsendingRepository.findBySkjemaId(nyttSkjema.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            val oppdatert = innsendingRepository.findBySkjemaId(nyttSkjema.id!!)!!
+            oppdatert.saksnummer shouldBe "MEL-600"
+            oppdatert.saksstatus.shouldBeNull()
+        }
+
+        @Test
+        fun `skal vaere idempotent naar samme saksnummer registreres paa nytt`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-601")
+
+            val token = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
+            webTestClient.post()
+                .uri("/m2m/api/skjema/${skjema.id}/saksnummer")
+                .header("Authorization", "Bearer $token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-601"}""")
+                .exchange()
+                .expectStatus().isNoContent
+
+            innsendingRepository.findBySkjemaId(skjema.id!!)!!.saksnummer shouldBe "MEL-601"
+        }
+
+        @Test
+        fun `skal returnere 409 naar innsendingen allerede har et annet saksnummer`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-602")
+
+            val token = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
+            webTestClient.post()
+                .uri("/m2m/api/skjema/${skjema.id}/saksnummer")
+                .header("Authorization", "Bearer $token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-603"}""")
+                .exchange()
+                .expectStatus().isEqualTo(409)
+
+            // Saksnummer er immutabelt – eksisterende verdi skal stå urørt
+            innsendingRepository.findBySkjemaId(skjema.id!!)!!.saksnummer shouldBe "MEL-602"
         }
 
         @Test
@@ -406,12 +440,12 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
     }
 
-    private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
+    private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null, saksstatus: Saksstatus? = null): Skjema {
         val skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
         )
         innsendingRepository.save(
-            innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
+            innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer, saksstatus = saksstatus)
         )
         return skjema
     }
@@ -441,7 +475,7 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal oppdatere alle innsendinger med samme saksnummer`() {
+        fun `skal kun oppdatere innsendingen for gitt skjema-id`() {
             val agDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-200")
             val atDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-200")
             val annenSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-999")
@@ -450,26 +484,37 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
                 .expectStatus().isNoContent
 
             innsendingRepository.findBySkjemaId(agDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
-            innsendingRepository.findBySkjemaId(atDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            // Andre innsendinger røres ikke – heller ikke de på samme saksnummer
+            innsendingRepository.findBySkjemaId(atDel.id!!)!!.saksstatus.shouldBeNull()
             innsendingRepository.findBySkjemaId(annenSak.id!!)!!.saksstatus.shouldBeNull()
         }
 
         @Test
-        fun `skal ved saksnummer-avvik re-koble innsendingen til oppgitt sak og oppdatere den kohorten`() {
+        fun `skal returnere 409 ved saksnummer-avvik uten aa endre noe`() {
             val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
-            val soskenPaaGammelSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
-            val innsendingPaaNySak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-301")
 
             oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "AVSLUTTET"}""")
+                .expectStatus().isEqualTo(409)
+
+            // Saksnummer er immutabelt – hverken saksnummer eller saksstatus skal endres
+            val uendret = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            uendret.saksnummer shouldBe "MEL-300"
+            uendret.saksstatus.shouldBeNull()
+            uendret.saksstatusOppdatert.shouldBeNull()
+        }
+
+        @Test
+        fun `skal ikke nedgradere AVSLUTTET til MOTTATT`() {
+            // Avsluttet er terminal for en innsending; en revurdering i Melosys skal ikke
+            // resette ferdigbehandlede innsendinger (produkteierbeslutning 2026-07-21).
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-310", saksstatus = Saksstatus.AVSLUTTET)
+
+            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-310", "saksstatus": "MOTTATT"}""")
                 .expectStatus().isNoContent
 
-            // melosys-api er autoritativ for skjema→sak-koblingen: saksnummer overskrives...
-            val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
-            oppdatert.saksnummer shouldBe "MEL-301"
-            oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
-            // ...den nye sak-kohorten sweepes, mens den gamle ikke røres
-            innsendingRepository.findBySkjemaId(innsendingPaaNySak.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
-            innsendingRepository.findBySkjemaId(soskenPaaGammelSak.id!!)!!.saksstatus.shouldBeNull()
+            val uendret = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            uendret.saksstatus shouldBe Saksstatus.AVSLUTTET
+            uendret.saksstatusOppdatert.shouldBeNull()
         }
 
         @Test
@@ -609,10 +654,63 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
 
             resultat.antallOppdatert shouldBe 2
             resultat.ukjenteSkjemaIder shouldBe listOf(ukjentSkjemaId)
+            resultat.konfliktSkjemaIder shouldBe emptyList()
             innsendingRepository.findBySkjemaId(medSaksnummer.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
             val backfillet = innsendingRepository.findBySkjemaId(utenSaksnummer.id!!)!!
             backfillet.saksstatus shouldBe Saksstatus.MOTTATT
             backfillet.saksnummer shouldBe "MEL-401"
+        }
+
+        @Test
+        fun `skal rapportere konfliktrad uten aa feile batchen`() {
+            val medKonflikt = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-800")
+            val utenKonflikt = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-801")
+
+            val resultat = webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(
+                    """
+                    {"oppdateringer": [
+                        {"skjemaId": "${medKonflikt.id}", "saksnummer": "MEL-899", "saksstatus": "AVSLUTTET"},
+                        {"skjemaId": "${utenKonflikt.id}", "saksnummer": "MEL-801", "saksstatus": "AVSLUTTET"}
+                    ]}
+                    """.trimIndent()
+                )
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BulkOppdaterSaksstatusResultat>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            resultat.antallOppdatert shouldBe 1
+            resultat.konfliktSkjemaIder shouldBe listOf(medKonflikt.id)
+            // Konfliktraden skal stå urørt (immutabelt saksnummer, ingen statusendring)
+            val uendret = innsendingRepository.findBySkjemaId(medKonflikt.id!!)!!
+            uendret.saksnummer shouldBe "MEL-800"
+            uendret.saksstatus.shouldBeNull()
+            innsendingRepository.findBySkjemaId(utenKonflikt.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+        }
+
+        @Test
+        fun `skal ikke nedgradere AVSLUTTET til MOTTATT i bulk`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-810", saksstatus = Saksstatus.AVSLUTTET)
+
+            val resultat = webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"oppdateringer": [{"skjemaId": "${skjema.id}", "saksnummer": "MEL-810", "saksstatus": "MOTTATT"}]}""")
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BulkOppdaterSaksstatusResultat>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            resultat.antallOppdatert shouldBe 0
+            resultat.konfliktSkjemaIder shouldBe emptyList()
+            val uendret = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            uendret.saksstatus shouldBe Saksstatus.AVSLUTTET
+            uendret.saksstatusOppdatert.shouldBeNull()
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -455,21 +455,21 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal ved saksnummer-avvik kun oppdatere den identifiserte innsendingen`() {
+        fun `skal ved saksnummer-avvik re-koble innsendingen til oppgitt sak og oppdatere den kohorten`() {
             val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
-            val soskenPaaEgenSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
-            val innsendingPaaOppgittSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-301")
+            val soskenPaaGammelSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
+            val innsendingPaaNySak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-301")
 
             oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "AVSLUTTET"}""")
                 .expectStatus().isNoContent
 
-            // Statusen gjelder skjemaet (per skjemaId i melosys-api) og settes på innsendingen...
+            // melosys-api er autoritativ for skjema→sak-koblingen: saksnummer overskrives...
             val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
-            oppdatert.saksnummer shouldBe "MEL-300"
+            oppdatert.saksnummer shouldBe "MEL-301"
             oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
-            // ...men ingen av sak-kohortene sweepes - verken egen sak eller den oppgitte
-            innsendingRepository.findBySkjemaId(soskenPaaEgenSak.id!!)!!.saksstatus.shouldBeNull()
-            innsendingRepository.findBySkjemaId(innsendingPaaOppgittSak.id!!)!!.saksstatus.shouldBeNull()
+            // ...den nye sak-kohorten sweepes, mens den gamle ikke røres
+            innsendingRepository.findBySkjemaId(innsendingPaaNySak.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            innsendingRepository.findBySkjemaId(soskenPaaGammelSak.id!!)!!.saksstatus.shouldBeNull()
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -385,19 +385,19 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
     }
 
+    private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
+        )
+        innsendingRepository.save(
+            innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
+        )
+        return skjema
+    }
+
     @Nested
     @DisplayName("PUT /m2m/api/skjema/{id}/saksstatus")
     inner class OppdaterSaksstatus {
-
-        private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
-            val skjema = skjemaRepository.save(
-                skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
-            )
-            innsendingRepository.save(
-                innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
-            )
-            return skjema
-        }
 
         private fun oppdaterSaksstatus(skjemaId: UUID, body: String) = webTestClient.put()
             .uri("/m2m/api/skjema/$skjemaId/saksstatus")
@@ -434,15 +434,21 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal beholde eksisterende saksnummer ved avvik men fortsatt oppdatere status`() {
+        fun `skal ved saksnummer-avvik beholde eksisterende saksnummer og oppdatere den saken - ikke den oppgitte`() {
             val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
+            val soskenPaaEgenSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
+            val innsendingPaaOppgittSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-301")
 
-            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "MOTTATT"}""")
+            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "AVSLUTTET"}""")
                 .expectStatus().isNoContent
 
             val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
             oppdatert.saksnummer shouldBe "MEL-300"
-            oppdatert.saksstatus shouldBe Saksstatus.MOTTATT
+            oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
+            // Søsken på innsendingens reelle sak oppdateres...
+            innsendingRepository.findBySkjemaId(soskenPaaEgenSak.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            // ...mens innsendinger på det oppgitte (avvikende) saksnummeret ikke røres
+            innsendingRepository.findBySkjemaId(innsendingPaaOppgittSak.id!!)!!.saksstatus.shouldBeNull()
         }
 
         @Test
@@ -485,14 +491,31 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
     @DisplayName("PUT /m2m/api/skjema/saksstatus/bulk")
     inner class BulkOppdaterSaksstatus {
 
-        private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
-            val skjema = skjemaRepository.save(
-                skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
-            )
-            innsendingRepository.save(
-                innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
-            )
-            return skjema
+        @Test
+        fun `skal telle unike innsendinger naar flere rader deler saksnummer`() {
+            val agDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")
+            val atDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")
+
+            val resultat = webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(
+                    """
+                    {"oppdateringer": [
+                        {"skjemaId": "${agDel.id}", "saksnummer": "MEL-500", "saksstatus": "AVSLUTTET"},
+                        {"skjemaId": "${atDel.id}", "saksnummer": "MEL-500", "saksstatus": "AVSLUTTET"}
+                    ]}
+                    """.trimIndent()
+                )
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BulkOppdaterSaksstatusResultat>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            resultat.antallOppdatert shouldBe 2
+            innsendingRepository.findBySkjemaId(agDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            innsendingRepository.findBySkjemaId(atDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -19,6 +19,7 @@ import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlFoedselsdato
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlNavn
 import no.nav.melosys.skjema.integrasjon.pdl.dto.PdlPerson
 import no.nav.melosys.skjema.korrektSyntetiskFnr
+import no.nav.melosys.skjema.m2mTokenWithOnlyReadSkjemaDataAccess
 import no.nav.melosys.skjema.m2mTokenWithReadSkjemaDataAccess
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -288,6 +289,26 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
+        fun `skal arve saksstatus naar saken allerede er synket for andre innsendinger`() {
+            val sosken = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-600")
+            innsendingRepository.save(
+                innsendingRepository.findBySkjemaId(sosken.id!!)!!.apply { saksstatus = Saksstatus.AVSLUTTET }
+            )
+            val nyttSkjema = lagInnsendtSkjemaMedInnsending(saksnummer = null)
+
+            val token = mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()
+            webTestClient.post()
+                .uri("/m2m/api/skjema/${nyttSkjema.id}/saksnummer")
+                .header("Authorization", "Bearer $token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-600"}""")
+                .exchange()
+                .expectStatus().isNoContent
+
+            innsendingRepository.findBySkjemaId(nyttSkjema.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+        }
+
+        @Test
         fun `skal returnere 400 naar saksnummer er tomt`() {
             val skjema = skjemaRepository.save(
                 skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
@@ -470,6 +491,27 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
             webTestClient.put()
                 .uri("/m2m/api/skjema/${UUID.randomUUID()}/saksstatus")
                 .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+
+        @Test
+        fun `skal returnere 403 for klient som kun har lesetilgang`() {
+            val token = mockOAuth2Server.m2mTokenWithOnlyReadSkjemaDataAccess()
+
+            // Klienten har lesetilgang (404 – slipper gjennom aspektet)...
+            webTestClient.get()
+                .uri("/m2m/api/skjema/utsendt-arbeidstaker/${UUID.randomUUID()}/data")
+                .header("Authorization", "Bearer $token")
+                .exchange()
+                .expectStatus().isNotFound
+
+            // ...men avvises på write-endepunktet
+            webTestClient.put()
+                .uri("/m2m/api/skjema/${UUID.randomUUID()}/saksstatus")
+                .header("Authorization", "Bearer $token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue("""{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
                 .exchange()

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -23,8 +23,11 @@ import no.nav.melosys.skjema.m2mTokenWithReadSkjemaDataAccess
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.m2m.BulkOppdaterSaksstatusResultat
 import no.nav.melosys.skjema.types.m2m.UtsendtArbeidstakerSkjemaM2MDto
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
@@ -379,6 +382,171 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
                 .bodyValue("""{"saksnummer": "SAK123"}""")
                 .exchange()
                 .expectStatus().isUnauthorized
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /m2m/api/skjema/{id}/saksstatus")
+    inner class OppdaterSaksstatus {
+
+        private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
+            val skjema = skjemaRepository.save(
+                skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
+            )
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
+            )
+            return skjema
+        }
+
+        private fun oppdaterSaksstatus(skjemaId: UUID, body: String) = webTestClient.put()
+            .uri("/m2m/api/skjema/$skjemaId/saksstatus")
+            .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .exchange()
+
+        @Test
+        fun `skal oppdatere saksstatus og backfille saksnummer naar det mangler`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = null)
+
+            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
+                .expectStatus().isNoContent
+
+            val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
+            oppdatert.saksnummer shouldBe "MEL-100"
+            oppdatert.saksstatusOppdatert.shouldNotBeNull()
+        }
+
+        @Test
+        fun `skal oppdatere alle innsendinger med samme saksnummer`() {
+            val agDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-200")
+            val atDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-200")
+            val annenSak = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-999")
+
+            oppdaterSaksstatus(agDel.id!!, """{"saksnummer": "MEL-200", "saksstatus": "AVSLUTTET"}""")
+                .expectStatus().isNoContent
+
+            innsendingRepository.findBySkjemaId(agDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            innsendingRepository.findBySkjemaId(atDel.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            innsendingRepository.findBySkjemaId(annenSak.id!!)!!.saksstatus.shouldBeNull()
+        }
+
+        @Test
+        fun `skal beholde eksisterende saksnummer ved avvik men fortsatt oppdatere status`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-300")
+
+            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "MEL-301", "saksstatus": "MOTTATT"}""")
+                .expectStatus().isNoContent
+
+            val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            oppdatert.saksnummer shouldBe "MEL-300"
+            oppdatert.saksstatus shouldBe Saksstatus.MOTTATT
+        }
+
+        @Test
+        fun `skal returnere 400 naar saksnummer er tomt`() {
+            val skjema = lagInnsendtSkjemaMedInnsending()
+
+            oppdaterSaksstatus(skjema.id!!, """{"saksnummer": "", "saksstatus": "AVSLUTTET"}""")
+                .expectStatus().isBadRequest
+        }
+
+        @Test
+        fun `skal returnere 404 naar skjema ikke finnes`() {
+            oppdaterSaksstatus(UUID.randomUUID(), """{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
+                .expectStatus().isNotFound
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            webTestClient.put()
+                .uri("/m2m/api/skjema/${UUID.randomUUID()}/saksstatus")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+
+        @Test
+        fun `skal returnere 401 naar token mangler`() {
+            webTestClient.put()
+                .uri("/m2m/api/skjema/${UUID.randomUUID()}/saksstatus")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"saksnummer": "MEL-100", "saksstatus": "AVSLUTTET"}""")
+                .exchange()
+                .expectStatus().isUnauthorized
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /m2m/api/skjema/saksstatus/bulk")
+    inner class BulkOppdaterSaksstatus {
+
+        private fun lagInnsendtSkjemaMedInnsending(saksnummer: String? = null): Skjema {
+            val skjema = skjemaRepository.save(
+                skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
+            )
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, status = InnsendingStatus.FERDIG, saksnummer = saksnummer)
+            )
+            return skjema
+        }
+
+        @Test
+        fun `skal oppdatere flere innsendinger og rapportere ukjente skjema-id-er`() {
+            val medSaksnummer = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-400")
+            val utenSaksnummer = lagInnsendtSkjemaMedInnsending(saksnummer = null)
+            val ukjentSkjemaId = UUID.randomUUID()
+
+            val resultat = webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(
+                    """
+                    {"oppdateringer": [
+                        {"skjemaId": "${medSaksnummer.id}", "saksnummer": "MEL-400", "saksstatus": "AVSLUTTET"},
+                        {"skjemaId": "${utenSaksnummer.id}", "saksnummer": "MEL-401", "saksstatus": "MOTTATT"},
+                        {"skjemaId": "$ukjentSkjemaId", "saksnummer": "MEL-402", "saksstatus": "AVSLUTTET"}
+                    ]}
+                    """.trimIndent()
+                )
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BulkOppdaterSaksstatusResultat>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            resultat.antallOppdatert shouldBe 2
+            resultat.ukjenteSkjemaIder shouldBe listOf(ukjentSkjemaId)
+            innsendingRepository.findBySkjemaId(medSaksnummer.id!!)!!.saksstatus shouldBe Saksstatus.AVSLUTTET
+            val backfillet = innsendingRepository.findBySkjemaId(utenSaksnummer.id!!)!!
+            backfillet.saksstatus shouldBe Saksstatus.MOTTATT
+            backfillet.saksnummer shouldBe "MEL-401"
+        }
+
+        @Test
+        fun `skal returnere 400 naar oppdateringer er tom`() {
+            webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"oppdateringer": []}""")
+                .exchange()
+                .expectStatus().isBadRequest
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"oppdateringer": [{"skjemaId": "${UUID.randomUUID()}", "saksnummer": "MEL-1", "saksstatus": "AVSLUTTET"}]}""")
+                .exchange()
+                .expectStatus().isForbidden
         }
     }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -534,6 +534,29 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
     inner class BulkOppdaterSaksstatus {
 
         @Test
+        fun `skal rapportere 0 oppdatert naar alt allerede er synket`() {
+            val skjema = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-700")
+            val body = """{"oppdateringer": [{"skjemaId": "${skjema.id}", "saksnummer": "MEL-700", "saksstatus": "AVSLUTTET"}]}"""
+
+            fun kjoerBulk() = webTestClient.put()
+                .uri("/m2m/api/skjema/saksstatus/bulk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithReadSkjemaDataAccess()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BulkOppdaterSaksstatusResultat>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+            kjoerBulk().antallOppdatert shouldBe 1
+            val foersteTidspunkt = innsendingRepository.findBySkjemaId(skjema.id!!)!!.saksstatusOppdatert
+
+            kjoerBulk().antallOppdatert shouldBe 0
+            // saksstatusOppdatert betyr «sist endret» og skal ikke røres av no-op-synk
+            innsendingRepository.findBySkjemaId(skjema.id!!)!!.saksstatusOppdatert shouldBe foersteTidspunkt
+        }
+
+        @Test
         fun `skal telle unike innsendinger naar flere rader deler saksnummer`() {
             val agDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")
             val atDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -602,7 +602,7 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal telle unike innsendinger naar flere rader deler saksnummer`() {
+        fun `skal oppdatere hver rad uavhengig naar flere rader deler saksnummer`() {
             val agDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")
             val atDel = lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-500")
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -27,6 +27,7 @@ import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.service.InnsendingService
 import no.nav.melosys.skjema.sikkerhet.AdminApiKeyInterceptor.Companion.API_KEY_HEADER
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.felles.PeriodeDto
@@ -534,6 +535,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             innsendtDato: Instant = foerCutoff,
             juridiskEnhet: String = korrektSyntetiskOrgnr,
             saksnummer: String? = null,
+            saksstatus: Saksstatus? = null,
             erstatterSkjemaId: UUID? = null
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
@@ -550,7 +552,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 )
             )
         ).also { skjema ->
-            innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato, saksnummer = saksnummer))
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato, saksnummer = saksnummer, saksstatus = saksstatus)
+            )
         }
 
         /** Handlingspliktig AG-del (arbeidsgiver uten fullmakt) – standard resend-kandidat. */
@@ -561,8 +565,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             innsendtDato: Instant = foerCutoff,
             juridiskEnhet: String = korrektSyntetiskOrgnr,
             saksnummer: String? = null,
+            saksstatus: Saksstatus? = null,
             erstatterSkjemaId: UUID? = null
-        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet, saksnummer, erstatterSkjemaId)
+        ): Skjema = lagInnsendtDel(Skjemadel.ARBEIDSGIVERS_DEL, representasjonstype, fnr, periode, innsendtDato, juridiskEnhet, saksnummer, saksstatus, erstatterSkjemaId)
 
         /** Innsendt arbeidstaker-del for samme person/enhet (markerer at saken ikke lenger venter på AT-del). */
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
@@ -639,6 +644,21 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
             resend().antallSendt shouldBe 0
             verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal ikke sende naar saken er avsluttet i melosys-api`() {
+            lagAgDel(saksnummer = "SAK-200", saksstatus = Saksstatus.AVSLUTTET)
+
+            resend().antallSendt shouldBe 0
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal fortsatt sende naar saken er mottatt i melosys-api`() {
+            lagAgDel(saksnummer = "SAK-201", saksstatus = Saksstatus.MOTTATT)
+
+            resend().antallSendt shouldBe 1
         }
 
         @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,3 +38,12 @@ MELOSYS_CONSOLE_AZP_NAMES: test-console-client-id
 MELOSYS_SKJEMA_ADMIN_APIKEY: test-admin-apikey
 VEDLEGG_BUCKET_NAME: test-vedlegg-bucket
 CLAMAV_URL: ${wiremock.server.url}
+
+# Read-only-klient i tillegg til test-melosys-client-id, slik at testene kan bevise at
+# write-endepunkter avviser klienter som kun har lesetilgang (write-lista arves fra
+# application.yml og inneholder bare test-melosys-client-id).
+m2m:
+  read-skjemadata:
+    clients:
+      - test-melosys-client-id
+      - test-read-only-client-id


### PR DESCRIPTION
Første del av saksstatus-synk fra melosys-api.

- Ny `Saksstatus`-enum (MOTTATT/AVSLUTTET) og m2m-DTO-er i types-modulen
- V17: `innsending.saksstatus` + `saksstatus_oppdatert`
- `PUT /m2m/api/skjema/{id}/saksstatus` + `PUT /m2m/api/skjema/saksstatus/bulk` — oppdaterer alle innsendinger på samme saksnummer, backfiller saksnummer der det mangler
- Resend-varsler ekskluderer nå innsendinger der saken er AVSLUTTET
- Opprydding: M2M-write validerer mot egen `m2m.write-skjemadata.clients` (før: gjenbrukte read-lista)

Oppfølging: event-listener + admin-massesynk med dry-run i melosys-api (krever publisert types-versjon herfra).