### PR TITLE
MELOSYS-8084 Saksstatus i bruksstatistikken og backup-uttrekk

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -40,6 +40,18 @@ class AdminController(
         return adminService.hentStatistikk()
     }
 
+    @GetMapping("/saksstatus/uttrekk")
+    @Operation(
+        summary = "Backup-uttrekk av saksnummer/saksstatus per skjema-id",
+        description = "Feltene massesynken kan endre, uten personopplysninger. Ta uttrekket FØR " +
+            "massesynk kjøres, som gjenopprettings- og diff-grunnlag."
+    )
+    @ApiResponse(responseCode = "200", description = "Uttrekk hentet")
+    fun hentSaksstatusUttrekk(): SaksstatusUttrekkDto {
+        log.info { "Admin: Henter saksstatus-uttrekk" }
+        return adminService.hentSaksstatusUttrekk()
+    }
+
     @GetMapping("/statistikk/bruk")
     @Operation(
         summary = "Hent bruksstatistikk for skjemaene",

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -148,10 +148,10 @@ data class SaksdekningDto(
      */
     val antallSakerMedFlereVersjoner: Long,
     /**
-     * Skinnventende: deler som står som ventende hos oss (mangler innsendt motpart), men der saken
-     * er AVSLUTTET i Melosys – motpartens del kom trolig via en annen kanal. Disse skal ikke purres.
+     * Deler som står som ventende hos oss (mangler innsendt motpart), men der saken er AVSLUTTET
+     * i Melosys – motpartens del kom trolig via en annen kanal. Disse skal ikke purres.
      */
-    val antallSkinnventende: Long
+    val antallVentendeMedAvsluttetSak: Long
 )
 
 /**
@@ -211,11 +211,11 @@ data class DelStatusDto(
     val venterIngenMotpart: Long,
     /** Del av [venterMotpartHarUtkast] der saken IKKE er avsluttet i Melosys (inkl. ikke synket). */
     val venterMotpartHarUtkastAktivSak: Long,
-    /** Del av [venterMotpartHarUtkast] der saken er AVSLUTTET i Melosys (skinnventende). */
+    /** Del av [venterMotpartHarUtkast] der saken er AVSLUTTET i Melosys. */
     val venterMotpartHarUtkastAvsluttetSak: Long,
     /** Del av [venterIngenMotpart] der saken IKKE er avsluttet i Melosys (inkl. ikke synket) – reelt ventende. */
     val venterIngenMotpartAktivSak: Long,
-    /** Del av [venterIngenMotpart] der saken er AVSLUTTET i Melosys (skinnventende). */
+    /** Del av [venterIngenMotpart] der saken er AVSLUTTET i Melosys. */
     val venterIngenMotpartAvsluttetSak: Long
 )
 

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -167,7 +167,7 @@ data class SaksstatusUttrekkDto(
 
 data class SaksstatusUttrekkRadDto(
     val skjemaId: UUID,
-    val referanseId: String?,
+    val referanseId: String,
     val saksnummer: String?,
     val saksstatus: Saksstatus?,
     val saksstatusOppdatert: Instant?

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -101,6 +101,10 @@ data class BrukStatistikkDto(
     val innsendtPerSprak: Map<Språk, Long>,
     /** Saksdekning – om begge deler (arbeidstaker + arbeidsgiver) er dekket, regnet fra faktiske verdier. */
     val saksdekning: SaksdekningDto,
+    /** Innsendte fordelt på synket saksstatus fra melosys-api. */
+    val saksstatusFordeling: SaksstatusFordelingDto,
+    /** Søknader startet fra motpart-CTA-en («arbeidsgiveren din har sendt inn sin del»). */
+    val motpartCta: MotpartCtaStatistikkDto,
     /** Unike personer (fnr) blant innsendte skjema. */
     val antallUnikePersoner: Long,
     /** Unike virksomheter (orgnr) blant innsendte skjema. */
@@ -142,7 +146,54 @@ data class SaksdekningDto(
      * Antall saker der minst én del er sendt i flere versjoner (samme person + juridisk enhet + del
      * sendt mer enn én gang). Inkluderer versjons-erstatninger – altså saker med «mer enn to deler».
      */
-    val antallSakerMedFlereVersjoner: Long
+    val antallSakerMedFlereVersjoner: Long,
+    /**
+     * Skinnventende: deler som står som ventende hos oss (mangler innsendt motpart), men der saken
+     * er AVSLUTTET i Melosys – motpartens del kom trolig via en annen kanal. Disse skal ikke purres.
+     */
+    val antallSkinnventende: Long
+)
+
+/**
+ * Backup-uttrekk av synk-tilstanden FØR massesynk/migrering: nøyaktig feltene synken kan endre,
+ * per skjema-id. Inneholder bevisst ingen personopplysninger (ingen fnr, navn eller skjemadata) —
+ * kan lastes ned fra melosys-console og brukes til gjenoppretting eller diff.
+ */
+data class SaksstatusUttrekkDto(
+    val tidspunkt: Instant,
+    val antall: Int,
+    val rader: List<SaksstatusUttrekkRadDto>
+)
+
+data class SaksstatusUttrekkRadDto(
+    val skjemaId: UUID,
+    val referanseId: String?,
+    val saksnummer: String?,
+    val saksstatus: Saksstatus?,
+    val saksstatusOppdatert: Instant?
+)
+
+/**
+ * Innsendte fordelt på saksstatus synket fra melosys-api.
+ * [ukjent] = ikke synket ennå – skal gå mot 0 etter at massesynken er kjørt, og er dermed
+ * også et mål på synk-dekningen.
+ */
+data class SaksstatusFordelingDto(
+    val mottatt: Long,
+    val avsluttet: Long,
+    val ukjent: Long
+)
+
+/**
+ * Effektmåling for motpart-CTA-en. Utkast er nåtilstand; innsendt følger periodefilteret.
+ * Nevneren (antall ventende motpart-søknader totalt) finnes ikke her – konvertering leses
+ * indirekte mot venter-tallene i [SaksdekningDto].
+ */
+data class MotpartCtaStatistikkDto(
+    /** Påbegynte utkast startet fra CTA-en. */
+    val antallUtkastViaCta: Long,
+    /** Innsendte søknader startet fra CTA-en. */
+    val antallInnsendtViaCta: Long
 )
 
 /**
@@ -157,7 +208,15 @@ data class DelStatusDto(
     /** Mangler innsendt motpart, men motparten har påbegynt et utkast (under arbeid). */
     val venterMotpartHarUtkast: Long,
     /** Mangler motpart helt – verken innsendt eller påbegynt utkast. */
-    val venterIngenMotpart: Long
+    val venterIngenMotpart: Long,
+    /** Del av [venterMotpartHarUtkast] der saken IKKE er avsluttet i Melosys (inkl. ikke synket). */
+    val venterMotpartHarUtkastAktivSak: Long,
+    /** Del av [venterMotpartHarUtkast] der saken er AVSLUTTET i Melosys (skinnventende). */
+    val venterMotpartHarUtkastAvsluttetSak: Long,
+    /** Del av [venterIngenMotpart] der saken IKKE er avsluttet i Melosys (inkl. ikke synket) – reelt ventende. */
+    val venterIngenMotpartAktivSak: Long,
+    /** Del av [venterIngenMotpart] der saken er AVSLUTTET i Melosys (skinnventende). */
+    val venterIngenMotpartAvsluttetSak: Long
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -3,6 +3,7 @@ package no.nav.melosys.skjema.repository
 import java.time.Instant
 import java.util.UUID
 import no.nav.melosys.skjema.domain.InnsendingStatus
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.entity.Skjema
 import org.springframework.data.jpa.repository.JpaRepository
@@ -61,4 +62,25 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
             "AND s.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
     )
     fun finnAlleInnsendteMedSkjema(): List<Innsending>
+
+    /**
+     * Synk-feltene per innsendt skjema, uten å materialisere skjemaets JSONB-data —
+     * uttrekket trenger kun radene på innsending-tabellen pluss skjema-id-en (FK).
+     */
+    @Query(
+        "SELECT i.skjema.id AS skjemaId, i.referanseId AS referanseId, i.saksnummer AS saksnummer, " +
+            "i.saksstatus AS saksstatus, i.saksstatusOppdatert AS saksstatusOppdatert " +
+            "FROM Innsending i " +
+            "WHERE i.skjema.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT " +
+            "AND i.skjema.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
+    )
+    fun finnSaksstatusUttrekk(): List<SaksstatusUttrekkProjeksjon>
+}
+
+interface SaksstatusUttrekkProjeksjon {
+    val skjemaId: UUID
+    val referanseId: String
+    val saksnummer: String?
+    val saksstatus: Saksstatus?
+    val saksstatusOppdatert: Instant?
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -152,14 +152,15 @@ class AdminService(
      * Backup-uttrekk av synk-tilstanden før massesynk: feltene synken kan endre, per skjema-id.
      * Ingen personopplysninger — se [SaksstatusUttrekkDto].
      */
+    @Transactional(readOnly = true)
     fun hentSaksstatusUttrekk(): SaksstatusUttrekkDto {
-        val rader = innsendingRepository.finnAlleInnsendteMedSkjema().map { innsending ->
+        val rader = innsendingRepository.finnSaksstatusUttrekk().map { rad ->
             SaksstatusUttrekkRadDto(
-                skjemaId = innsending.skjema.id!!,
-                referanseId = innsending.referanseId,
-                saksnummer = innsending.saksnummer,
-                saksstatus = innsending.saksstatus,
-                saksstatusOppdatert = innsending.saksstatusOppdatert
+                skjemaId = rad.skjemaId,
+                referanseId = rad.referanseId,
+                saksnummer = rad.saksnummer,
+                saksstatus = rad.saksstatus,
+                saksstatusOppdatert = rad.saksstatusOppdatert
             )
         }
         return SaksstatusUttrekkDto(tidspunkt = Instant.now(), antall = rader.size, rader = rader)

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -191,7 +191,7 @@ class AdminService(
             arbeidsgiverDeler = arbeidsgiverStatus,
             antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler),
             antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(innsendt),
-            antallSkinnventende = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
+            antallVentendeMedAvsluttetSak = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
                 it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
             }
         )

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -9,6 +9,10 @@ import java.util.UUID
 import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
 import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
 import no.nav.melosys.skjema.controller.admin.DelStatusDto
+import no.nav.melosys.skjema.controller.admin.MotpartCtaStatistikkDto
+import no.nav.melosys.skjema.controller.admin.SaksstatusFordelingDto
+import no.nav.melosys.skjema.controller.admin.SaksstatusUttrekkDto
+import no.nav.melosys.skjema.controller.admin.SaksstatusUttrekkRadDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.ResendVarslerResultatDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
@@ -28,6 +32,7 @@ import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.felles.PeriodeDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerMetadata
@@ -97,11 +102,14 @@ class AdminService(
                 flyt = metadata.representasjonstype,
                 sprak = innsending.innsendtSprak,
                 periode = innsending.skjema.utsendelsePeriode(),
-                erstattet = innsending.skjema.id in erstattedeIder
+                erstattet = innsending.skjema.id in erstattedeIder,
+                saksstatus = innsending.saksstatus,
+                opprettetVia = innsending.skjema.opprettetVia
             )
         }
 
-        val utkast = adminStatistikkRepository.finnAlleUtkast().mapNotNull { skjema ->
+        val utkastSkjemaer = adminStatistikkRepository.finnAlleUtkast()
+        val utkast = utkastSkjemaer.mapNotNull { skjema ->
             val metadata = skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
             UtkastSkjema(skjema.fnr, metadata.juridiskEnhetOrgnr, metadata.skjemadel, skjema.utsendelsePeriode())
         }
@@ -125,10 +133,36 @@ class AdminService(
             innsendtPerFlyt = Representasjonstype.entries.associateWith { f -> innsendt.count { it.flyt == f }.toLong() },
             innsendtPerSprak = Språk.entries.associateWith { sp -> innsendt.count { it.sprak == sp }.toLong() },
             saksdekning = beregnSaksdekning(innsendt, utkast),
+            saksstatusFordeling = SaksstatusFordelingDto(
+                mottatt = innsendt.count { it.saksstatus == Saksstatus.MOTTATT }.toLong(),
+                avsluttet = innsendt.count { it.saksstatus == Saksstatus.AVSLUTTET }.toLong(),
+                ukjent = innsendt.count { it.saksstatus == null }.toLong()
+            ),
+            motpartCta = MotpartCtaStatistikkDto(
+                antallUtkastViaCta = utkastSkjemaer.count { it.opprettetVia == OpprettetVia.MOTPART_CTA }.toLong(),
+                antallInnsendtViaCta = innsendt.count { it.opprettetVia == OpprettetVia.MOTPART_CTA }.toLong()
+            ),
             antallUnikePersoner = innsendt.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
             antallUnikeVirksomheter = innsendt.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
             topplisteVirksomheter = beregnToppliste(innsendt)
         )
+    }
+
+    /**
+     * Backup-uttrekk av synk-tilstanden før massesynk: feltene synken kan endre, per skjema-id.
+     * Ingen personopplysninger — se [SaksstatusUttrekkDto].
+     */
+    fun hentSaksstatusUttrekk(): SaksstatusUttrekkDto {
+        val rader = innsendingRepository.finnAlleInnsendteMedSkjema().map { innsending ->
+            SaksstatusUttrekkRadDto(
+                skjemaId = innsending.skjema.id!!,
+                referanseId = innsending.referanseId,
+                saksnummer = innsending.saksnummer,
+                saksstatus = innsending.saksstatus,
+                saksstatusOppdatert = innsending.saksstatusOppdatert
+            )
+        }
+        return SaksstatusUttrekkDto(tidspunkt = Instant.now(), antall = rader.size, rader = rader)
     }
 
     private fun innenfor(tidspunkt: Instant, fra: Instant?, tilEksklusiv: Instant?): Boolean =
@@ -147,13 +181,18 @@ class AdminService(
         val utkastArbeidstakerPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
         val utkastArbeidsgiverPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
 
+        val arbeidstakerStatus = delStatus(arbeidstakerDeler, arbeidsgiverePerSak, utkastArbeidsgiverPerSak)
+        val arbeidsgiverStatus = delStatus(arbeidsgiverDeler, arbeidstakerePerSak, utkastArbeidstakerPerSak)
         return SaksdekningDto(
             antallKomplette = innsendt.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
             antallSakerMedBeggeDeler = antallSakerMedBeggeDeler(innsendt),
-            arbeidstakerDeler = delStatus(arbeidstakerDeler, arbeidsgiverePerSak, utkastArbeidsgiverPerSak),
-            arbeidsgiverDeler = delStatus(arbeidsgiverDeler, arbeidstakerePerSak, utkastArbeidstakerPerSak),
+            arbeidstakerDeler = arbeidstakerStatus,
+            arbeidsgiverDeler = arbeidsgiverStatus,
             antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler),
-            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(innsendt)
+            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(innsendt),
+            antallSkinnventende = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
+                it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
+            }
         )
     }
 
@@ -173,16 +212,34 @@ class AdminService(
     ): DelStatusDto {
         var medMotpart = 0L
         var venterMotpartHarUtkast = 0L
+        var venterMotpartHarUtkastAvsluttet = 0L
         var venterIngenMotpart = 0L
+        var venterIngenMotpartAvsluttet = 0L
         for (del in deler) {
+            val avsluttet = del.saksstatus == Saksstatus.AVSLUTTET
             when {
                 motpartSendtPerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> medMotpart++
                 // Bevisst kun person + juridisk enhet (ikke periode): se kommentar over.
-                motpartUtkastPerSak[del.sakNokkel()]?.isNotEmpty() == true -> venterMotpartHarUtkast++
-                else -> venterIngenMotpart++
+                motpartUtkastPerSak[del.sakNokkel()]?.isNotEmpty() == true -> {
+                    venterMotpartHarUtkast++
+                    if (avsluttet) venterMotpartHarUtkastAvsluttet++
+                }
+                else -> {
+                    venterIngenMotpart++
+                    if (avsluttet) venterIngenMotpartAvsluttet++
+                }
             }
         }
-        return DelStatusDto(deler.size.toLong(), medMotpart, venterMotpartHarUtkast, venterIngenMotpart)
+        return DelStatusDto(
+            totalt = deler.size.toLong(),
+            medMotpart = medMotpart,
+            venterMotpartHarUtkast = venterMotpartHarUtkast,
+            venterIngenMotpart = venterIngenMotpart,
+            venterMotpartHarUtkastAktivSak = venterMotpartHarUtkast - venterMotpartHarUtkastAvsluttet,
+            venterMotpartHarUtkastAvsluttetSak = venterMotpartHarUtkastAvsluttet,
+            venterIngenMotpartAktivSak = venterIngenMotpart - venterIngenMotpartAvsluttet,
+            venterIngenMotpartAvsluttetSak = venterIngenMotpartAvsluttet
+        )
     }
 
     /** Saker (person + juridisk enhet) der begge deler er dekket – komplett eller matchende separate deler. */
@@ -250,7 +307,9 @@ class AdminService(
         val flyt: Representasjonstype,
         val sprak: Språk,
         override val periode: PeriodeDto?,
-        val erstattet: Boolean
+        val erstattet: Boolean,
+        val saksstatus: Saksstatus?,
+        val opprettetVia: OpprettetVia?
     ) : SakDel
 
     private data class UtkastSkjema(

--- a/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/TestData.kt
@@ -28,6 +28,7 @@ import no.nav.melosys.skjema.types.utsendtarbeidstaker.DegSelvMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverMedFullmaktMetadata
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.RadgiverfirmaInfo
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.felles.SimpleOrganisasjonDto
 import no.nav.melosys.skjema.types.SkjemaType
@@ -386,6 +387,7 @@ fun skjemaMedDefaultVerdier(
     type: SkjemaType = SkjemaType.UTSENDT_ARBEIDSTAKER,
     data: no.nav.melosys.skjema.types.SkjemaData? = null,
     metadata: UtsendtArbeidstakerMetadata = utsendtArbeidstakerMetadataMedDefaultVerdier(),
+    opprettetVia: OpprettetVia? = null,
     opprettetDato: Instant = Instant.now(),
     endretDato: Instant = Instant.now(),
     opprettetAv: String = fnr,
@@ -399,6 +401,7 @@ fun skjemaMedDefaultVerdier(
         orgnr = orgnr,
         data = data,
         metadata = metadata,
+        opprettetVia = opprettetVia,
         opprettetDato = opprettetDato,
         endretDato = endretDato,
         opprettetAv = opprettetAv,

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -492,6 +492,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 .returnResult()
                 .responseBody!!
             json shouldNotContain fnr
+            json shouldNotContain innsending.innsenderFnr
             json shouldNotContain "Test Testesen"
 
             val uttrekk = adminClient.get().uri("/admin/saksstatus/uttrekk")
@@ -550,6 +551,12 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         fun `motpart-cta telles for innsendte i perioden`() {
             lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "62000000001", opprettetVia = OpprettetVia.MOTPART_CTA)
             lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "62000000002")
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL,
+                fnr = "62000000004",
+                opprettetVia = OpprettetVia.MOTPART_CTA,
+                innsendtDato = Instant.parse("2020-01-15T12:00:00Z")
+            )
             skjemaRepository.save(
                 skjemaMedDefaultVerdier(
                     fnr = "62000000003",
@@ -559,9 +566,14 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 )
             )
 
-            val cta = hentBruk().motpartCta
-            cta.antallInnsendtViaCta shouldBe 1
-            cta.antallUtkastViaCta shouldBe 1
+            val alt = hentBruk().motpartCta
+            alt.antallInnsendtViaCta shouldBe 2
+            alt.antallUtkastViaCta shouldBe 1
+
+            // Innsendt følger periodefilteret; utkast er nåtilstand og påvirkes ikke
+            val iPerioden = hentBruk(fraOgMed = "2026-01-01").motpartCta
+            iPerioden.antallInnsendtViaCta shouldBe 1
+            iPerioden.antallUtkastViaCta shouldBe 1
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -524,10 +524,10 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `venter-tall splittes paa aktiv og avsluttet sak, og skinnventende telles`() {
+        fun `venter-tall splittes paa aktiv og avsluttet sak, og ventende med avsluttet sak telles`() {
             // Venter uten motpart, aktiv sak (MOTTATT)
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000001", saksstatus = Saksstatus.MOTTATT)
-            // Venter uten motpart, avsluttet sak (skinnventende — motpart kom via annen kanal)
+            // Venter uten motpart, avsluttet sak (motpart kom via annen kanal)
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000002", saksstatus = Saksstatus.AVSLUTTET)
             // Venter uten motpart, ikke synket (regnes som aktiv)
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000003")
@@ -544,7 +544,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 venterMotpartHarUtkastAktivSak shouldBe 0
                 venterMotpartHarUtkastAvsluttetSak shouldBe 1
             }
-            s.antallSkinnventende shouldBe 2
+            s.antallVentendeMedAvsluttetSak shouldBe 2
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.every
 import io.mockk.verify
 import java.time.Instant
@@ -31,6 +32,7 @@ import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.Språk
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.felles.PeriodeDto
+import no.nav.melosys.skjema.types.utsendtarbeidstaker.OpprettetVia
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidstakersSkjemaDataDto
@@ -300,7 +302,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             sprak: Språk = Språk.NORSK_BOKMAL,
             erstatterSkjemaId: UUID? = null,
             innsendtDato: Instant = Instant.now(),
-            innsenderFnr: String = "12345678901"
+            innsenderFnr: String = "12345678901",
+            saksstatus: Saksstatus? = null,
+            opprettetVia: OpprettetVia? = null
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
                 fnr = fnr,
@@ -314,11 +318,18 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                     skjemadel = skjemadel,
                     juridiskEnhetOrgnr = juridiskEnhet,
                     erstatterSkjemaId = erstatterSkjemaId
-                )
+                ),
+                opprettetVia = opprettetVia
             )
         ).also { skjema ->
             innsendingRepository.save(
-                innsendingMedDefaultVerdier(skjema = skjema, innsendtSprak = sprak, opprettetDato = innsendtDato, innsenderFnr = innsenderFnr)
+                innsendingMedDefaultVerdier(
+                    skjema = skjema,
+                    innsendtSprak = sprak,
+                    opprettetDato = innsendtDato,
+                    innsenderFnr = innsenderFnr,
+                    saksstatus = saksstatus
+                )
             )
         }
 
@@ -463,6 +474,94 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             s.antallSakerMedBeggeDeler shouldBe 0
             s.arbeidstakerDeler.venterIngenMotpart shouldBe 1
             s.arbeidsgiverDeler.venterIngenMotpart shouldBe 1
+        }
+
+        @Test
+        fun `saksstatus-uttrekk returnerer synk-feltene uten personopplysninger`() {
+            val fnr = "63000000001"
+            val skjema = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, saksstatus = Saksstatus.MOTTATT)
+            val innsending = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            innsending.saksnummer = "MEL-123456"
+            innsendingRepository.save(innsending)
+
+            val json = adminClient.get().uri("/admin/saksstatus/uttrekk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .exchange()
+                .expectStatus().isOk
+                .expectBody(String::class.java)
+                .returnResult()
+                .responseBody!!
+            json shouldNotContain fnr
+            json shouldNotContain "Test Testesen"
+
+            val uttrekk = adminClient.get().uri("/admin/saksstatus/uttrekk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<SaksstatusUttrekkDto>()
+                .returnResult()
+                .responseBody!!
+            uttrekk.antall shouldBe 1
+            with(uttrekk.rader.single()) {
+                skjemaId shouldBe skjema.id
+                saksnummer shouldBe "MEL-123456"
+                saksstatus shouldBe Saksstatus.MOTTATT
+                referanseId shouldBe innsending.referanseId
+            }
+        }
+
+        @Test
+        fun `saksstatusfordeling teller mottatt, avsluttet og ukjent`() {
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "60000000001", saksstatus = Saksstatus.MOTTATT)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "60000000002", saksstatus = Saksstatus.AVSLUTTET)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "60000000003")
+
+            val fordeling = hentBruk().saksstatusFordeling
+            fordeling.mottatt shouldBe 1
+            fordeling.avsluttet shouldBe 1
+            fordeling.ukjent shouldBe 1
+        }
+
+        @Test
+        fun `venter-tall splittes paa aktiv og avsluttet sak, og skinnventende telles`() {
+            // Venter uten motpart, aktiv sak (MOTTATT)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000001", saksstatus = Saksstatus.MOTTATT)
+            // Venter uten motpart, avsluttet sak (skinnventende — motpart kom via annen kanal)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000002", saksstatus = Saksstatus.AVSLUTTET)
+            // Venter uten motpart, ikke synket (regnes som aktiv)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000003")
+            // Venter med motpart-utkast, avsluttet sak
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "61000000004", saksstatus = Saksstatus.AVSLUTTET)
+            lagUtkast(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "61000000004")
+
+            val s = hentBruk().saksdekning
+            with(s.arbeidsgiverDeler) {
+                venterIngenMotpart shouldBe 3
+                venterIngenMotpartAktivSak shouldBe 2
+                venterIngenMotpartAvsluttetSak shouldBe 1
+                venterMotpartHarUtkast shouldBe 1
+                venterMotpartHarUtkastAktivSak shouldBe 0
+                venterMotpartHarUtkastAvsluttetSak shouldBe 1
+            }
+            s.antallSkinnventende shouldBe 2
+        }
+
+        @Test
+        fun `motpart-cta telles for innsendte i perioden`() {
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "62000000001", opprettetVia = OpprettetVia.MOTPART_CTA)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "62000000002")
+            skjemaRepository.save(
+                skjemaMedDefaultVerdier(
+                    fnr = "62000000003",
+                    status = SkjemaStatus.UTKAST,
+                    metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(skjemadel = Skjemadel.ARBEIDSTAKERS_DEL),
+                    opprettetVia = OpprettetVia.MOTPART_CTA
+                )
+            )
+
+            val cta = hentBruk().motpartCta
+            cta.antallInnsendtViaCta shouldBe 1
+            cta.antallUtkastViaCta shouldBe 1
         }
 
         @Test


### PR DESCRIPTION
- `saksstatusFordeling` (mottatt/avsluttet/ukjent) og venter-tall splittet på aktiv/avsluttet sak (`antallVentendeMedAvsluttetSak`)
- Motpart-CTA-effekttall (`opprettetVia`-aggregat)
- `GET /admin/saksstatus/uttrekk`: backup av saksnummer/saksstatus per skjema-id uten personopplysninger, for nedlasting i console før massesynk