### PR TITLE
MELOSYS-8084 Startup-probe så liveness ikke dreper appen under oppstart

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -11,6 +11,14 @@ spec:
   port: 8080
   ingresses:
     - https://melosys-skjema-api.intern.dev.nav.no
+  # Startup-proben holder liveness/readiness tilbake til appen er oppe -
+  # oppstart tar 40-50s+ under CPU-throttling, og liveness (initialDelay 20 +
+  # 3x10s failureThreshold) drepte containeren midt i oppstarten.
+  startup:
+    path: /actuator/health
+    initialDelay: 10
+    periodSeconds: 5
+    failureThreshold: 60
   liveness:
     path: /actuator/health
     initialDelay: 20

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -11,6 +11,14 @@ spec:
   port: 8080
   ingresses:
     - https://melosys-skjema-api.intern.nav.no
+  # Startup-proben holder liveness/readiness tilbake til appen er oppe -
+  # oppstart tar 40-50s+ under CPU-throttling, og liveness (initialDelay 20 +
+  # 3x10s failureThreshold) drepte containeren midt i oppstarten.
+  startup:
+    path: /actuator/health
+    initialDelay: 10
+    periodSeconds: 5
+    failureThreshold: 60
   liveness:
     path: /actuator/health
     initialDelay: 20


### PR DESCRIPTION
Oppstart tar 40-50s+ under CPU-throttling; liveness (initialDelay 20 + 3×10s failureThreshold) drepte containeren rett før den ble ferdig — deploy-dev for 5ebbe9e feilet på rollout-timeout selv om appen starter fint (Flyway grønn, «Started in 39.9s» → SIGTERM). Startup-proben gir opptil ~5 min oppstartsvindu før liveness tar over.