### PR TITLE
Legg til automerge av Dependabot-PRer

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,30 @@
+name: Dependabot Automerge
+
+on:
+  schedule:
+    - cron: '0 4 * * 1-5'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CLIENT_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+      - name: Automerge Dependabot PRs
+        uses: navikt/automerge-dependabot@v1.5.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          blackout-periods: 'Sat,Sun,Dec 24-Jan 2'
+          semver-filter: 'patch,minor'
+          merge-method: 'squash'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,3 +28,5 @@ jobs:
           blackout-periods: 'Sat,Sun,Dec 24-Jan 2'
           semver-filter: 'patch,minor'
           merge-method: 'squash'
+          # main krever at branchen er oppdatert før merge (strict status checks)
+          update-branch-before-merge: 'true'


### PR DESCRIPTION
Innfører samme Dependabot-automerge som melosys-api, pluss `update-branch-before-merge` siden main her krever oppdatert branch før merge (strict status checks).

- Kjører hverdager kl. 04 UTC (`workflow_dispatch` for manuell kjøring)
- `navikt/automerge-dependabot@v1.5.1` merger kun patch/minor, squash
- Blackout: helger og 24. des–2. jan
- GitHub App-token (`CLIENT_ID`/`PRIVATE_KEY` er lagt inn på repoet) slik at merge til main trigger deploy-dev
- Utdaterte Dependabot-brancher oppdateres automatisk før merge, med venting på grønne sjekker

«Build og test» er nå satt som required status check på main.