### PR TITLE
MELOSYS-8084 Saksnummer, saksstatus og motpart-status i innsendte-listen

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSkjemaResponse.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSkjemaResponse.kt
@@ -3,6 +3,7 @@ package no.nav.melosys.skjema.types
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.skjemadefinisjon.SkjemaDefinisjonDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
@@ -38,5 +39,11 @@ data class InnsendtSkjemaResponse(
     val definisjon: SkjemaDefinisjonDto,
 
     @param:Schema(description = "Indikerer om fullmakt er aktiv. null=ikke relevant, true=aktiv, false=tapt (arbeidstaker-data strippet).")
-    val fullmaktAktiv: Boolean? = null
+    val fullmaktAktiv: Boolean? = null,
+
+    @param:Schema(description = "Melosys-saksnummer, null hvis ikke mottatt fra melosys-api ennå", example = "MEL-123456")
+    val saksnummer: String? = null,
+
+    @param:Schema(description = "Saksstatus i melosys-api, null = ikke synket ennå (behandles som MOTTATT)")
+    val saksstatus: Saksstatus? = null
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSoknadOversiktDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/InnsendtSoknadOversiktDto.kt
@@ -3,7 +3,9 @@ package no.nav.melosys.skjema.types
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 
 /**
  * DTO for oversikt over innsendte søknader.
@@ -12,6 +14,10 @@ import no.nav.melosys.skjema.types.common.SkjemaStatus
 data class InnsendtSoknadOversiktDto(
     val id: UUID,
     val referanseId: String?,
+    val saksnummer: String?, // Melosys-saksnummer (MEL-<n>), null hvis ikke mottatt fra melosys-api ennå
+    val saksstatus: Saksstatus?, // null = ikke synket ennå (behandles som MOTTATT i visning)
+    val motpartStatus: MotpartStatus,
+    val skjemadel: Skjemadel,
     val arbeidsgiverNavn: String?,
     val arbeidsgiverOrgnr: String,
     val arbeidstakerNavn: String,
@@ -21,6 +27,23 @@ data class InnsendtSoknadOversiktDto(
     val status: SkjemaStatus,
     val fullmaktAktiv: Boolean? = null // null=ikke relevant, true=aktiv, false=tapt
 )
+
+/**
+ * Status for motpartens del av søknaden.
+ *
+ * Merk: motpart som sendte via annen kanal (Fyll-inn/Altinn/papir) gir ikke kobling,
+ * og vises som VENTER inntil saken avsluttes i melosys-api (saksstatus er da eneste indikator).
+ */
+enum class MotpartStatus {
+    /** Motparten har sendt inn sin del (koblet skjema med status SENDT) */
+    HAR_SENDT,
+
+    /** Skjemadelen har en motpart som ikke har sendt inn sin del ennå */
+    VENTER,
+
+    /** Skjemadelen har ingen motpart (kombinert del med fullmakt) */
+    IKKE_RELEVANT
+}
 
 /**
  * Response-objekt for paginert liste av innsendte søknader.

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/UtsendtArbeidstakerSkjemaRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/UtsendtArbeidstakerSkjemaRepository.kt
@@ -220,4 +220,25 @@ interface UtsendtArbeidstakerSkjemaRepository : JpaRepository<Skjema, UUID> {
         @Param("searchTerm") searchTerm: String,
         pageable: Pageable
     ): Page<Skjema>
+
+    /**
+     * Alle skjemaer med gitt status for gitte personer, uavhengig av representasjonstype.
+     *
+     * Brukes av motpart-status-utledningen i innsendte-listen: motpart-koblinger og
+     * erstatter-referanser settes kun mellom skjemaer med samme fnr
+     * (se [no.nav.melosys.skjema.service.UtsendtArbeidstakerSkjemaKoblingService]),
+     * så dette settet dekker hele kobling-/erstatter-kjeden for hver rad på siden.
+     */
+    @Query(
+        """
+        SELECT * FROM skjema
+        WHERE fnr IN :fnrs
+        AND type = '$TYPE_UTSENDT_ARBEIDSTAKER'
+        AND status = :status
+    """, nativeQuery = true
+    )
+    fun findByFnrInAndStatus(
+        @Param("fnrs") fnrs: List<String>,
+        @Param("status") status: String
+    ): List<Skjema>
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
@@ -84,9 +84,9 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
             else -> reprService.hentFullmaktsgiverFnr()
         }
 
-        val sendteKobledeSkjemaIder = hentSendteKobledeSkjemaIder(page.content)
+        val sendteVersjonerPerFnr = hentSendteVersjonerPerFnr(page.content)
 
-        val soknader = page.content.map { konverterTilInnsendtSoknadDto(it, personerMedAktivFullmakt, sendteKobledeSkjemaIder) }
+        val soknader = page.content.map { konverterTilInnsendtSoknadDto(it, personerMedAktivFullmakt, sendteVersjonerPerFnr) }
 
         log.debug { "Fant ${page.totalElements} innsendte søknader, returnerer side ${request.side} med ${soknader.size} resultater" }
 
@@ -213,41 +213,96 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
     }
 
     /**
-     * Batch-henter id-ene til koblede skjemaer (motpartens del) med status SENDT for sidens rader.
+     * Batch-henter metadata for alle SENDT-e utsendt arbeidstaker-skjemaer som tilhører personene
+     * på siden, gruppert per fnr.
      *
-     * Ett findAllById-kall per side i stedet for ett oppslag per rad — unngår N+1
-     * selv om sidestørrelsen er lav (typisk 5 rader).
+     * Ett spørringskall per side (fnr IN) i stedet for ett oppslag per rad eller per ledd i
+     * erstatter-kjeden — unngår N+1 selv om sidestørrelsen er lav (typisk 5 rader).
+     * Motpart-koblinger og erstatter-referanser settes kun mellom skjemaer med samme fnr
+     * (se [UtsendtArbeidstakerSkjemaKoblingService]), så settet dekker hele kjeden for hver rad.
      */
-    private fun hentSendteKobledeSkjemaIder(skjemaer: List<Skjema>): Set<UUID> {
-        val kobletIder = skjemaer
-            .mapNotNull { (it.metadata as? UtsendtArbeidstakerMetadata)?.kobletSkjemaId }
+    private fun hentSendteVersjonerPerFnr(skjemaer: List<Skjema>): Map<String, SendteVersjoner> {
+        val fnrs = skjemaer
+            .filter { (it.metadata as? UtsendtArbeidstakerMetadata)?.skjemadel != Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+            .map { it.fnr }
             .distinct()
 
-        if (kobletIder.isEmpty()) {
-            return emptySet()
+        if (fnrs.isEmpty()) {
+            return emptyMap()
         }
 
-        return utsendtArbeidstakerSkjemaRepository.findAllById(kobletIder)
-            .filter { it.status == SkjemaStatus.SENDT }
-            .mapNotNull { it.id }
-            .toSet()
+        return utsendtArbeidstakerSkjemaRepository.findByFnrInAndStatus(fnrs, INNSENDT_STATUS)
+            .groupBy { it.fnr }
+            .mapValues { (_, sendte) -> SendteVersjoner(sendte) }
     }
 
     /**
      * Utleder motpart-status for en skjemadel:
      * - Kombinert del (ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) har aldri motpart → IKKE_RELEVANT
-     * - Koblet skjema med status SENDT → HAR_SENDT
+     * - Motpartens del finnes i noen SENDT versjon → HAR_SENDT
      * - Ellers → VENTER (inkluderer koblet skjema som kun er utkast, og motpart via annen kanal)
+     *
+     * Resubmisjonstilfellet (produkteier-beslutning 2026-07-27): når en part sender NY VERSJON av
+     * sin del, flytter [UtsendtArbeidstakerSkjemaKoblingService] koblingen til den nye versjonen og
+     * NULLER `kobletSkjemaId` på den gamle. Et rent `kobletSkjemaId`-oppslag ville derfor vist
+     * VENTER for rader hvis kobling er flyttet — selv om motparten faktisk har sendt. Derfor følges
+     * erstatter-kjeden for radens egen del (transitivt, begge retninger), og raden viser HAR_SENDT
+     * når noen versjon i kjeden er koblet til en motpart-del som finnes i en SENDT versjon — den
+     * koblede selv eller en versjon i dens erstatter-kjede (nyere som har overtatt koblingen).
+     *
+     * Traverseringen skjer i minne over batch-oppslaget fra [hentSendteVersjonerPerFnr] og er
+     * sirkel-sikker via besøkt-sett (samme mønster som M2MSkjemaService.hentTidligereInnsendteSkjema).
      */
     private fun utledMotpartStatus(
+        skjema: Skjema,
         metadata: UtsendtArbeidstakerMetadata,
-        sendteKobledeSkjemaIder: Set<UUID>
+        sendteVersjonerPerFnr: Map<String, SendteVersjoner>
     ): MotpartStatus {
-        return when {
-            metadata.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL -> MotpartStatus.IKKE_RELEVANT
-            metadata.kobletSkjemaId in sendteKobledeSkjemaIder -> MotpartStatus.HAR_SENDT
-            else -> MotpartStatus.VENTER
+        val motpartsDel = when (metadata.skjemadel) {
+            Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL -> return MotpartStatus.IKKE_RELEVANT
+            Skjemadel.ARBEIDSTAKERS_DEL -> Skjemadel.ARBEIDSGIVERS_DEL
+            Skjemadel.ARBEIDSGIVERS_DEL -> Skjemadel.ARBEIDSTAKERS_DEL
         }
+        val sendte = sendteVersjonerPerFnr[skjema.fnr] ?: return MotpartStatus.VENTER
+
+        // Motpart-kandidater: radens egen kobling + koblingene til alle versjoner i radens erstatter-kjede
+        // (koblingen kan være flyttet til en nyere versjon av radens egen del).
+        val motpartKandidater = buildSet {
+            metadata.kobletSkjemaId?.let(::add)
+            finnErstatterKjede(skjema.id, metadata, sendte).forEach { versjonId ->
+                sendte.metadataPerId[versjonId]?.kobletSkjemaId?.let(::add)
+            }
+        }
+
+        val motpartHarSendt = motpartKandidater.any { kandidatId ->
+            finnErstatterKjede(kandidatId, sendte.metadataPerId[kandidatId], sendte)
+                .any { sendte.metadataPerId[it]?.skjemadel == motpartsDel }
+        }
+        return if (motpartHarSendt) MotpartStatus.HAR_SENDT else MotpartStatus.VENTER
+    }
+
+    /**
+     * Finner alle versjoner i erstatter-kjeden til [startId] (inkludert startId selv) blant
+     * personens SENDT-e skjemaer — transitivt i begge retninger: eldre versjoner via
+     * `erstatterSkjemaId` og nyere versjoner via den reverserte relasjonen.
+     *
+     * Sirkel-sikker: besøkt-settet garanterer terminering selv ved sirkulære erstatter-referanser.
+     */
+    private fun finnErstatterKjede(
+        startId: UUID?,
+        startMetadata: UtsendtArbeidstakerMetadata?,
+        sendte: SendteVersjoner
+    ): Set<UUID> {
+        startId ?: return emptySet()
+        val besokt = mutableSetOf(startId)
+        val ko = ArrayDeque(listOf(startId))
+        while (ko.isNotEmpty()) {
+            val id = ko.removeFirst()
+            val metadata = if (id == startId) startMetadata else sendte.metadataPerId[id]
+            val naboer = listOfNotNull(metadata?.erstatterSkjemaId) + sendte.erstattetAvPerId[id].orEmpty()
+            naboer.forEach { if (besokt.add(it)) ko.add(it) }
+        }
+        return besokt
     }
 
     /**
@@ -257,7 +312,7 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
     private fun konverterTilInnsendtSoknadDto(
         skjema: Skjema,
         personerMedAktivFullmakt: Set<String>,
-        sendteKobledeSkjemaIder: Set<UUID>
+        sendteVersjonerPerFnr: Map<String, SendteVersjoner>
     ): InnsendtSoknadOversiktDto {
         val metadata = skjema.metadata as UtsendtArbeidstakerMetadata
         val innsending = skjema.id?.let { innsendingRepository.findBySkjemaId(it) }
@@ -267,7 +322,7 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
             referanseId = innsending?.referanseId,
             saksnummer = innsending?.saksnummer,
             saksstatus = innsending?.saksstatus,
-            motpartStatus = utledMotpartStatus(metadata, sendteKobledeSkjemaIder),
+            motpartStatus = utledMotpartStatus(skjema, metadata, sendteVersjonerPerFnr),
             skjemadel = metadata.skjemadel,
             arbeidsgiverNavn = metadata.arbeidsgiverNavn,
             arbeidsgiverOrgnr = skjema.orgnr,
@@ -315,6 +370,25 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
         }
     }
 
+}
+
+/**
+ * Oppslagsstruktur over én persons SENDT-e utsendt arbeidstaker-skjemaer:
+ * metadata per skjema-id og den reverserte erstatter-relasjonen
+ * (hvilke skjemaer som oppgir å erstatte en gitt id).
+ */
+private class SendteVersjoner(sendte: List<Skjema>) {
+    val metadataPerId: Map<UUID, UtsendtArbeidstakerMetadata> = sendte
+        .mapNotNull { skjema ->
+            val id = skjema.id ?: return@mapNotNull null
+            val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+            id to metadata
+        }
+        .toMap()
+
+    val erstattetAvPerId: Map<UUID, List<UUID>> = metadataPerId.entries
+        .mapNotNull { (id, metadata) -> metadata.erstatterSkjemaId?.let { it to id } }
+        .groupBy({ it.first }, { it.second })
 }
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService.kt
@@ -11,6 +11,8 @@ import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
 import no.nav.melosys.skjema.types.HentInnsendteSoknaderRequest
 import no.nav.melosys.skjema.types.InnsendtSoknadOversiktDto
 import no.nav.melosys.skjema.types.InnsendteSoknaderResponse
+import no.nav.melosys.skjema.types.MotpartStatus
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.SorteringsFelt
 import no.nav.melosys.skjema.types.Sorteringsretning
@@ -82,7 +84,9 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
             else -> reprService.hentFullmaktsgiverFnr()
         }
 
-        val soknader = page.content.map { konverterTilInnsendtSoknadDto(it, personerMedAktivFullmakt) }
+        val sendteKobledeSkjemaIder = hentSendteKobledeSkjemaIder(page.content)
+
+        val soknader = page.content.map { konverterTilInnsendtSoknadDto(it, personerMedAktivFullmakt, sendteKobledeSkjemaIder) }
 
         log.debug { "Fant ${page.totalElements} innsendte søknader, returnerer side ${request.side} med ${soknader.size} resultater" }
 
@@ -209,12 +213,51 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
     }
 
     /**
+     * Batch-henter id-ene til koblede skjemaer (motpartens del) med status SENDT for sidens rader.
+     *
+     * Ett findAllById-kall per side i stedet for ett oppslag per rad — unngår N+1
+     * selv om sidestørrelsen er lav (typisk 5 rader).
+     */
+    private fun hentSendteKobledeSkjemaIder(skjemaer: List<Skjema>): Set<UUID> {
+        val kobletIder = skjemaer
+            .mapNotNull { (it.metadata as? UtsendtArbeidstakerMetadata)?.kobletSkjemaId }
+            .distinct()
+
+        if (kobletIder.isEmpty()) {
+            return emptySet()
+        }
+
+        return utsendtArbeidstakerSkjemaRepository.findAllById(kobletIder)
+            .filter { it.status == SkjemaStatus.SENDT }
+            .mapNotNull { it.id }
+            .toSet()
+    }
+
+    /**
+     * Utleder motpart-status for en skjemadel:
+     * - Kombinert del (ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL) har aldri motpart → IKKE_RELEVANT
+     * - Koblet skjema med status SENDT → HAR_SENDT
+     * - Ellers → VENTER (inkluderer koblet skjema som kun er utkast, og motpart via annen kanal)
+     */
+    private fun utledMotpartStatus(
+        metadata: UtsendtArbeidstakerMetadata,
+        sendteKobledeSkjemaIder: Set<UUID>
+    ): MotpartStatus {
+        return when {
+            metadata.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL -> MotpartStatus.IKKE_RELEVANT
+            metadata.kobletSkjemaId in sendteKobledeSkjemaIder -> MotpartStatus.HAR_SENDT
+            else -> MotpartStatus.VENTER
+        }
+    }
+
+    /**
      * Konverterer Skjema til InnsendtSoknadOversiktDto.
      * Maskerer fnr og henter nødvendige metadata-verdier.
      */
     private fun konverterTilInnsendtSoknadDto(
         skjema: Skjema,
-        personerMedAktivFullmakt: Set<String>
+        personerMedAktivFullmakt: Set<String>,
+        sendteKobledeSkjemaIder: Set<UUID>
     ): InnsendtSoknadOversiktDto {
         val metadata = skjema.metadata as UtsendtArbeidstakerMetadata
         val innsending = skjema.id?.let { innsendingRepository.findBySkjemaId(it) }
@@ -222,6 +265,10 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService(
         return InnsendtSoknadOversiktDto(
             id = skjema.id ?: throw IllegalStateException("Skjema ID er null"),
             referanseId = innsending?.referanseId,
+            saksnummer = innsending?.saksnummer,
+            saksstatus = innsending?.saksstatus,
+            motpartStatus = utledMotpartStatus(metadata, sendteKobledeSkjemaIder),
+            skjemadel = metadata.skjemadel,
             arbeidsgiverNavn = metadata.arbeidsgiverNavn,
             arbeidsgiverOrgnr = skjema.orgnr,
             arbeidstakerNavn = metadata.arbeidstakerNavn,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -353,7 +353,9 @@ class UtsendtArbeidstakerService(
             skjemaDefinisjonVersjon = innsending.skjemaDefinisjonVersjon,
             skjemaData = if (fullmaktAktiv == false) stripArbeidstakersData(skjemaData) else skjemaData,
             definisjon = definisjon,
-            fullmaktAktiv = fullmaktAktiv
+            fullmaktAktiv = fullmaktAktiv,
+            saksnummer = innsending.saksnummer,
+            saksstatus = innsending.saksstatus
         )
     }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
@@ -9,6 +9,9 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
 import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.arbeidstakersSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.integrasjon.repr.ReprService
 import no.nav.melosys.skjema.integrasjon.repr.dto.Fullmakt
@@ -16,6 +19,7 @@ import no.nav.melosys.skjema.innsendingMedDefaultVerdier
 import no.nav.melosys.skjema.korrektSyntetiskFnr
 import no.nav.melosys.skjema.korrektSyntetiskOrgnr
 import no.nav.melosys.skjema.radgiverfirmaInfoMedDefaultVerdier
+import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
@@ -25,6 +29,7 @@ import no.nav.melosys.skjema.types.MotpartStatus
 import no.nav.melosys.skjema.types.felles.OrganisasjonDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
 import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
@@ -50,6 +55,9 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest : Api
 
     @Autowired
     private lateinit var skjemaRepository: SkjemaRepository
+
+    @Autowired
+    private lateinit var koblingService: UtsendtArbeidstakerSkjemaKoblingService
 
     @Autowired
     private lateinit var innsendingRepository: InnsendingRepository
@@ -1207,6 +1215,119 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest : Api
         response.soknader shouldHaveSize 1
         response.soknader[0].saksstatus shouldBe Saksstatus.AVSLUTTET
         response.soknader[0].motpartStatus shouldBe MotpartStatus.HAR_SENDT
+    }
+
+    // ========================================
+    // MotpartStatus ved resubmisjon — erstatter-kjeden følges
+    // (produkteier-beslutning 2026-07-27, se utledMotpartStatus)
+    // ========================================
+
+    /**
+     * Sender inn et skjema slik produksjonsflyten gjør det: lagres med status SENDT og kobles
+     * via [UtsendtArbeidstakerSkjemaKoblingService.finnOgKobl] — ingen håndsatt kobling-metadata.
+     */
+    private fun sendInnOgKobl(representasjonstype: Representasjonstype, skjemadel: Skjemadel): Skjema {
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = representasjonstype,
+                    skjemadel = skjemadel
+                ),
+                data = when (skjemadel) {
+                    Skjemadel.ARBEIDSTAKERS_DEL -> arbeidstakersSkjemaDataDtoMedDefaultVerdier()
+                    else -> arbeidsgiversSkjemaDataDtoMedDefaultVerdier().copy(
+                        utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()
+                    )
+                }
+            )
+        )
+        koblingService.finnOgKobl(skjema)
+        return skjema
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: HAR_SENDT beholdes når motparten sender ny versjon av sin del")
+    fun `motpartStatus skal forbli HAR_SENDT når motparten sender ny versjon`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+        every { altinnService.hentBrukersTilganger() } returns listOf(
+            OrganisasjonDto(korrektSyntetiskOrgnr, "Test Arbeidsgiver AS", "AS")
+        )
+
+        // 1) Arbeidstakeren (A) sender sin del
+        sendInnOgKobl(Representasjonstype.DEG_SELV, Skjemadel.ARBEIDSTAKERS_DEL)
+
+        // 2) Motparten (B) sender arbeidsgivers del v1 → motpart-kobles til A
+        sendInnOgKobl(Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL)
+        service.hentInnsendteSoknader(standardRequestDegSelv()).soknader.single().motpartStatus shouldBe MotpartStatus.HAR_SENDT
+
+        // 3) Motparten (B) sender NY VERSJON (v2) — erstatter v1 og overtar koblingen til A,
+        //    og koblingsservicen NULLER kobletSkjemaId på v1
+        sendInnOgKobl(Representasjonstype.ARBEIDSGIVER, Skjemadel.ARBEIDSGIVERS_DEL)
+
+        // A skal FORTSATT vise HAR_SENDT — motparten har faktisk sendt (v2)
+        service.hentInnsendteSoknader(standardRequestDegSelv()).soknader.single().motpartStatus shouldBe MotpartStatus.HAR_SENDT
+
+        // Begge arbeidsgiver-radene viser HAR_SENDT: motparten (A) har sendt, selv om v1
+        // mistet koblingen sin da v2 overtok den — erstatter-kjeden følges
+        val arbeidsgiverRespons = service.hentInnsendteSoknader(
+            HentInnsendteSoknaderRequest(side = 1, antall = 10, representasjonstype = Representasjonstype.ARBEIDSGIVER)
+        )
+        arbeidsgiverRespons.soknader shouldHaveSize 2
+        arbeidsgiverRespons.soknader.forEach { it.motpartStatus shouldBe MotpartStatus.HAR_SENDT }
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: Sirkulær erstatter-referanse terminerer og gir korrekt status")
+    fun `sirkulær erstatter-referanse skal ikke gi evig løkke`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        // Håndsatt korrupt data: to arbeidstaker-versjoner som erstatter hverandre sirkulært.
+        // v2 holder koblingen til en SENDT arbeidsgiver-del; v1 har mistet sin.
+        val motpartSkjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                ),
+                opprettetAv = etAnnetKorrektSyntetiskFnr
+            )
+        )
+        val v2 = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    kobletSkjemaId = motpartSkjema.id
+                )
+            )
+        )
+        val v1 = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    erstatterSkjemaId = v2.id
+                )
+            )
+        )
+        // Lukk sirkelen: v2 erstatter v1 som erstatter v2
+        v2.metadata = (v2.metadata as UtsendtArbeidstakerMetadata).medErstatterSkjemaId(v1.id)
+        skjemaRepository.save(v2)
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 2
+        response.soknader.forEach { it.motpartStatus shouldBe MotpartStatus.HAR_SENDT }
     }
 
     // ========================================

--- a/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest.kt
@@ -21,8 +21,11 @@ import no.nav.melosys.skjema.repository.SkjemaRepository
 import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
 import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.HentInnsendteSoknaderRequest
+import no.nav.melosys.skjema.types.MotpartStatus
 import no.nav.melosys.skjema.types.felles.OrganisasjonDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
 import org.junit.jupiter.api.BeforeEach
@@ -933,6 +936,277 @@ class HentInnsendteSoknaderUtsendtArbeidstakerSkjemaServiceIntegrationTest : Api
         } catch (e: IllegalArgumentException) {
             e.message shouldBe "radgiverfirmaOrgnr er påkrevd for RADGIVER"
         }
+    }
+
+    // ========================================
+    // Saksnummer, saksstatus, skjemadel og motpart-status
+    // ========================================
+
+    private fun standardRequestDegSelv() = HentInnsendteSoknaderRequest(
+        side = 1,
+        antall = 10,
+        representasjonstype = Representasjonstype.DEG_SELV
+    )
+
+    @Test
+    @DisplayName("Saksinfo: Skal populere saksnummer og saksstatus fra innsendingen")
+    fun `skal populere saksnummer og saksstatus fra innsendingen`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(representasjonstype = Representasjonstype.DEG_SELV)
+            )
+        )
+        innsendingRepository.save(
+            innsendingMedDefaultVerdier(skjema = skjema, saksnummer = "MEL-123456", saksstatus = Saksstatus.MOTTATT)
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].saksnummer shouldBe "MEL-123456"
+        response.soknader[0].saksstatus shouldBe Saksstatus.MOTTATT
+    }
+
+    @Test
+    @DisplayName("Saksinfo: saksnummer og saksstatus skal være null når innsendingen mangler dem")
+    fun `saksnummer og saksstatus skal være null når innsendingen mangler dem`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(representasjonstype = Representasjonstype.DEG_SELV)
+            )
+        )
+        innsendingRepository.save(
+            innsendingMedDefaultVerdier(skjema = skjema, saksnummer = null, saksstatus = null)
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].saksnummer shouldBe null
+        response.soknader[0].saksstatus shouldBe null
+    }
+
+    @Test
+    @DisplayName("Saksinfo: Skal populere skjemadel fra metadata")
+    fun `skal populere skjemadel fra metadata`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].skjemadel shouldBe Skjemadel.ARBEIDSTAKERS_DEL
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: VENTER når skjemadel har motpart uten kobling")
+    fun `motpartStatus skal være VENTER uten kobling`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    kobletSkjemaId = null
+                )
+            )
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.VENTER
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: VENTER når koblet skjema kun er utkast")
+    fun `motpartStatus skal være VENTER når koblet skjema kun er utkast`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        // Motpartens del (AG-del) er kun UTKAST
+        val motpartSkjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.UTKAST,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                ),
+                opprettetAv = etAnnetKorrektSyntetiskFnr
+            )
+        )
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    kobletSkjemaId = motpartSkjema.id
+                )
+            )
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.VENTER
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: HAR_SENDT når koblet skjema er sendt inn")
+    fun `motpartStatus skal være HAR_SENDT når koblet skjema er sendt inn`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        // Motpartens del (AG-del) er SENDT
+        val motpartSkjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                ),
+                opprettetAv = etAnnetKorrektSyntetiskFnr
+            )
+        )
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    kobletSkjemaId = motpartSkjema.id
+                )
+            )
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.HAR_SENDT
+    }
+
+    @Test
+    @DisplayName("MotpartStatus: IKKE_RELEVANT for kombinert del")
+    fun `motpartStatus skal være IKKE_RELEVANT for kombinert del`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.IKKE_RELEVANT
+    }
+
+    @Test
+    @DisplayName("Saksinfo: AVSLUTTET sak uten kobling returnerer både saksstatus og motpartStatus (avsluttet-vinner håndteres i visning)")
+    fun `avsluttet sak uten kobling skal returnere både saksstatus og motpartStatus`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        // Motpart sendte via annen kanal (ingen kobling), saken er avsluttet i melosys-api.
+        // Backend returnerer VENTER + AVSLUTTET; frontend lar AVSLUTTET vinne i visningen.
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+        innsendingRepository.save(
+            innsendingMedDefaultVerdier(skjema = skjema, saksnummer = "MEL-654321", saksstatus = Saksstatus.AVSLUTTET)
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].saksstatus shouldBe Saksstatus.AVSLUTTET
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.VENTER
+    }
+
+    @Test
+    @DisplayName("Saksinfo: AVSLUTTET sak med sendt kobling returnerer HAR_SENDT og AVSLUTTET")
+    fun `avsluttet sak med sendt kobling skal returnere HAR_SENDT og AVSLUTTET`() {
+        val userFnr = korrektSyntetiskFnr
+        every { subjectHandler.getUserID() } returns userFnr
+
+        val motpartSkjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                ),
+                opprettetAv = etAnnetKorrektSyntetiskFnr
+            )
+        )
+
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = userFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    kobletSkjemaId = motpartSkjema.id
+                )
+            )
+        )
+        innsendingRepository.save(
+            innsendingMedDefaultVerdier(skjema = skjema, saksnummer = "MEL-654321", saksstatus = Saksstatus.AVSLUTTET)
+        )
+
+        val response = service.hentInnsendteSoknader(standardRequestDegSelv())
+
+        response.soknader shouldHaveSize 1
+        response.soknader[0].saksstatus shouldBe Saksstatus.AVSLUTTET
+        response.soknader[0].motpartStatus shouldBe MotpartStatus.HAR_SENDT
     }
 
     // ========================================

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.skjemadefinisjon.SkjemaDefinisjonDto
 import no.nav.melosys.skjema.validators.UtsendtArbeidstakerSkjemaDataValidator
@@ -115,6 +116,36 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val response = service.hentInnsendtSkjema(skjemaId, null)
 
             response.dokumentTittel shouldBe "Bekreftelse fra arbeidsgiver på utsending til annet EØS-land eller Sveits"
+        }
+
+        test("skal populere saksnummer og saksstatus fra innsendingen") {
+            val skjemaId = UUID.randomUUID()
+            val skjema = skjemaMedDefaultVerdier(
+                id = skjemaId,
+                status = SkjemaStatus.SENDT,
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier(),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+            val innsending = innsendingMedDefaultVerdier(
+                skjema = skjema,
+                innsendtSprak = Språk.NORSK_BOKMAL,
+                saksnummer = "MEL-123456",
+                saksstatus = Saksstatus.AVSLUTTET
+            )
+            val definisjon = SkjemaDefinisjonDto(type = "A1", versjon = "1", seksjoner = emptyMap())
+
+            every { mockSubjectHandler.getUserID() } returns skjema.fnr
+            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockInnsendingRepository.findBySkjemaId(skjemaId) } returns innsending
+            every { mockSkjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, "1", Språk.NORSK_BOKMAL) } returns definisjon
+
+            val response = service.hentInnsendtSkjema(skjemaId, null)
+
+            response.saksnummer shouldBe "MEL-123456"
+            response.saksstatus shouldBe Saksstatus.AVSLUTTET
         }
     }
 


### PR DESCRIPTION
Plan-oppgave 02 + 03 (backend). Stablet på #348 — retargetes til main når den merges.

- `InnsendtSoknadOversiktDto`: nye felter `saksnummer`, `saksstatus`, `motpartStatus` (ny enum `HAR_SENDT`/`VENTER`/`IKKE_RELEVANT`) og `skjemadel` (frontend trenger den for «venter på …»-tekst).
- `InnsendtSkjemaResponse` (detaljsiden `/skjema/{id}/innsendt`): `saksnummer` + `saksstatus` — ren utvidelse, innsendingen hentes allerede der.
- Motpart-status utledes fra `metadata.kobletSkjemaId` + koblet skjema med status SENDT. Koblede skjemaer batch-hentes med ett `findAllById`-kall per side (unngår N+1).
- Backend returnerer saksstatus og motpartStatus uavhengig; «Avsluttet vinner over venter» håndteres i frontend-visningen.

NB: Badge-tekstene i frontend (egen PR i melosys-skjema-web) venter endelig designer-godkjenning.