### PR TITLE
MELOSYS-8084 Preutfyll land og periode fra arbeidsgivers del (motpart-CTA)

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
@@ -1,5 +1,6 @@
 package no.nav.melosys.skjema.types.utsendtarbeidstaker
 
+import java.util.UUID
 import no.nav.melosys.skjema.types.felles.PersonDto
 import no.nav.melosys.skjema.types.felles.SimpleOrganisasjonDto
 
@@ -8,5 +9,11 @@ data class OpprettUtsendtArbeidstakerSoknadRequest(
     val radgiverfirma: SimpleOrganisasjonDto?,
     val arbeidsgiver: SimpleOrganisasjonDto,
     val arbeidstaker: PersonDto,
-    val opprettetVia: OpprettetVia? = null
+    val opprettetVia: OpprettetVia? = null,
+    /**
+     * Innsendt arbeidsgiver-del å forhåndsutfylle land og utsendingsperiode fra
+     * (motpart-CTA). Må være innlogget brukers egen ventende arbeidsgiver-del —
+     * ellers ignoreres den. Verdiene kan fritt overskrives i utfyllingen.
+     */
+    val prefyllFraSkjemaId: UUID? = null
 )

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettUtsendtArbeidstakerSoknadRequest.kt
@@ -9,7 +9,7 @@ data class OpprettUtsendtArbeidstakerSoknadRequest(
     val radgiverfirma: SimpleOrganisasjonDto?,
     val arbeidsgiver: SimpleOrganisasjonDto,
     val arbeidstaker: PersonDto,
-    val opprettetVia: OpprettetVia? = null,
+    val opprettetVia: OpprettetVia = OpprettetVia.ORDINAER,
     /**
      * Innsendt arbeidsgiver-del å forhåndsutfylle land og utsendingsperiode fra
      * (motpart-CTA). Må være innlogget brukers egen ventende arbeidsgiver-del —

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/OpprettetVia.kt
@@ -1,10 +1,13 @@
 package no.nav.melosys.skjema.types.utsendtarbeidstaker
 
 /**
- * Hvordan et skjema ble startet, når det skjedde via en annen inngang enn ordinær flyt
- * (null = ordinær flyt). Brukes kun til aggregert bruksstatistikk i admin.
+ * Hvordan et skjema ble startet. Brukes kun til aggregert bruksstatistikk i admin.
+ * Null i databasen betyr opprettet før målingen fantes.
  */
 enum class OpprettetVia {
     /** Startet fra «motpart har sendt inn sin del»-oppfordringen på oversikten. */
-    MOTPART_CTA
+    MOTPART_CTA,
+
+    /** Startet på eget initiativ via ordinær flyt. */
+    ORDINAER
 }

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
@@ -15,5 +15,6 @@ data class UtsendtArbeidstakerSkjemaDto(
     override val opprettetDato: LocalDateTime,
     override val endretDato: LocalDateTime,
     override val metadata: UtsendtArbeidstakerMetadata,
-    override val data: UtsendtArbeidstakerSkjemaData
+    override val data: UtsendtArbeidstakerSkjemaData,
+    val opprettetVia: OpprettetVia? = null
 ) : SkjemaDto

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
@@ -16,7 +16,6 @@ data class UtsendtArbeidstakerSkjemaDto(
     override val endretDato: LocalDateTime,
     override val metadata: UtsendtArbeidstakerMetadata,
     override val data: UtsendtArbeidstakerSkjemaData,
-    val opprettetVia: OpprettetVia? = null,
     /**
      * Land og periode slik arbeidsgiveren oppga dem i delen utkastet ble forhåndsutfylt
      * fra (motpart-CTA) — uendret selv om bruker overskriver sine egne verdier.

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/UtsendtArbeidstakerSkjemaDto.kt
@@ -16,5 +16,10 @@ data class UtsendtArbeidstakerSkjemaDto(
     override val endretDato: LocalDateTime,
     override val metadata: UtsendtArbeidstakerMetadata,
     override val data: UtsendtArbeidstakerSkjemaData,
-    val opprettetVia: OpprettetVia? = null
+    val opprettetVia: OpprettetVia? = null,
+    /**
+     * Land og periode slik arbeidsgiveren oppga dem i delen utkastet ble forhåndsutfylt
+     * fra (motpart-CTA) — uendret selv om bruker overskriver sine egne verdier.
+     */
+    val motpartensUtsendingsperiodeOgLand: UtsendingsperiodeOgLandDto? = null
 ) : SkjemaDto

--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/utsendtarbeidstaker/VentendeMotpartSoknaderResponse.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.skjema.types.utsendtarbeidstaker
 
 import java.time.Instant
 import java.util.UUID
+import no.nav.melosys.skjema.types.felles.LandKode
 import no.nav.melosys.skjema.types.felles.PeriodeDto
 
 /**
@@ -13,6 +14,7 @@ data class VentendeMotpartSoknadDto(
     val arbeidsgiverNavn: String,
     val arbeidsgiverOrgnr: String,
     val utsendingsperiode: PeriodeDto?,
+    val utsendelseLand: LandKode?,
     val innsendtDato: Instant
 )
 

--- a/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/entity/Skjema.kt
@@ -56,6 +56,9 @@ class Skjema(
     @Column(name = "opprettet_via", length = 50)
     val opprettetVia: OpprettetVia? = null,
 
+    @Column(name = "prefylt_fra_skjema_id", columnDefinition = "UUID")
+    var prefyltFraSkjemaId: UUID? = null,
+
     @Column(name = "opprettet_dato", nullable = false)
     val opprettetDato: Instant = Instant.now(),
 

--- a/src/main/kotlin/no/nav/melosys/skjema/extensions/SkjemaExtensions.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/extensions/SkjemaExtensions.kt
@@ -34,7 +34,8 @@ fun Skjema.toUtsendtArbeidstakerDto(): UtsendtArbeidstakerSkjemaDto {
         opprettetDato = this.opprettetDato.toOsloLocalDateTime(),
         endretDato = this.endretDato.toOsloLocalDateTime(),
         metadata = metadata,
-        data = this.utsendtArbeidstakerSkjemaDataOrEmpty()
+        data = this.utsendtArbeidstakerSkjemaDataOrEmpty(),
+        opprettetVia = this.opprettetVia
     )
 }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/extensions/SkjemaExtensions.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/extensions/SkjemaExtensions.kt
@@ -34,8 +34,7 @@ fun Skjema.toUtsendtArbeidstakerDto(): UtsendtArbeidstakerSkjemaDto {
         opprettetDato = this.opprettetDato.toOsloLocalDateTime(),
         endretDato = this.endretDato.toOsloLocalDateTime(),
         metadata = metadata,
-        data = this.utsendtArbeidstakerSkjemaDataOrEmpty(),
-        opprettetVia = this.opprettetVia
+        data = this.utsendtArbeidstakerSkjemaDataOrEmpty()
     )
 }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -162,6 +162,19 @@ class UtsendtArbeidstakerService(
         }
 
         skjema.data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(utsendingsperiodeOgLand = utsendingsperiodeOgLand)
+        skjema.prefyltFraSkjemaId = kilde.id
+    }
+
+    /**
+     * Legger ved motpartens oppgitte land og periode fra arbeidsgiver-delen utkastet ble
+     * forhåndsutfylt fra, slik at frontend kan vise dem selv etter at bruker har endret verdiene.
+     */
+    private fun medMotpartensOppgitteVerdier(dto: UtsendtArbeidstakerSkjemaDto, skjema: Skjema): UtsendtArbeidstakerSkjemaDto {
+        val kildeId = skjema.prefyltFraSkjemaId ?: return dto
+        val motpartensVerdier = skjemaRepository.findById(kildeId).orElse(null)
+            ?.let { (it.data as? UtsendtArbeidstakerSkjemaData)?.utsendingsperiodeOgLand }
+            ?: return dto
+        return dto.copy(motpartensUtsendingsperiodeOgLand = motpartensVerdier)
     }
 
     /**
@@ -174,7 +187,7 @@ class UtsendtArbeidstakerService(
     fun hentSkjema(skjemaId: UUID): UtsendtArbeidstakerSkjemaDto {
         val skjema = findByIdOrThrow(skjemaId)
         if (skjema.status != SkjemaStatus.SENDT) {
-            return krevSkrivetilgang(skjema).toUtsendtArbeidstakerDto()
+            return medMotpartensOppgitteVerdier(krevSkrivetilgang(skjema).toUtsendtArbeidstakerDto(), skjema)
         }
 
         val dto = skjema.toUtsendtArbeidstakerDto()

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -150,8 +150,9 @@ class UtsendtArbeidstakerService(
             || kilde.fnr != innloggetBrukerFnr
             || kilde.status != SkjemaStatus.SENDT
             || kildeMetadata?.skjemadel != Skjemadel.ARBEIDSGIVERS_DEL
+            || kildeMetadata.juridiskEnhetOrgnr != skjema.utsendtArbeidstakerMetadataOrThrow().juridiskEnhetOrgnr
         ) {
-            log.warn { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: ikke en innsendt arbeidsgiver-del for innlogget bruker" }
+            log.warn { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: ikke en innsendt arbeidsgiver-del for innlogget bruker og samme arbeidsgiver" }
             return
         }
 

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -121,6 +121,8 @@ class UtsendtArbeidstakerService(
             }
         }
 
+        request.prefyllFraSkjemaId?.let { prefyllFraMotpartsDel(skjema, it, innloggetBrukerFnr) }
+
         val savedSkjema = skjemaRepository.save(skjema)
         log.info { "Opprettet Utsendt Arbeidstaker søknad med id: ${savedSkjema.id}, representasjonstype: ${request.representasjonstype}" }
 
@@ -128,6 +130,38 @@ class UtsendtArbeidstakerService(
             id = savedSkjema.id ?: throw IllegalStateException("Skjema ID var null etter lagring"),
             status = savedSkjema.status
         )
+    }
+
+    /**
+     * Forhåndsutfyller land og utsendingsperiode i et nytt arbeidstaker-utkast fra en innsendt
+     * arbeidsgiver-del (motpart-CTA). Kilden må være innlogget brukers egen ventende
+     * arbeidsgiver-del; alt annet ignoreres slik at opprettelsen aldri feiler på prefyll.
+     * Verdiene er kun startverdier og kan fritt overskrives i utfyllingen.
+     */
+    private fun prefyllFraMotpartsDel(skjema: Skjema, prefyllFraSkjemaId: UUID, innloggetBrukerFnr: String) {
+        if (skjema.utsendtArbeidstakerMetadataOrThrow().skjemadel != Skjemadel.ARBEIDSTAKERS_DEL) {
+            log.warn { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: gjelder kun arbeidstakers del" }
+            return
+        }
+
+        val kilde = skjemaRepository.findById(prefyllFraSkjemaId).orElse(null)
+        val kildeMetadata = kilde?.metadata as? UtsendtArbeidstakerMetadata
+        if (kilde == null
+            || kilde.fnr != innloggetBrukerFnr
+            || kilde.status != SkjemaStatus.SENDT
+            || kildeMetadata?.skjemadel != Skjemadel.ARBEIDSGIVERS_DEL
+        ) {
+            log.warn { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: ikke en innsendt arbeidsgiver-del for innlogget bruker" }
+            return
+        }
+
+        val utsendingsperiodeOgLand = (kilde.data as? UtsendtArbeidstakerSkjemaData)?.utsendingsperiodeOgLand
+        if (utsendingsperiodeOgLand == null) {
+            log.info { "Prefyll fra skjema $prefyllFraSkjemaId hoppet over: kilden mangler utsendingsperiode og land" }
+            return
+        }
+
+        skjema.data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(utsendingsperiodeOgLand = utsendingsperiodeOgLand)
     }
 
     /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -1,5 +1,6 @@
 package no.nav.melosys.skjema.service
 
+import io.getunleash.Unleash
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.melosys.skjema.config.observability.MDCOperations
 import no.nav.melosys.skjema.entity.Skjema
@@ -11,6 +12,7 @@ import no.nav.melosys.skjema.extensions.toUtsendtArbeidstakerDto
 import no.nav.melosys.skjema.extensions.utsendtArbeidstakerMetadataOrThrow
 import no.nav.melosys.skjema.extensions.utsendtArbeidstakerSkjemaDataOrEmpty
 import no.nav.melosys.skjema.extensions.utsendtArbeidstakerSkjemaDataOrThrow
+import no.nav.melosys.skjema.featuretoggle.ToggleNavn
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
 import no.nav.melosys.skjema.integrasjon.repr.ReprService
 import no.nav.melosys.skjema.repository.InnsendingRepository
@@ -56,6 +58,7 @@ class UtsendtArbeidstakerService(
     private val referanseIdGenerator: ReferanseIdGenerator,
     private val skjemaDefinisjonService: SkjemaDefinisjonService,
     @Lazy private val vedleggService: VedleggService,
+    private val unleash: Unleash,
 ) {
 
     /**
@@ -139,6 +142,10 @@ class UtsendtArbeidstakerService(
      * Verdiene er kun startverdier og kan fritt overskrives i utfyllingen.
      */
     private fun prefyllFraMotpartsDel(skjema: Skjema, prefyllFraSkjemaId: UUID, innloggetBrukerFnr: String) {
+        if (!unleash.isEnabled(ToggleNavn.MOTPART_CTA.navn)) {
+            log.info { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: motpart-CTA-toggle er av" }
+            return
+        }
         if (skjema.utsendtArbeidstakerMetadataOrThrow().skjemadel != Skjemadel.ARBEIDSTAKERS_DEL) {
             log.warn { "Prefyll fra skjema $prefyllFraSkjemaId ignorert: gjelder kun arbeidstakers del" }
             return

--- a/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadService.kt
@@ -3,7 +3,6 @@ package no.nav.melosys.skjema.service
 import io.getunleash.Unleash
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.UUID
-import no.nav.melosys.skjema.extensions.utsendelsePeriode
 import no.nav.melosys.skjema.featuretoggle.ToggleNavn
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
@@ -13,6 +12,7 @@ import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerSkjemaData
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.VentendeMotpartSoknadDto
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.VentendeMotpartSoknaderResponse
 import org.springframework.stereotype.Service
@@ -75,11 +75,13 @@ class VentendeMotpartSoknadService(
         val ventende = kandidater
             .filter { it.id !in avsluttedeSkjemaIder }
             .map { skjema ->
+                val utsendingsperiodeOgLand = (skjema.data as? UtsendtArbeidstakerSkjemaData)?.utsendingsperiodeOgLand
                 VentendeMotpartSoknadDto(
                     skjemaId = skjema.id!!,
                     arbeidsgiverNavn = (skjema.metadata as UtsendtArbeidstakerMetadata).arbeidsgiverNavn,
                     arbeidsgiverOrgnr = skjema.orgnr,
-                    utsendingsperiode = skjema.utsendelsePeriode(),
+                    utsendingsperiode = utsendingsperiodeOgLand?.utsendelsePeriode,
+                    utsendelseLand = utsendingsperiodeOgLand?.utsendelseLand,
                     innsendtDato = skjema.endretDato
                 )
             }

--- a/src/main/resources/db/migration/V19__Add_prefylt_fra_skjema_id_to_skjema.sql
+++ b/src/main/resources/db/migration/V19__Add_prefylt_fra_skjema_id_to_skjema.sql
@@ -1,0 +1,4 @@
+-- Arbeidsgiver-delen utkastet ble forhåndsutfylt fra (motpart-CTA), for å kunne vise
+-- motpartens oppgitte verdier under utfylling selv etter at bruker har endret dem.
+ALTER TABLE skjema
+    ADD COLUMN prefylt_fra_skjema_id UUID;

--- a/src/main/resources/db/migration/V19__Add_prefylt_fra_skjema_id_to_skjema.sql
+++ b/src/main/resources/db/migration/V19__Add_prefylt_fra_skjema_id_to_skjema.sql
@@ -1,4 +1,4 @@
 -- Arbeidsgiver-delen utkastet ble forhåndsutfylt fra (motpart-CTA), for å kunne vise
 -- motpartens oppgitte verdier under utfylling selv etter at bruker har endret dem.
 ALTER TABLE skjema
-    ADD COLUMN prefylt_fra_skjema_id UUID;
+    ADD COLUMN prefylt_fra_skjema_id UUID REFERENCES skjema (id) ON DELETE SET NULL;

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -290,8 +290,8 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
     }
 
     @Test
-    @DisplayName("Uten opprettetVia i requesten forblir feltet null")
-    fun `opprettetVia er null ved ordinaer opprettelse`() {
+    @DisplayName("Uten opprettetVia i requesten lagres ORDINAER")
+    fun `opprettetVia er ordinaer ved vanlig opprettelse`() {
         every { eregService.organisasjonsnummerEksisterer(korrektSyntetiskOrgnr) } returns true
         every { eregService.hentOrganisasjonMedJuridiskEnhet(korrektSyntetiskOrgnr) } returns OrganisasjonMedJuridiskEnhetDto(
             organisasjon = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS"),
@@ -321,6 +321,6 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
             .responseBody
 
         response.shouldNotBeNull()
-        skjemaRepository.findById(response.id).orElseThrow().opprettetVia shouldBe null
+        skjemaRepository.findById(response.id).orElseThrow().opprettetVia shouldBe OpprettetVia.ORDINAER
     }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -167,7 +167,6 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
             .exchange()
             .expectStatus().isOk
             .expectBody()
-            .jsonPath("$.opprettetVia").isEqualTo("MOTPART_CTA")
             .jsonPath("$.data.utsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
             .jsonPath("$.data.utsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
             .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.getToken
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
 import no.nav.melosys.skjema.integrasjon.pdl.PdlService
@@ -21,6 +22,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettUtsendtArbeidstake
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
 import no.nav.melosys.skjema.utsendingsperiodeOgLandDtoMedDefaultVerdier
 import no.nav.melosys.skjema.arbeidsgiversSkjemaDataDtoMedDefaultVerdier
@@ -130,6 +132,101 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
         response.shouldNotBeNull()
         val lagret = skjemaRepository.findById(response.id).orElseThrow()
         lagret.opprettetVia shouldBe OpprettetVia.MOTPART_CTA
+    }
+
+    @Test
+    @DisplayName("prefyllFraSkjemaId kopierer land og periode fra egen innsendt arbeidsgiver-del")
+    fun `prefyller land og periode fra arbeidsgiver-delen`() {
+        mockOpprettAvhengigheter()
+        val agDel = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+                    .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+        )
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${agDel.id}", "opprettetVia": "MOTPART_CTA"""")
+
+        val lagret = skjemaRepository.findById(response.id).orElseThrow()
+        val data = lagret.data as UtsendtArbeidstakerArbeidstakersSkjemaDataDto
+        data.utsendingsperiodeOgLand shouldBe utsendingsperiodeOgLandDtoMedDefaultVerdier()
+
+        webTestClient.get()
+            .uri("/api/skjema/utsendt-arbeidstaker/${response.id}")
+            .headers { it.setBearerAuth(token) }
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.opprettetVia").isEqualTo("MOTPART_CTA")
+            .jsonPath("$.data.utsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
+            .jsonPath("$.data.utsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
+    }
+
+    @Test
+    @DisplayName("prefyllFraSkjemaId som ikke er egen innsendt arbeidsgiver-del ignoreres")
+    fun `prefyll ignoreres for ugyldige kilder`() {
+        mockOpprettAvhengigheter()
+        val annenPersonsAgDel = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = etAnnetKorrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+                    .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+        )
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${annenPersonsAgDel.id}"""")
+
+        skjemaRepository.findById(response.id).orElseThrow().data shouldBe null
+    }
+
+    private fun opprettSoknad(token: String, ekstraFelter: String): OpprettUtsendtArbeidstakerSoknadResponse {
+        val response = webTestClient.post()
+            .uri("/api/skjema/utsendt-arbeidstaker/opprett-med-kontekst")
+            .headers { it.setBearerAuth(token) }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                """
+                {
+                  "representasjonstype": "DEG_SELV",
+                  "radgiverfirma": null,
+                  "arbeidsgiver": {"orgnr": "$korrektSyntetiskOrgnr", "navn": "Test Arbeidsgiver AS"},
+                  "arbeidstaker": {"fnr": "$korrektSyntetiskFnr", "etternavn": "Testesen"},
+                  $ekstraFelter
+                }
+                """.trimIndent()
+            )
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody(OpprettUtsendtArbeidstakerSoknadResponse::class.java)
+            .returnResult()
+            .responseBody
+
+        response.shouldNotBeNull()
+        return response
+    }
+
+    private fun mockOpprettAvhengigheter() {
+        every { eregService.organisasjonsnummerEksisterer(korrektSyntetiskOrgnr) } returns true
+        every { eregService.hentOrganisasjonMedJuridiskEnhet(korrektSyntetiskOrgnr) } returns OrganisasjonMedJuridiskEnhetDto(
+            organisasjon = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS"),
+            juridiskEnhet = SimpleOrganisasjonDto(orgnr = korrektSyntetiskOrgnr, navn = "Test Arbeidsgiver AS")
+        )
+        every { pdlService.hentNavn(korrektSyntetiskFnr) } returns "Test Testesen"
     }
 
     @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -169,6 +169,47 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
             .jsonPath("$.opprettetVia").isEqualTo("MOTPART_CTA")
             .jsonPath("$.data.utsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
             .jsonPath("$.data.utsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
+            .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
+            .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
+    }
+
+    @Test
+    @DisplayName("Motpartens oppgitte verdier består etter at bruker har overskrevet sine egne")
+    fun `motpartens verdier bestaar etter overskriving`() {
+        mockOpprettAvhengigheter()
+        val agDel = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+                    .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
+                )
+            )
+        )
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+        val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${agDel.id}"""")
+
+        webTestClient.post()
+            .uri("/api/skjema/utsendt-arbeidstaker/${response.id}/utsendingsperiode-og-land")
+            .headers { it.setBearerAuth(token) }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"utsendelseLand": "DE", "utsendelsePeriode": {"fraDato": "2025-03-01", "tilDato": "2025-09-30"}}""")
+            .exchange()
+            .expectStatus().isOk
+
+        webTestClient.get()
+            .uri("/api/skjema/utsendt-arbeidstaker/${response.id}")
+            .headers { it.setBearerAuth(token) }
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.data.utsendingsperiodeOgLand.utsendelseLand").isEqualTo("DE")
+            .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
+            .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -94,6 +94,7 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
             .jsonPath("$.soknader[0].arbeidsgiverOrgnr").isEqualTo(korrektSyntetiskOrgnr)
             .jsonPath("$.soknader[0].utsendingsperiode.fraDato").isEqualTo("2024-01-01")
             .jsonPath("$.soknader[0].utsendingsperiode.tilDato").isEqualTo("2024-12-31")
+            .jsonPath("$.soknader[0].utsendelseLand").isEqualTo("SE")
             .jsonPath("$.soknader[0].innsendtDato").isNotEmpty
     }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -10,6 +10,7 @@ import no.nav.melosys.skjema.ApiTestBase
 import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.getToken
+import no.nav.melosys.skjema.featuretoggle.ToggleNavn
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
 import no.nav.melosys.skjema.integrasjon.pdl.PdlService
 import no.nav.melosys.skjema.korrektSyntetiskFnr
@@ -210,6 +211,21 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
             .jsonPath("$.data.utsendingsperiodeOgLand.utsendelseLand").isEqualTo("DE")
             .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelseLand").isEqualTo("SE")
             .jsonPath("$.motpartensUtsendingsperiodeOgLand.utsendelsePeriode.fraDato").isEqualTo("2024-01-01")
+    }
+
+    @Test
+    @DisplayName("prefyll ignoreres når motpart-CTA-toggelen er av")
+    fun `prefyll ignoreres naar toggle er av`() {
+        mockOpprettAvhengigheter()
+        val agDel = lagreKilde()
+        (unleash as FakeUnleash).enableAllExcept(ToggleNavn.MOTPART_CTA.navn)
+        val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
+
+        val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${agDel.id}"""")
+
+        val lagret = skjemaRepository.findById(response.id).orElseThrow()
+        lagret.data shouldBe null
+        lagret.prefyltFraSkjemaId shouldBe null
     }
 
     @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/VentendeMotpartSoknadApiIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import no.nav.melosys.skjema.ApiTestBase
+import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.getToken
 import no.nav.melosys.skjema.integrasjon.ereg.EregService
@@ -216,25 +217,43 @@ class VentendeMotpartSoknadApiIntegrationTest : ApiTestBase() {
     @DisplayName("prefyllFraSkjemaId som ikke er egen innsendt arbeidsgiver-del ignoreres")
     fun `prefyll ignoreres for ugyldige kilder`() {
         mockOpprettAvhengigheter()
-        val annenPersonsAgDel = skjemaRepository.save(
-            skjemaMedDefaultVerdier(
-                fnr = etAnnetKorrektSyntetiskFnr,
-                orgnr = korrektSyntetiskOrgnr,
-                status = SkjemaStatus.SENDT,
-                data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
-                    .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
-                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
-                    representasjonstype = Representasjonstype.ARBEIDSGIVER,
-                    skjemadel = Skjemadel.ARBEIDSGIVERS_DEL
-                )
-            )
-        )
         val token = mockOAuth2Server.getToken(claims = mapOf("pid" to korrektSyntetiskFnr))
 
-        val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${annenPersonsAgDel.id}"""")
+        val ugyldigeKilder = listOf(
+            lagreKilde(fnr = etAnnetKorrektSyntetiskFnr),
+            lagreKilde(status = SkjemaStatus.UTKAST),
+            lagreKilde(skjemadel = Skjemadel.ARBEIDSTAKERS_DEL, representasjonstype = Representasjonstype.DEG_SELV),
+            lagreKilde(juridiskEnhetOrgnr = "974761076")
+        )
 
-        skjemaRepository.findById(response.id).orElseThrow().data shouldBe null
+        ugyldigeKilder.forEach { kilde ->
+            val response = opprettSoknad(token, """"prefyllFraSkjemaId": "${kilde.id}"""")
+            val lagret = skjemaRepository.findById(response.id).orElseThrow()
+            lagret.data shouldBe null
+            lagret.prefyltFraSkjemaId shouldBe null
+        }
     }
+
+    private fun lagreKilde(
+        fnr: String = korrektSyntetiskFnr,
+        status: SkjemaStatus = SkjemaStatus.SENDT,
+        skjemadel: Skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+        representasjonstype: Representasjonstype = Representasjonstype.ARBEIDSGIVER,
+        juridiskEnhetOrgnr: String = korrektSyntetiskOrgnr
+    ): Skjema = skjemaRepository.save(
+        skjemaMedDefaultVerdier(
+            fnr = fnr,
+            orgnr = korrektSyntetiskOrgnr,
+            status = status,
+            data = arbeidsgiversSkjemaDataDtoMedDefaultVerdier()
+                .copy(utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier()),
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = representasjonstype,
+                skjemadel = skjemadel,
+                juridiskEnhetOrgnr = juridiskEnhetOrgnr
+            )
+        )
+    )
 
     private fun opprettSoknad(token: String, ekstraFelter: String): OpprettUtsendtArbeidstakerSoknadResponse {
         val response = webTestClient.post()

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.melosys.skjema.service
 
+import io.getunleash.FakeUnleash
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -75,7 +76,8 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         eventPublisher,
         referanseIdGenerator,
         mockSkjemaDefinisjonService,
-        mockVedleggService
+        mockVedleggService,
+        FakeUnleash().apply { enableAll() }
     )
 
     val testArbeidsgiver = simpleOrganisasjonDtoMedDefaultVerdier(orgnr = "123456789")

--- a/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/VentendeMotpartSoknadServiceIntegrationTest.kt
@@ -83,6 +83,7 @@ class VentendeMotpartSoknadServiceIntegrationTest : ApiTestBase() {
             arbeidsgiverNavn shouldBe "Test Arbeidsgiver AS"
             arbeidsgiverOrgnr shouldBe korrektSyntetiskOrgnr
             utsendingsperiode shouldBe periodeDtoMedDefaultVerdier()
+            utsendelseLand shouldBe LandKode.SE
             innsendtDato shouldBe skjemaRepository.findById(skjema.id!!).orElseThrow().endretDato
         }
     }


### PR DESCRIPTION
- `prefyllFraSkjemaId` på opprett-requesten: kopierer land og periode fra egen innsendt arbeidsgiver-del (streng eierskaps- og arbeidsgiver-validering)
- `motpartensUtsendingsperiodeOgLand` i skjema-DTO-en så frontend kan vise arbeidsgiverens oppgitte verdier
- `utsendelseLand` i ventende motpart-søknader (vises i banner-teksten)