### PR TITLE
8157 Fjern midlertidige slett-utkast admin-endepunkter

### DIFF
--- a/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/common/SkjemaStatus.kt
+++ b/melosys-skjema-api-types/src/main/kotlin/no/nav/melosys/skjema/types/common/SkjemaStatus.kt
@@ -10,16 +10,5 @@ enum class SkjemaStatus {
     UTKAST,
 
     /** Bruker har sendt inn søknaden. Asynkron prosessering pågår eller er fullført. */
-    SENDT,
-
-    /**
-     * LEGACY/MIDLERTIDIG: gammel soft-delete-status. Skrives ikke lenger – utkast hard-slettes nå.
-     *
-     * Beholdes kun så JPA fortsatt kan mappe eksisterende rader med `status='SLETTET'` uten å kaste
-     * (EnumType.STRING) i tidsvinduet før admin-oppryddingen (POST /admin/utkast/rydd-slettede) har
-     * fysisk slettet dem i prod. Fjernes – sammen med DB-constraintet – i oppfølgings-PR-en
-     * MELOSYS-8157 etter at oppryddingen er kjørt.
-     */
-    @Deprecated("Legacy soft-delete – fjernes etter at prod er ryddet via admin-endepunktet")
-    SLETTET
+    SENDT
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -124,15 +124,4 @@ class AdminController(
         return adminService.resendVarsler()
     }
 
-    @PostMapping("/utkast/rydd-slettede")
-    @Operation(
-        summary = "MIDLERTIDIG: hard-delete av soft-deletede (SLETTET) utkast",
-        description = "Engangs GDPR-opprydding av gamle soft-deletede utkast. Sletter skjema-rader " +
-            "(cascade) og tilhørende vedlegg-blobs i bucket. Fjernes når prod er ryddet (MELOSYS-8157)."
-    )
-    @ApiResponse(responseCode = "200", description = "Opprydding utført")
-    fun ryddSletteUtkast(): RyddUtkastResultatDto {
-        log.info { "Admin: Rydder soft-deletede utkast" }
-        return adminService.ryddSletteUtkast()
-    }
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -61,19 +61,6 @@ data class ResendVarslerResultatDto(
 )
 
 /**
- * Resultat av MIDLERTIDIG opprydding av soft-deletede (SLETTET) utkast (MELOSYS-8157).
- *
- * @property antallSkjema antall skjema-rader som ble hard-slettet (cascade fjernet vedlegg/innsending)
- * @property antallVedleggSlettet antall vedlegg-blobs som ble slettet fra bucket
- * @property antallVedleggFeilet antall vedlegg-blobs som ikke lot seg slette (rad er likevel borte)
- */
-data class RyddUtkastResultatDto(
-    val antallSkjema: Int,
-    val antallVedleggSlettet: Int,
-    val antallVedleggFeilet: Int
-)
-
-/**
  * Bruksstatistikk for skjemaene – ment for overvåking av bruk via melosys-console.
  * Inneholder kun aggregerte tall, ingen personopplysninger.
  */

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/SkjemaRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/SkjemaRepository.kt
@@ -4,10 +4,8 @@ import no.nav.melosys.skjema.entity.Skjema
 import no.nav.melosys.skjema.types.SkjemaType
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Repository
@@ -19,47 +17,5 @@ interface SkjemaRepository : JpaRepository<Skjema, UUID> {
     @Query("SELECT s FROM Skjema s WHERE s.id = :id AND s.status = 'SENDT'")
     fun findByIdAndStatusSendt(id: UUID): Skjema?
 
-    /**
-     * Henter et skjema på id, men ekskluderer soft-deletede (SLETTET) rader.
-     *
-     * Brukes som standard oppslag i tjenestelaget slik at legacy SLETTET-utkast aldri eksponeres
-     * som redigerbare skjema i tidsvinduet før admin-oppryddingen har hard-slettet dem. JPQL mot
-     * status-strengen siden [SkjemaStatus.SLETTET] er deprecated legacy og ikke skal brukes i ny kode
-     * (fjernes når prod er ryddet, MELOSYS-8157).
-     */
-    @Query("SELECT s FROM Skjema s WHERE s.id = :id AND s.status != 'SLETTET'")
-    fun findAktivById(id: UUID): Skjema?
-
     fun countByStatus(status: SkjemaStatus): Long
-
-    /**
-     * Henter storage-referansene til alle vedlegg som tilhører soft-deletede (SLETTET) skjemaer.
-     *
-     * MIDLERTIDIG: brukes av admin-oppryddingen som hard-sletter gamle SLETTET-utkast. Native SQL mot
-     * status-strengen siden [SkjemaStatus.SLETTET] er deprecated legacy og ikke skal brukes i ny kode
-     * (fjernes når prod er ryddet, MELOSYS-8157).
-     */
-    @Query(
-        nativeQuery = true,
-        value = """
-        SELECT v.storage_referanse
-        FROM vedlegg v
-        JOIN skjema s ON v.skjema_id = s.id
-        WHERE s.status = 'SLETTET'
-    """
-    )
-    fun finnVedleggStorageReferanserForSletteSkjema(): List<String>
-
-    /**
-     * Hard-sletter alle soft-deletede (SLETTET) skjemaer. DB-cascade fjerner tilhørende
-     * vedlegg-/innsending-/fullmakt-rader. Returnerer antall slettede skjema-rader.
-     *
-     * MIDLERTIDIG: engangs-opprydding via admin-endepunkt. Fjernes når prod er ryddet (MELOSYS-8157).
-     * Egen kort `@Transactional` slik at selve DELETE-en kjøres isolert – kalleren holder ingen
-     * DB-transaksjon mens den gjør eksterne bucket-kall.
-     */
-    @Modifying
-    @Transactional
-    @Query(nativeQuery = true, value = "DELETE FROM skjema WHERE status = 'SLETTET'")
-    fun slettAlleSletteSkjema(): Int
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -17,14 +17,12 @@ import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.ResendVarslerResultatDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
 import no.nav.melosys.skjema.controller.admin.SaksdekningDto
-import no.nav.melosys.skjema.controller.admin.RyddUtkastResultatDto
 import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
 import no.nav.melosys.skjema.controller.admin.VirksomhetStatistikkDto
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
 import no.nav.melosys.skjema.extensions.overlapper
 import no.nav.melosys.skjema.extensions.utsendelsePeriode
-import no.nav.melosys.skjema.integrasjon.storage.VedleggStorageClient
 import no.nav.melosys.skjema.repository.AdminStatistikkRepository
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
@@ -58,8 +56,7 @@ class AdminService(
     private val skjemaRepository: SkjemaRepository,
     private val adminStatistikkRepository: AdminStatistikkRepository,
     private val innsendingService: InnsendingService,
-    private val arbeidstakerVarslingService: ArbeidstakerVarslingService,
-    private val vedleggStorageClient: VedleggStorageClient
+    private val arbeidstakerVarslingService: ArbeidstakerVarslingService
 ) {
 
     @Transactional(readOnly = true)
@@ -470,46 +467,6 @@ class AdminService(
                 agMeta.juridiskEnhetOrgnr == atMeta.juridiskEnhetOrgnr &&
                 agPeriode.overlapper(atPeriode)
         }
-    }
-
-    /**
-     * MIDLERTIDIG: hard-sletter alle gjenværende soft-deletede (SLETTET) utkast for GDPR-opprydding.
-     *
-     * Sletter både vedlegg-blobs i bucket (ingen foreldreløse filer) og selve skjema-radene
-     * (DB-cascade fjerner vedlegg-/innsending-/fullmakt-rader). Blob-sletting er best-effort:
-     * en feilet blob stopper ikke radslettingen, men telles og logges.
-     *
-     * Bevisst IKKE `@Transactional`: de eksterne bucket-kallene gjøres utenfor DB-transaksjon for å
-     * unngå lange transaksjoner / lock-holdetid ved nettverkslatens. Selve DELETE-en kjøres i sin egen
-     * korte transaksjon ([SkjemaRepository.slettAlleSletteSkjema]).
-     *
-     * Fjernes når prod er ryddet (MELOSYS-8157).
-     */
-    fun ryddSletteUtkast(): RyddUtkastResultatDto {
-        val storageReferanser = skjemaRepository.finnVedleggStorageReferanserForSletteSkjema()
-
-        var slettedeBlober = 0
-        var feiledeBlober = 0
-        storageReferanser.forEach { referanse ->
-            try {
-                vedleggStorageClient.slett(referanse)
-                slettedeBlober++
-            } catch (e: Exception) {
-                feiledeBlober++
-                log.error(e) { "Admin: Klarte ikke slette vedlegg-blob $referanse under opprydding av slettede utkast" }
-            }
-        }
-
-        val antallSkjema = skjemaRepository.slettAlleSletteSkjema()
-        log.info {
-            "Admin: Ryddet $antallSkjema soft-deletede utkast " +
-                "(vedlegg-blobs slettet=$slettedeBlober, feilet=$feiledeBlober)"
-        }
-        return RyddUtkastResultatDto(
-            antallSkjema = antallSkjema,
-            antallVedleggSlettet = slettedeBlober,
-            antallVedleggFeilet = feiledeBlober
-        )
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerService.kt
@@ -438,8 +438,8 @@ class UtsendtArbeidstakerService(
             ?: throw AccessDeniedException("Innlogget bruker har ikke tilgang til skjema")
 
     private fun findByIdOrThrow(skjemaId: UUID): Skjema =
-        skjemaRepository.findAktivById(skjemaId)
-            ?: throw NoSuchElementException("Skjema med id $skjemaId finnes ikke")
+        skjemaRepository.findById(skjemaId)
+            .orElseThrow { NoSuchElementException("Skjema med id $skjemaId finnes ikke") }
 
     fun saveUtsendingsperiodeOgLand(skjemaId: UUID, request: UtsendingsperiodeOgLandDto): UtsendtArbeidstakerSkjemaDto {
         log.info { "Saving utsendingsperiode og land info for skjema: $skjemaId" }

--- a/src/main/resources/db/migration/V20__Fjern_slettet_status.sql
+++ b/src/main/resources/db/migration/V20__Fjern_slettet_status.sql
@@ -1,0 +1,4 @@
+-- Fjern SLETTET fra skjema-status etter at admin-oppryddingen er kjørt (MELOSYS-8157).
+-- Det finnes ikke lenger soft-slettede utkast, så constrainten begrenses til aktive statuser.
+ALTER TABLE skjema DROP CONSTRAINT IF EXISTS skjema_status_check;
+ALTER TABLE skjema ADD CONSTRAINT skjema_status_check CHECK (status IN ('UTKAST', 'SENDT'));

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -21,7 +21,6 @@ import no.nav.melosys.skjema.innsendingMedDefaultVerdier
 import no.nav.melosys.skjema.kafka.BrukervarselMelding
 import no.nav.melosys.skjema.kafka.BrukervarselProducer
 import no.nav.melosys.skjema.korrektSyntetiskOrgnr
-import no.nav.melosys.skjema.integrasjon.storage.VedleggStorageClient
 import no.nav.melosys.skjema.m2mTokenWithoutAccess
 import no.nav.melosys.skjema.repository.InnsendingRepository
 import no.nav.melosys.skjema.repository.SkjemaRepository
@@ -72,9 +71,6 @@ class AdminControllerIntegrationTest : ApiTestBase() {
     private lateinit var innsendingService: InnsendingService
 
     @MockkBean(relaxed = true)
-    private lateinit var vedleggStorageClient: VedleggStorageClient
-
-    @MockkBean(relaxed = true)
     private lateinit var brukervarselProducer: BrukervarselProducer
 
     /** WebTestClient som sender gyldig admin-API-nøkkel på alle kall (jf. application-test.yml). */
@@ -84,7 +80,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
     @BeforeEach
     fun setUp() {
-        // Native delete (cascade) – rydder også gamle SLETTET-rader som seedes via SQL i denne testen.
+        // Native delete (cascade) – rydder skjema-tabellen før hver test.
         jdbcTemplate.update("DELETE FROM skjema")
     }
 
@@ -836,123 +832,4 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
     }
 
-    @Nested
-    @DisplayName("POST /admin/utkast/rydd-slettede")
-    inner class RyddSletteUtkast {
-
-        /** Seeder en SLETTET-skjemarad (med valgfritt vedlegg) direkte via SQL, jf. gammel soft-delete. */
-        private fun seedSletteSkjema(storageReferanse: String? = null): UUID {
-            val skjemaId = UUID.randomUUID()
-            jdbcTemplate.update(
-                """
-                INSERT INTO skjema (id, status, type, fnr, orgnr, metadata, opprettet_av, endret_av)
-                VALUES (?, 'SLETTET', 'UTSENDT_ARBEIDSTAKER', '01816023404', '123456789',
-                        '{"representasjonstype":"DEG_SELV"}'::jsonb, '01816023404', '01816023404')
-                """.trimIndent(),
-                skjemaId
-            )
-            if (storageReferanse != null) {
-                jdbcTemplate.update(
-                    """
-                    INSERT INTO vedlegg (id, skjema_id, filnavn, original_filnavn, filtype, filstorrelse, storage_referanse, opprettet_av)
-                    VALUES (?, ?, 'fil.pdf', 'fil.pdf', 'PDF', 123, ?, '01816023404')
-                    """.trimIndent(),
-                    UUID.randomUUID(), skjemaId, storageReferanse
-                )
-            }
-            return skjemaId
-        }
-
-        private fun antallSkjemaIDb(): Int =
-            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM skjema", Int::class.java)!!
-
-        private fun antallVedleggIDb(): Int =
-            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM vedlegg", Int::class.java)!!
-
-        @Test
-        fun `skal hard-slette SLETTET-skjema, cascade vedlegg-rader og slette blobs`() {
-            seedSletteSkjema(storageReferanse = "skjemaer/a/vedlegg/b/fil.pdf")
-            seedSletteSkjema(storageReferanse = "skjemaer/c/vedlegg/d/fil.pdf")
-            seedSletteSkjema(storageReferanse = null)
-            // Et innsendt skjema som IKKE skal røres
-            skjemaRepository.save(
-                skjemaMedDefaultVerdier(status = SkjemaStatus.SENDT, data = arbeidstakersSkjemaDataDtoMedDefaultVerdier())
-            )
-
-            val body = adminClient.post().uri("/admin/utkast/rydd-slettede")
-                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk
-                .expectBody<RyddUtkastResultatDto>()
-                .returnResult().responseBody.shouldNotBeNull()
-
-            body.antallSkjema shouldBe 3
-            body.antallVedleggSlettet shouldBe 2
-            body.antallVedleggFeilet shouldBe 0
-
-            // Kun det innsendte skjemaet er igjen, alle vedlegg-rader er cascade-slettet
-            antallSkjemaIDb() shouldBe 1
-            antallVedleggIDb() shouldBe 0
-            verify(exactly = 1) { vedleggStorageClient.slett("skjemaer/a/vedlegg/b/fil.pdf") }
-            verify(exactly = 1) { vedleggStorageClient.slett("skjemaer/c/vedlegg/d/fil.pdf") }
-        }
-
-        @Test
-        fun `skal telle feilede blob-slettinger men likevel slette radene`() {
-            seedSletteSkjema(storageReferanse = "skjemaer/x/vedlegg/y/fil.pdf")
-            every { vedleggStorageClient.slett("skjemaer/x/vedlegg/y/fil.pdf") } throws RuntimeException("bucket nede")
-
-            val body = adminClient.post().uri("/admin/utkast/rydd-slettede")
-                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk
-                .expectBody<RyddUtkastResultatDto>()
-                .returnResult().responseBody.shouldNotBeNull()
-
-            body.antallSkjema shouldBe 1
-            body.antallVedleggSlettet shouldBe 0
-            body.antallVedleggFeilet shouldBe 1
-            antallSkjemaIDb() shouldBe 0
-        }
-
-        @Test
-        fun `skal returnere nuller når ingen SLETTET-utkast finnes`() {
-            val body = adminClient.post().uri("/admin/utkast/rydd-slettede")
-                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk
-                .expectBody<RyddUtkastResultatDto>()
-                .returnResult().responseBody.shouldNotBeNull()
-
-            body.antallSkjema shouldBe 0
-            body.antallVedleggSlettet shouldBe 0
-            body.antallVedleggFeilet shouldBe 0
-        }
-
-        @Test
-        fun `skal returnere 403 når azp ikke matcher tillatt klient`() {
-            adminClient.post().uri("/admin/utkast/rydd-slettede")
-                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
-                .exchange()
-                .expectStatus().isForbidden
-        }
-
-        @Test
-        fun `JPA skal kunne laste legacy SLETTET-rad uten å kaste i opprydding-vinduet`() {
-            // Regresjon: SLETTET er fjernet som aktiv status, men beholdt i enumet slik at eksisterende
-            // rader kan mappes (EnumType.STRING) før admin-oppryddingen er kjørt i prod (MELOSYS-8157).
-            // Uten dette ville findById på en gammel soft-deletet rad kaste og gi 500 i klient-kodeløp.
-            val skjemaId = skjemaRepository.save(
-                skjemaMedDefaultVerdier(status = SkjemaStatus.SLETTET)
-            ).id.shouldNotBeNull()
-
-            val skjema = skjemaRepository.findById(skjemaId)
-
-            skjema.isPresent shouldBe true
-            skjema.get().status shouldBe SkjemaStatus.SLETTET
-        }
-    }
 }

--- a/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/UtsendtArbeidstakerServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.Runs
 import io.mockk.verify
+import java.util.Optional
 import java.util.UUID
 import no.nav.melosys.skjema.etAnnetKorrektSyntetiskFnr
 import no.nav.melosys.skjema.exception.AccessDeniedException
@@ -111,7 +112,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val definisjon = SkjemaDefinisjonDto(type = "A1", versjon = "1", seksjoner = emptyMap())
 
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockInnsendingRepository.findBySkjemaId(skjemaId) } returns innsending
             every { mockSkjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, "1", Språk.NORSK_BOKMAL) } returns definisjon
 
@@ -140,7 +141,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val definisjon = SkjemaDefinisjonDto(type = "A1", versjon = "1", seksjoner = emptyMap())
 
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockInnsendingRepository.findBySkjemaId(skjemaId) } returns innsending
             every { mockSkjemaDefinisjonService.hent(SkjemaType.UTSENDT_ARBEIDSTAKER, "1", Språk.NORSK_BOKMAL) } returns definisjon
 
@@ -306,7 +307,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
 
             val result = service.hentSkjemaMedLesetilgang(skjemaId)
 
@@ -336,7 +337,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockReprService.harSkriverettigheterForMedlemskap(arbeidstakerFnr) } returns true
 
             val result = service.hentSkjemaMedLesetilgang(skjemaId)
@@ -366,7 +367,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockReprService.harSkriverettigheterForMedlemskap(arbeidstakerFnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
@@ -394,7 +395,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
             val result = service.hentSkjemaMedLesetilgang(skjemaId)
@@ -421,7 +422,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
 
             val exception = shouldThrow<AccessDeniedException> {
@@ -436,7 +437,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val skjemaId = UUID.randomUUID()
 
             every { mockSubjectHandler.getUserID() } returns currentUser
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns null
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.empty()
 
             shouldThrow<NoSuchElementException> {
                 service.hentSkjemaMedLesetilgang(skjemaId)
@@ -453,7 +454,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns alleredeSendtSkjema.fnr
-            every { mockSkjemaRepository.findAktivById(alleredeSendtSkjema.id!!) } returns alleredeSendtSkjema
+            every { mockSkjemaRepository.findById(alleredeSendtSkjema.id!!) } returns Optional.of(alleredeSendtSkjema)
 
             shouldThrow<SkjemaErIkkeRedigerbartException> {
                 service.sendInnSkjema(alleredeSendtSkjema.id!!)
@@ -481,7 +482,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("hentSkjema: tapt fullmakt + Altinn-tilgang → returnerer skjema med strippet AT-data") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(radgiverMedFullmaktSendtSkjema(skjemaId))
             every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
@@ -496,7 +497,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("hentSkjema: aktiv fullmakt → returnerer full data") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(radgiverMedFullmaktSendtSkjema(skjemaId))
             every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns true
 
             val data = service.hentSkjema(skjemaId).data as UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
@@ -507,7 +508,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("hentSkjema: tapt fullmakt + ingen Altinn-tilgang → AccessDeniedException") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(radgiverMedFullmaktSendtSkjema(skjemaId, medData = false))
             every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
 
@@ -517,7 +518,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("getSkjemaMetadata: tapt fullmakt + Altinn-tilgang → returnerer metadata") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(radgiverMedFullmaktSendtSkjema(skjemaId, medData = false))
             every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
@@ -527,7 +528,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("getSkjemaMetadata: tapt fullmakt + ingen Altinn-tilgang → AccessDeniedException") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns radgiverMedFullmaktSendtSkjema(skjemaId, medData = false)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(radgiverMedFullmaktSendtSkjema(skjemaId, medData = false))
             every { mockReprService.harLeserettigheterForMedlemskap(arbeidstakerFnr) } returns false
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns false
 
@@ -549,7 +550,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns korrektSyntetiskFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
             val data = service.hentSkjema(skjemaId).data as UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
@@ -573,7 +574,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns fullmektigFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockReprService.harSkriverettigheterForMedlemskap(arbeidstakerFnr) } returns false
 
             shouldThrow<AccessDeniedException> { service.hentSkjema(skjemaId) }
@@ -601,7 +602,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("hentSkjema: opprinnelig creator med Altinn-tilgang får tilgang til eget utkast") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns hrPersonA
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId))
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
             service.hentSkjema(skjemaId).id shouldBe skjemaId
@@ -610,7 +611,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
         test("hentSkjema: annen kollega med Altinn-tilgang får IKKE lese andres utkast") {
             val skjemaId = UUID.randomUUID()
             every { mockSubjectHandler.getUserID() } returns hrPersonB
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId)
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(arbeidsgiverUtkastStartetAv(hrPersonA, skjemaId))
             every { mockAltinnService.harBrukerTilgang(testArbeidsgiver.orgnr) } returns true
 
             shouldThrow<AccessDeniedException> { service.hentSkjema(skjemaId) }
@@ -626,7 +627,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjema.id!!) } returns skjema
+            every { mockSkjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
             every { mockSkjemaRepository.save(any()) } returns skjema
 
             service.saveVedleggValg(skjema.id!!, VedleggValgDto(harAnnenDokumentasjon = false))
@@ -642,7 +643,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             )
 
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjema.id!!) } returns skjema
+            every { mockSkjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
             every { mockSkjemaRepository.save(any()) } returns skjema
 
             service.saveVedleggValg(skjema.id!!, VedleggValgDto(harAnnenDokumentasjon = true))
@@ -656,7 +657,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val skjemaId = UUID.randomUUID()
             val skjema = skjemaMedDefaultVerdier(id = skjemaId, status = SkjemaStatus.UTKAST, fnr = korrektSyntetiskFnr)
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockSkjemaRepository.delete(skjema) } just Runs
 
             service.slettUtkast(skjemaId)
@@ -669,7 +670,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val skjemaId = UUID.randomUUID()
             val skjema = skjemaMedDefaultVerdier(id = skjemaId, status = SkjemaStatus.UTKAST, fnr = korrektSyntetiskFnr)
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
             every { mockVedleggService.slettBlobberForSkjema(skjemaId) } throws RuntimeException("blob-sletting feilet")
 
             shouldThrow<RuntimeException> { service.slettUtkast(skjemaId) }
@@ -681,7 +682,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val skjemaId = UUID.randomUUID()
             val skjema = skjemaMedDefaultVerdier(id = skjemaId, status = SkjemaStatus.SENDT, fnr = korrektSyntetiskFnr)
             every { mockSubjectHandler.getUserID() } returns skjema.fnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
 
             shouldThrow<SkjemaErIkkeRedigerbartException> { service.slettUtkast(skjemaId) }
 
@@ -693,7 +694,7 @@ class UtsendtArbeidstakerServiceTest : FunSpec({
             val skjemaId = UUID.randomUUID()
             val skjema = skjemaMedDefaultVerdier(id = skjemaId, status = SkjemaStatus.UTKAST, fnr = korrektSyntetiskFnr)
             every { mockSubjectHandler.getUserID() } returns etAnnetKorrektSyntetiskFnr
-            every { mockSkjemaRepository.findAktivById(skjemaId) } returns skjema
+            every { mockSkjemaRepository.findById(skjemaId) } returns Optional.of(skjema)
 
             shouldThrow<AccessDeniedException> { service.slettUtkast(skjemaId) }
 


### PR DESCRIPTION
Fjern midlertidige admin-endepunkter og legacy SLETTET-status etter at GDPR-oppryddingen er kjørt i test og prod.

Etter MELOSYS-8112 finnes det ikke lenger soft-slettede utkast. Denne PR-en rydder bort det midlertidige endepunktet, tilhørende tjenestelogikk, DTO-er, repository-metoder og enum-verdien, og strammer inn DB-constraintet til kun å tillate UTKAST/SENDT.
[MELOSYS-8157](https://jira.adeo.no/browse/MELOSYS-8157)

- Fjern POST /admin/utkast/rydd-slettede og tilhørende AdminService-metode
- Fjern RyddUtkastResultatDto
- Fjern SkjemaStatus.SLETTET
- Fjern midlertidige repository-metoder og erstatt findAktivById med findById
- Legg til Flyway-migrasjon V20__Fjern_slettet_status.sql
- Oppdater/fjern tester for rydd-slettede og legacy SLETTET-mapping

## Testing
- [x] Enhetstester
- [x] Integrasjonstester
- [x] Manuell testing lokalt (bygg)
- [ ] E2E-tester (ikke relevant)
