### PR TITLE
MELOSYS-8084 Motpart-CTA: endepunkt for ventende motpart-søknader

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
@@ -7,5 +7,6 @@ data class OpprettUtsendtArbeidstakerSoknadRequest(
     val representasjonstype: Representasjonstype,
     val radgiverfirma: SimpleOrganisasjonDto?,
     val arbeidsgiver: SimpleOrganisasjonDto,
-    val arbeidstaker: PersonDto
+    val arbeidstaker: PersonDto,
+    val opprettetVia: OpprettetVia? = null
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
@@ -1,0 +1,11 @@
+package no.nav.melosys.skjema.types.utsendtarbeidstaker
+
+/**
+ * Hvordan et skjema ble startet, når det skjedde via en annen inngang enn ordinær flyt
+ * (null = ordinær flyt). Brukes kun til aggregert bruksstatistikk i admin — eksponeres
+ * aldri til sluttbruker og knyttes ikke til nye personopplysninger.
+ */
+enum class OpprettetVia {
+    /** Startet fra «motpart har sendt inn sin del»-oppfordringen på oversikten. */
+    MOTPART_CTA
+}

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
@@ -2,8 +2,7 @@ package no.nav.melosys.skjema.types.utsendtarbeidstaker
 
 /**
  * Hvordan et skjema ble startet, når det skjedde via en annen inngang enn ordinær flyt
- * (null = ordinær flyt). Brukes kun til aggregert bruksstatistikk i admin — eksponeres
- * aldri til sluttbruker og knyttes ikke til nye personopplysninger.
+ * (null = ordinær flyt). Brukes kun til aggregert bruksstatistikk i admin.
  */
 enum class OpprettetVia {
     /** Startet fra «motpart har sendt inn sin del»-oppfordringen på oversikten. */

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
@@ -1,0 +1,23 @@
+package no.nav.melosys.skjema.types.utsendtarbeidstaker
+
+import java.time.Instant
+import java.util.UUID
+import no.nav.melosys.skjema.types.felles.PeriodeDto
+
+/**
+ * En innsendt arbeidsgiver-del som venter på at innlogget bruker sender inn arbeidstakers del.
+ *
+ * Inneholder kun det arbeidstaker trenger for å starte sin del — samme opplysninger som
+ * allerede gis i brukervarselet ved arbeidsgivers innsending (ingen ny eksponering).
+ */
+data class VentendeMotpartSoknadDto(
+    val skjemaId: UUID,
+    val arbeidsgiverNavn: String,
+    val arbeidsgiverOrgnr: String,
+    val utsendingsperiode: PeriodeDto?,
+    val innsendtDato: Instant
+)
+
+data class VentendeMotpartSoknaderResponse(
+    val soknader: List<VentendeMotpartSoknadDto>
+)

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
@@ -6,9 +6,7 @@ import no.nav.melosys.skjema.types.felles.PeriodeDto
 
 /**
  * En innsendt arbeidsgiver-del som venter på at innlogget bruker sender inn arbeidstakers del.
- *
- * Inneholder kun det arbeidstaker trenger for å starte sin del — samme opplysninger som
- * allerede gis i brukervarselet ved arbeidsgivers innsending (ingen ny eksponering).
+ * Skal kun inneholde det arbeidstaker trenger for å starte sin del.
  */
 data class VentendeMotpartSoknadDto(
     val skjemaId: UUID,

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/UtsendtArbeidstakerController.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 import no.nav.melosys.skjema.service.HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService
 import no.nav.melosys.skjema.service.HentUtkastUtsendtArbeidstakerService
 import no.nav.melosys.skjema.service.UtsendtArbeidstakerService
+import no.nav.melosys.skjema.service.VentendeMotpartSoknadService
 import no.nav.melosys.skjema.types.HentInnsendteSoknaderRequest
 import no.nav.melosys.skjema.types.HentUtkastRequest
 import no.nav.melosys.skjema.types.InnsendtSkjemaResponse
@@ -20,6 +21,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.SkjemaInnsendtKvittering
 import no.nav.melosys.skjema.types.UtkastListeResponse
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.VentendeMotpartSoknaderResponse
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsgiverensVirksomhetINorgeDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidsstedIUtlandetDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.ArbeidstakerensLonnDto
@@ -54,6 +56,7 @@ class UtsendtArbeidstakerController(
     private val utsendtArbeidstakerService: UtsendtArbeidstakerService,
     private val hentInnsendteSoknaderService: HentInnsendteSoknaderUtsendtArbeidstakerSkjemaService,
     private val hentUtkastService: HentUtkastUtsendtArbeidstakerService,
+    private val ventendeMotpartSoknadService: VentendeMotpartSoknadService,
 ) {
 
     @GetMapping("/utkast")
@@ -107,6 +110,13 @@ class UtsendtArbeidstakerController(
     fun slettUtkast(@PathVariable id: UUID) {
         log.info { "Sletter utkast: $id" }
         utsendtArbeidstakerService.slettUtkast(id)
+    }
+
+    @GetMapping("/ventende-motpart-soknader")
+    @Operation(summary = "Hent innsendte arbeidsgiver-deler som venter på innlogget brukers arbeidstaker-del")
+    @ApiResponse(responseCode = "200", description = "Liste over ventende motpart-søknader hentet (tom når toggle er av)")
+    fun hentVentendeMotpartSoknader(): ResponseEntity<VentendeMotpartSoknaderResponse> {
+        return ResponseEntity.ok(ventendeMotpartSoknadService.hentVentendeMotpartSoknader())
     }
 
     @PostMapping("/opprett-med-kontekst")

--- a/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 import no.nav.melosys.skjema.types.SkjemaData
 import no.nav.melosys.skjema.types.SkjemaMetadata
 import no.nav.melosys.skjema.types.SkjemaType
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.common.SkjemaStatus
@@ -50,6 +51,10 @@ class Skjema(
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "metadata", nullable = false)
     var metadata: SkjemaMetadata,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "opprettet_via", length = 50)
+    val opprettetVia: OpprettetVia? = null,
 
     @Column(name = "opprettet_dato", nullable = false)
     val opprettetDato: Instant = Instant.now(),

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -18,6 +18,8 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
 
     fun findBySkjemaId(skjemaId: UUID): Innsending?
 
+    fun findBySkjemaIdIn(skjemaIder: Collection<UUID>): List<Innsending>
+
     /**
      * Finner innsendinger som er kandidater for retry.
      *

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -85,6 +85,7 @@ class UtsendtArbeidstakerService(
                     fnr = innloggetBrukerFnr,
                     orgnr = request.arbeidsgiver.orgnr,
                     metadata = metadata,
+                    opprettetVia = request.opprettetVia,
                     opprettetAv = innloggetBrukerFnr,
                     endretAv = innloggetBrukerFnr
                 )
@@ -100,6 +101,7 @@ class UtsendtArbeidstakerService(
                     orgnr = request.arbeidsgiver.orgnr,
                     fnr = request.arbeidstaker.fnr,
                     metadata = metadata,
+                    opprettetVia = request.opprettetVia,
                     opprettetAv = innloggetBrukerFnr,
                     endretAv = innloggetBrukerFnr
                 )
@@ -112,6 +114,7 @@ class UtsendtArbeidstakerService(
                     fnr = request.arbeidstaker.fnr,
                     orgnr = request.arbeidsgiver.orgnr,
                     metadata = metadata,
+                    opprettetVia = request.opprettetVia,
                     opprettetAv = innloggetBrukerFnr,
                     endretAv = innloggetBrukerFnr
                 )

--- a/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
@@ -1,0 +1,87 @@
+package no.nav.melosys.skjema.service
+
+import io.getunleash.Unleash
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.melosys.skjema.extensions.utsendelsePeriode
+import no.nav.melosys.skjema.featuretoggle.ToggleNavn
+import no.nav.melosys.skjema.repository.InnsendingRepository
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
+import no.nav.melosys.skjema.types.SkjemaType
+import no.nav.melosys.skjema.types.common.Saksstatus
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.VentendeMotpartSoknadDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.VentendeMotpartSoknaderResponse
+import org.springframework.stereotype.Service
+
+private val log = KotlinLogging.logger { }
+
+/**
+ * Finner innsendte arbeidsgiver-deler som venter på at innlogget bruker (som arbeidstaker)
+ * sender inn sin del. Brukes av motpart-CTA-en på oversikten i melosys-skjema-web.
+ *
+ * En arbeidsgiver-del regnes som ventende når ALLE kriteriene under er oppfylt:
+ * - status SENDT og `skjemadel == ARBEIDSGIVERS_DEL` med innlogget brukers fnr som arbeidstaker
+ * - ikke koblet til en arbeidstaker-del (`kobletSkjemaId == null`)
+ * - ikke erstattet av en nyere versjon (kun siste versjon i en erstatter-kjede vises)
+ * - saken er ikke avsluttet i Melosys (`innsending.saksstatus != AVSLUTTET` — motparten kan ha
+ *   sendt via annen kanal uten at kobling finnes)
+ * - brukeren har ikke allerede et arbeidstaker-utkast for samme juridiske enhet (samme guard
+ *   som [ArbeidstakerVarslingService] bruker for å unngå purring av de som er i gang)
+ */
+@Service
+class VentendeMotpartSoknadService(
+    private val skjemaRepository: SkjemaRepository,
+    private val innsendingRepository: InnsendingRepository,
+    private val subjectHandler: SubjectHandler,
+    private val unleash: Unleash
+) {
+
+    fun hentVentendeMotpartSoknader(): VentendeMotpartSoknaderResponse {
+        if (!unleash.isEnabled(ToggleNavn.MOTPART_CTA.navn)) {
+            return VentendeMotpartSoknaderResponse(emptyList())
+        }
+
+        val innloggetBrukerFnr = subjectHandler.getUserID()
+        val sendte = skjemaRepository.findByFnrAndTypeAndStatus(innloggetBrukerFnr, SkjemaType.UTSENDT_ARBEIDSTAKER, SkjemaStatus.SENDT)
+
+        val erstattedeIder = sendte
+            .mapNotNull { (it.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
+            .toSet()
+
+        val juridiskeEnheterMedArbeidstakerUtkast = skjemaRepository
+            .findByFnrAndTypeAndStatus(innloggetBrukerFnr, SkjemaType.UTSENDT_ARBEIDSTAKER, SkjemaStatus.UTKAST)
+            .mapNotNull { utkast ->
+                (utkast.metadata as? UtsendtArbeidstakerMetadata)
+                    ?.takeIf { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+                    ?.juridiskEnhetOrgnr
+            }
+            .toSet()
+
+        val ventende = sendte
+            .mapNotNull { skjema ->
+                val id = skjema.id ?: return@mapNotNull null
+                val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+
+                if (metadata.skjemadel != Skjemadel.ARBEIDSGIVERS_DEL) return@mapNotNull null
+                if (metadata.kobletSkjemaId != null) return@mapNotNull null
+                if (id in erstattedeIder) return@mapNotNull null
+                if (metadata.juridiskEnhetOrgnr in juridiskeEnheterMedArbeidstakerUtkast) return@mapNotNull null
+                if (innsendingRepository.findBySkjemaId(id)?.saksstatus == Saksstatus.AVSLUTTET) return@mapNotNull null
+
+                VentendeMotpartSoknadDto(
+                    skjemaId = id,
+                    arbeidsgiverNavn = metadata.arbeidsgiverNavn,
+                    arbeidsgiverOrgnr = skjema.orgnr,
+                    utsendingsperiode = skjema.utsendelsePeriode(),
+                    innsendtDato = skjema.endretDato
+                )
+            }
+            .sortedByDescending { it.innsendtDato }
+
+        log.debug { "Fant ${ventende.size} ventende motpart-søknader for innlogget bruker" }
+        return VentendeMotpartSoknaderResponse(ventende)
+    }
+}

--- a/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.skjema.service
 
 import io.getunleash.Unleash
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.UUID
 import no.nav.melosys.skjema.extensions.utsendelsePeriode
 import no.nav.melosys.skjema.featuretoggle.ToggleNavn
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -60,20 +61,23 @@ class VentendeMotpartSoknadService(
             }
             .toSet()
 
-        val ventende = sendte
-            .mapNotNull { skjema ->
-                val id = skjema.id ?: return@mapNotNull null
-                val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+        val kandidater = sendte.filter { skjema ->
+            val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@filter false
+            skjema.id != null
+                && metadata.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL
+                && metadata.kobletSkjemaId == null
+                && skjema.id !in erstattedeIder
+                && metadata.juridiskEnhetOrgnr !in juridiskeEnheterMedArbeidstakerUtkast
+        }
 
-                if (metadata.skjemadel != Skjemadel.ARBEIDSGIVERS_DEL) return@mapNotNull null
-                if (metadata.kobletSkjemaId != null) return@mapNotNull null
-                if (id in erstattedeIder) return@mapNotNull null
-                if (metadata.juridiskEnhetOrgnr in juridiskeEnheterMedArbeidstakerUtkast) return@mapNotNull null
-                if (innsendingRepository.findBySkjemaId(id)?.saksstatus == Saksstatus.AVSLUTTET) return@mapNotNull null
+        val avsluttedeSkjemaIder = hentAvsluttedeSkjemaIder(kandidater.mapNotNull { it.id })
 
+        val ventende = kandidater
+            .filter { it.id !in avsluttedeSkjemaIder }
+            .map { skjema ->
                 VentendeMotpartSoknadDto(
-                    skjemaId = id,
-                    arbeidsgiverNavn = metadata.arbeidsgiverNavn,
+                    skjemaId = skjema.id!!,
+                    arbeidsgiverNavn = (skjema.metadata as UtsendtArbeidstakerMetadata).arbeidsgiverNavn,
                     arbeidsgiverOrgnr = skjema.orgnr,
                     utsendingsperiode = skjema.utsendelsePeriode(),
                     innsendtDato = skjema.endretDato
@@ -83,5 +87,15 @@ class VentendeMotpartSoknadService(
 
         log.debug { "Fant ${ventende.size} ventende motpart-søknader for innlogget bruker" }
         return VentendeMotpartSoknaderResponse(ventende)
+    }
+
+    private fun hentAvsluttedeSkjemaIder(skjemaIder: List<UUID>): Set<UUID> {
+        if (skjemaIder.isEmpty()) {
+            return emptySet()
+        }
+        return innsendingRepository.findBySkjemaIdIn(skjemaIder)
+            .filter { it.saksstatus == Saksstatus.AVSLUTTET }
+            .mapNotNull { it.skjema.id }
+            .toSet()
     }
 }

--- a/src/main/resources/db/migration/V18__Add_opprettet_via_to_skjema.sql
+++ b/src/main/resources/db/migration/V18__Add_opprettet_via_to_skjema.sql
@@ -1,0 +1,3 @@
+-- Hvordan skjemaet ble startet (null = ordinær flyt). Kun for aggregert bruksstatistikk.
+ALTER TABLE skjema
+    ADD COLUMN opprettet_via VARCHAR(50);

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/ProtectedEndpointsApiTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/ProtectedEndpointsApiTest.kt
@@ -37,6 +37,7 @@ class ProtectedEndpointsApiTes: ApiTestBase() {
     fun endepunkterSomKreverGyldigToken(): List<Arguments> = listOf(
         // SkjemaController - new opprett-med-kontekst endpoints
         Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/opprett-med-kontekst"),
+        Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker/ventende-motpart-soknader"),
         Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker/123"),
         Arguments.of(HttpMethod.POST, "/api/skjema/utsendt-arbeidstaker/123/send-inn"),
         Arguments.of(HttpMethod.GET, "/api/skjema/utsendt-arbeidstaker/123/innsendt-kvittering"),

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -1,0 +1,169 @@
+package no.nav.melosys.skjema.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.getunleash.FakeUnleash
+import io.getunleash.Unleash
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.getToken
+import no.nav.melosys.skjema.integrasjon.ereg.EregService
+import no.nav.melosys.skjema.integrasjon.pdl.PdlService
+import no.nav.melosys.skjema.korrektSyntetiskFnr
+import no.nav.melosys.skjema.korrektSyntetiskOrgnr
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.felles.OrganisasjonMedJuridiskEnhetDto
+import no.nav.melosys.skjema.types.felles.SimpleOrganisasjonDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettUtsendtArbeidstakerSoknadResponse
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
+import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
+import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * API-tester for motpart-CTA-flyten: JSON-kontrakten for ventende motpart-søknader
+ * og at `opprettetVia` fra opprett-requesten persisteres på skjemaet.
+ */
+class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var mockOAuth2Server: MockOAuth2Server
+
+    @Autowired
+    private lateinit var skjemaRepository: SkjemaRepository
+
+    @MockkBean
+    private lateinit var eregService: EregService
+
+    @MockkBean
+    private lateinit var pdlService: PdlService
+
+    @Autowired
+    private lateinit var unleash: Unleash
+
+    @BeforeEach
+    fun setUp() {
+        skjemaRepository.deleteAll()
+        (unleash as FakeUnleash).enableAll()
+    }
+
+    @Test
+    @DisplayName("GET ventende-motpart-soknader returnerer JSON med arbeidsgiver, periode og innsendt dato")
+    fun `henter ventende motpart-soknader som json`() {
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+                    .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+        )
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        webTestClient.get()
+            .uri("/api/skjema/utsendt-arbeidstaker/ventende-motpart-soknader")
+            .headers { it.setBearerAuth(token) }
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.soknader.length()").isEqualTo(1)
+            .jsonPath("$.soknader[0].skjemaId").isEqualTo(skjema.id.toString())
+            .jsonPath("$.soknader[0].arbeidsgiverNavn").isEqualTo("Test Arbeidsgiver AS")
+            .jsonPath("$.soknader[0].arbeidsgiverOrgnr").isEqualTo(korrektSyntetiskOrgnr)
+            .jsonPath("$.soknader[0].utsendingsperiode.fraDato").isEqualTo("2024-01-01")
+            .jsonPath("$.soknader[0].utsendingsperiode.tilDato").isEqualTo("2024-12-31")
+            .jsonPath("$.soknader[0].innsendtDato").isNotEmpty
+    }
+
+    @Test
+    @DisplayName("opprettetVia fra opprett-requesten persisteres på skjemaet")
+    fun `opprettetVia persisteres ved opprettelse`() {
+        every { eregService.organisasjonsnummerEksisterer(korrektSyntetiskOrgnr) } returns true
+        every { eregService.hentOrganisasjonMedJuridiskEnhet(korrektSyntetiskOrgnr) } returns OrganisasjonMedJuridiskEnhetDto(
+            organisasjon = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS"),
+            juridiskEnhet = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS")
+        )
+        every { pdlService.hentNavn(korrektSyntetiskFnr) } returns "Test Testesen"
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        val response = webTestClient.post()
+            .uri("/api/skjema/utsendt-arbeidstaker/opprett-med-kontekst")
+            .headers { it.setBearerAuth(token) }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "representasjonstype": "DEG_SELV",
+                  "radgiverfirma": null,
+                  "arbeidsgiver": {"orgnr": "$korrektSyntetiskOrgnr", "navn": "Test Arbeidsgiver AS"},
+                  "arbeidstaker": {"fnr": "$korrektSyntetiskFnr", "etternavn": "Testesen"},
+                  "opprettetVia": "MOTPART_CTA"
+                }
+                """.trimIndent()
+            )
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody(OpprettUtsendtArbeidstakerSoknadResponse::class.java)
+            .returnResult()
+            .responseBody
+
+        response.shouldNotBeNull()
+        val lagret = skjemaRepository.findById(response.id).orElseThrow()
+        lagret.opprettetVia shouldBe OpprettetVia.MOTPART_CTA
+    }
+
+    @Test
+    @DisplayName("Uten opprettetVia i requesten forblir feltet null")
+    fun `opprettetVia er null ved ordinaer opprettelse`() {
+        every { eregService.organisasjonsnummerEksisterer(korrektSyntetiskOrgnr) } returns true
+        every { eregService.hentOrganisasjonMedJuridiskEnhet(korrektSyntetiskOrgnr) } returns OrganisasjonMedJuridiskEnhetDto(
+            organisasjon = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS"),
+            juridiskEnhet = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS")
+        )
+        every { pdlService.hentNavn(korrektSyntetiskFnr) } returns "Test Testesen"
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        val response = webTestClient.post()
+            .uri("/api/skjema/utsendt-arbeidstaker/opprett-med-kontekst")
+            .headers { it.setBearerAuth(token) }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "representasjonstype": "DEG_SELV",
+                  "radgiverfirma": null,
+                  "arbeidsgiver": {"orgnr": "$korrektSyntetiskOrgnr", "navn": "Test Arbeidsgiver AS"},
+                  "arbeidstaker": {"fnr": "$korrektSyntetiskFnr", "etternavn": "Testesen"}
+                }
+                """.trimIndent()
+            )
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody(OpprettUtsendtArbeidstakerSoknadResponse::class.java)
+            .returnResult()
+            .responseBody
+
+        response.shouldNotBeNull()
+        skjemaRepository.findById(response.id).orElseThrow().opprettetVia shouldBe null
+    }
+}

--- a/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 import no.nav.melosys.skjema.ApiTestBase
 import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
@@ -84,7 +83,7 @@ class VentendeMotpartSoknadServiceIntegrationTest : ApiTestBase() {
             arbeidsgiverNavn shouldBe "Test Arbeidsgiver AS"
             arbeidsgiverOrgnr shouldBe korrektSyntetiskOrgnr
             utsendingsperiode shouldBe periodeDtoMedDefaultVerdier()
-            innsendtDato shouldBe skjema.endretDato.truncatedTo(ChronoUnit.MICROS)
+            innsendtDato shouldBe skjemaRepository.findById(skjema.id!!).orElseThrow().endretDato
         }
     }
 
@@ -115,6 +114,52 @@ class VentendeMotpartSoknadServiceIntegrationTest : ApiTestBase() {
 
         response.soknader shouldHaveSize 1
         response.soknader.single().skjemaId shouldBe ny.id
+    }
+
+    @Test
+    @DisplayName("Erstatter-kjede over flere ledd gir kun treff for nyeste versjon")
+    fun `erstatter-kjede over flere ledd gir kun treff for nyeste`() {
+        val a = lagreSendtArbeidsgiverDel()
+        val b = lagreSendtArbeidsgiverDel(erstatterSkjemaId = a.id)
+        val c = lagreSendtArbeidsgiverDel(erstatterSkjemaId = b.id)
+
+        val response = service.hentVentendeMotpartSoknader()
+
+        response.soknader shouldHaveSize 1
+        response.soknader.single().skjemaId shouldBe c.id
+    }
+
+    @Test
+    @DisplayName("Arbeidsgiver-del uten utsendingsperiode gir treff uten periode")
+    fun `arbeidsgiver-del uten utsendingsperiode gir treff uten periode`() {
+        val skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+        )
+
+        val response = service.hentVentendeMotpartSoknader()
+
+        response.soknader shouldHaveSize 1
+        with(response.soknader.single()) {
+            skjemaId shouldBe skjema.id
+            utsendingsperiode shouldBe null
+        }
+    }
+
+    @Test
+    @DisplayName("Innsending uten synket saksstatus gir treff")
+    fun `innsending uten synket saksstatus gir treff`() {
+        val skjema = lagreSendtArbeidsgiverDel()
+        innsendingRepository.save(innsendingMedDefaultVerdier(skjema = skjema, saksstatus = null))
+
+        service.hentVentendeMotpartSoknader().soknader shouldHaveSize 1
     }
 
     @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
@@ -1,0 +1,235 @@
+package no.nav.melosys.skjema.service
+
+import com.ninjasquad.springmockk.MockkBean
+import io.getunleash.FakeUnleash
+import io.getunleash.Unleash
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
+import no.nav.melosys.skjema.entity.Skjema
+import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
+import no.nav.melosys.skjema.featuretoggle.ToggleNavn
+import no.nav.melosys.skjema.innsendingMedDefaultVerdier
+import no.nav.melosys.skjema.korrektSyntetiskFnr
+import no.nav.melosys.skjema.korrektSyntetiskOrgnr
+import no.nav.melosys.skjema.periodeDtoMedDefaultVerdier
+import no.nav.melosys.skjema.repository.InnsendingRepository
+import no.nav.melosys.skjema.repository.SkjemaRepository
+import no.nav.melosys.skjema.sikkerhet.context.SubjectHandler
+import no.nav.melosys.skjema.skjemaMedDefaultVerdier
+import no.nav.melosys.skjema.types.common.Saksstatus
+import no.nav.melosys.skjema.types.common.SkjemaStatus
+import no.nav.melosys.skjema.types.felles.LandKode
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendingsperiodeOgLandDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
+import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class VentendeMotpartSoknadServiceIntegrationTest : ApiTestBase() {
+
+    @Autowired
+    private lateinit var service: VentendeMotpartSoknadService
+
+    @Autowired
+    private lateinit var skjemaRepository: SkjemaRepository
+
+    @Autowired
+    private lateinit var innsendingRepository: InnsendingRepository
+
+    @Autowired
+    private lateinit var unleash: Unleash
+
+    @MockkBean
+    private lateinit var subjectHandler: SubjectHandler
+
+    private val arbeidstakerFnr = korrektSyntetiskFnr
+    private val annenJuridiskEnhetOrgnr = "974761076"
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(subjectHandler)
+        every { subjectHandler.getUserID() } returns arbeidstakerFnr
+        innsendingRepository.deleteAll()
+        skjemaRepository.deleteAll()
+        (unleash as FakeUnleash).enableAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        (unleash as FakeUnleash).enableAll()
+    }
+
+    @Test
+    @DisplayName("Ukoblet innsendt arbeidsgiver-del gir treff med arbeidsgiver, periode og innsendt dato")
+    fun `ukoblet arbeidsgiver-del gir treff`() {
+        val skjema = lagreSendtArbeidsgiverDel()
+
+        val response = service.hentVentendeMotpartSoknader()
+
+        response.soknader shouldHaveSize 1
+        with(response.soknader.single()) {
+            skjemaId shouldBe skjema.id
+            arbeidsgiverNavn shouldBe "Test Arbeidsgiver AS"
+            arbeidsgiverOrgnr shouldBe korrektSyntetiskOrgnr
+            utsendingsperiode shouldBe periodeDtoMedDefaultVerdier()
+            innsendtDato shouldBe skjema.endretDato.truncatedTo(ChronoUnit.MICROS)
+        }
+    }
+
+    @Test
+    @DisplayName("Toggle av gir alltid tom liste")
+    fun `toggle av gir tom liste`() {
+        lagreSendtArbeidsgiverDel()
+        (unleash as FakeUnleash).enableAllExcept(ToggleNavn.MOTPART_CTA.navn)
+
+        service.hentVentendeMotpartSoknader().soknader.shouldBeEmpty()
+    }
+
+    @Test
+    @DisplayName("Koblet arbeidsgiver-del gir ikke treff")
+    fun `koblet arbeidsgiver-del gir ikke treff`() {
+        lagreSendtArbeidsgiverDel(kobletSkjemaId = UUID.randomUUID())
+
+        service.hentVentendeMotpartSoknader().soknader.shouldBeEmpty()
+    }
+
+    @Test
+    @DisplayName("Arbeidsgiver-del erstattet av nyere versjon gir kun treff for nyeste")
+    fun `erstattet versjon gir kun treff for nyeste`() {
+        val gammel = lagreSendtArbeidsgiverDel()
+        val ny = lagreSendtArbeidsgiverDel(erstatterSkjemaId = gammel.id)
+
+        val response = service.hentVentendeMotpartSoknader()
+
+        response.soknader shouldHaveSize 1
+        response.soknader.single().skjemaId shouldBe ny.id
+    }
+
+    @Test
+    @DisplayName("Avsluttet sak gir ikke treff, mottatt sak gir treff")
+    fun `avsluttet sak gir ikke treff`() {
+        val avsluttet = lagreSendtArbeidsgiverDel()
+        innsendingRepository.save(innsendingMedDefaultVerdier(skjema = avsluttet, saksstatus = Saksstatus.AVSLUTTET))
+
+        val mottatt = lagreSendtArbeidsgiverDel(juridiskEnhetOrgnr = annenJuridiskEnhetOrgnr)
+        innsendingRepository.save(innsendingMedDefaultVerdier(skjema = mottatt, saksstatus = Saksstatus.MOTTATT))
+
+        val response = service.hentVentendeMotpartSoknader()
+
+        response.soknader shouldHaveSize 1
+        response.soknader.single().skjemaId shouldBe mottatt.id
+    }
+
+    @Test
+    @DisplayName("Eksisterende arbeidstaker-utkast for samme juridiske enhet gir ikke treff")
+    fun `arbeidstaker-utkast for samme juridiske enhet gir ikke treff`() {
+        lagreSendtArbeidsgiverDel()
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                status = SkjemaStatus.UTKAST,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+
+        service.hentVentendeMotpartSoknader().soknader.shouldBeEmpty()
+    }
+
+    @Test
+    @DisplayName("Arbeidstaker-utkast for annen juridisk enhet gir fortsatt treff")
+    fun `arbeidstaker-utkast for annen juridisk enhet gir fortsatt treff`() {
+        lagreSendtArbeidsgiverDel()
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                status = SkjemaStatus.UTKAST,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    juridiskEnhetOrgnr = annenJuridiskEnhetOrgnr
+                )
+            )
+        )
+
+        service.hentVentendeMotpartSoknader().soknader shouldHaveSize 1
+    }
+
+    @Test
+    @DisplayName("Egen innsendt arbeidstaker-del og kombinert del gir ikke treff")
+    fun `andre skjemadeler gir ikke treff`() {
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+        skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = arbeidstakerFnr,
+                status = SkjemaStatus.SENDT,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
+                    skjemadel = Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL
+                )
+            )
+        )
+
+        service.hentVentendeMotpartSoknader().soknader.shouldBeEmpty()
+    }
+
+    @Test
+    @DisplayName("Arbeidsgiver-del for annen arbeidstaker gir ikke treff")
+    fun `annen arbeidstakers arbeidsgiver-del gir ikke treff`() {
+        lagreSendtArbeidsgiverDel(fnr = etAnnetKorrektSyntetiskFnr)
+
+        service.hentVentendeMotpartSoknader().soknader.shouldBeEmpty()
+    }
+
+    private fun lagreSendtArbeidsgiverDel(
+        fnr: String = arbeidstakerFnr,
+        kobletSkjemaId: UUID? = null,
+        erstatterSkjemaId: UUID? = null,
+        juridiskEnhetOrgnr: String = korrektSyntetiskOrgnr
+    ): Skjema = skjemaRepository.save(
+        skjemaMedDefaultVerdier(
+            fnr = fnr,
+            orgnr = korrektSyntetiskOrgnr,
+            status = SkjemaStatus.SENDT,
+            data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier().medUtsendingsperiode(),
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+                kobletSkjemaId = kobletSkjemaId,
+                erstatterSkjemaId = erstatterSkjemaId,
+                juridiskEnhetOrgnr = juridiskEnhetOrgnr
+            )
+        )
+    )
+
+    private fun UtsendtArbeidstakerArbeidsgiversSkjemaDataDto.medUtsendingsperiode(): UtsendtArbeidstakerArbeidsgiversSkjemaDataDto =
+        copy(
+            utsendingsperiodeOgLand = UtsendingsperiodeOgLandDto(
+                utsendelseLand = LandKode.SE,
+                utsendelsePeriode = periodeDtoMedDefaultVerdier()
+            )
+        )
+}


### PR DESCRIPTION
- Nytt endepunkt `GET /api/skjema/utsendt-arbeidstaker/ventende-motpart-soknader` (bak toggle `melosys.skjema.motpart-cta`)
- Nytt valgfritt felt `opprettetVia` på opprett-requesten, lagres i egen kolonne for aggregert bruksstatistikk