### PR TITLE
MELOSYS-8084 Dry-run på resend-varsler

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -115,13 +115,13 @@ class AdminController(
         description = "Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til arbeidstakere " +
             "som fikk et varsel med feil lenke før lenken ble fikset. Kandidatene finnes i koden: alle " +
             "handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn før " +
-            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Tar ingen parametere. " +
-            "Returnerer antall sendte varsler og saksnumrene som faktisk fikk et nytt varsel."
+            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Med dryRun=true (default) " +
+            "sendes ingenting — responsen viser hvem som VILLE fått varsel. Kjør med dryRun=false for å sende."
     )
-    @ApiResponse(responseCode = "200", description = "Resending utført")
-    fun resendVarsler(): ResendVarslerResultatDto {
-        log.info { "Admin: Resend varsler til arbeidstakere som fikk varsel med feil lenke" }
-        return adminService.resendVarsler()
+    @ApiResponse(responseCode = "200", description = "Resending utført (eller opptalt ved dry-run)")
+    fun resendVarsler(@RequestParam(defaultValue = "true") dryRun: Boolean): ResendVarslerResultatDto {
+        log.info { "Admin: Resend varsler (dryRun=$dryRun) til arbeidstakere som fikk varsel med feil lenke" }
+        return adminService.resendVarsler(dryRun)
     }
 
     @PostMapping("/utkast/rydd-slettede")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -52,10 +52,12 @@ data class RetryResultatDto(
  * MELOSYS-8168 (midlertidig): Resultat av resending. Kandidatene finnes i koden (AG-del innsendt før
  * SMS ble aktivert, som fortsatt venter på AT-del), så endepunktet trenger ingen request-body.
  *
- * [saksnumre] lister sakene som faktisk fikk et nytt varsel (for sporbarhet på fagsiden), og
- * [antallSendt] er antallet i listen. Saker som mangler saksnummer representeres med skjema-id-en sin.
+ * [saksnumre] lister sakene som fikk et nytt varsel — eller ved [dryRun] ville fått, uten at noe
+ * sendes. [antallSendt] er antallet i listen. Saker som mangler saksnummer representeres med
+ * skjema-id-en sin.
  */
 data class ResendVarslerResultatDto(
+    val dryRun: Boolean,
     val antallSendt: Int,
     val saksnumre: List<String>
 )

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -397,14 +397,14 @@ class AdminService(
      * [retryAlleFeilede]) så vi ikke holder en DB-connection åpen gjennom Kafka-sendingen. Returnerer antall
      * sendte varsler og saksnumrene som faktisk fikk et nytt varsel (for sporbarhet på fagsiden).
      */
-    fun resendVarsler(): ResendVarslerResultatDto {
+    fun resendVarsler(dryRun: Boolean): ResendVarslerResultatDto {
         val kandidater = finnResendKandidater()
-        log.info { "Admin: Resend – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del)" }
+        log.info { "Admin: Resend (dryRun=$dryRun) – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del)" }
 
         val sendteSaksnumre = mutableListOf<String>()
         kandidater.forEach { kandidat ->
             try {
-                if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(kandidat.skjemaId)) {
+                if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(kandidat.skjemaId, dryRun)) {
                     // Saker uten saksnummer representeres med skjema-id-en, så ingen sending blir usynlig.
                     sendteSaksnumre += kandidat.saksnummer ?: kandidat.skjemaId.toString()
                 }
@@ -412,8 +412,8 @@ class AdminService(
                 log.error(e) { "Admin: Resend feilet for skjema ${kandidat.skjemaId}" }
             }
         }
-        log.info { "Admin: Resend ferdig – ${sendteSaksnumre.size} varsler sendt" }
-        return ResendVarslerResultatDto(antallSendt = sendteSaksnumre.size, saksnumre = sendteSaksnumre)
+        log.info { "Admin: Resend ferdig (dryRun=$dryRun) – ${sendteSaksnumre.size} varsler ${if (dryRun) "ville blitt sendt" else "sendt"}" }
+        return ResendVarslerResultatDto(dryRun = dryRun, antallSendt = sendteSaksnumre.size, saksnumre = sendteSaksnumre)
     }
 
     /** Finner resend-kandidatene med skjema-id og saksnummer (se [resendVarsler] for kriteriene). */

--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -96,9 +96,11 @@ class ArbeidstakerVarslingService(
      * Bypasser [no.nav.melosys.skjema.entity.Innsending.brukervarselSendt]-sjekken (resend er eksplisitt)
      * og endrer ikke det feltet, men beholder utkast-guarden slik at de som har påbegynt sin del ikke purres.
      *
-     * @return true hvis varsel ble sendt på nytt, false hvis caset ble hoppet over.
+     * Med [dryRun] evalueres alle kriteriene uten at noe sendes — for trygg opptelling på forhånd.
+     *
+     * @return true hvis varsel ble sendt på nytt (eller ville blitt sendt ved dry-run), false ellers.
      */
-    fun resendVarselTilArbeidstaker(skjemaId: UUID): Boolean {
+    fun resendVarselTilArbeidstaker(skjemaId: UUID, dryRun: Boolean = false): Boolean {
         val skjema = skjemaRepository.findById(skjemaId).orElse(null)
         if (skjema == null) {
             log.warn { "Resend: fant ikke skjema $skjemaId, hopper over" }
@@ -117,7 +119,7 @@ class ArbeidstakerVarslingService(
         }
 
         return when (metadata) {
-            is ArbeidsgiverMetadata, is RadgiverMetadata -> resendUtenFullmakt(skjema.fnr, skjema.orgnr, metadata)
+            is ArbeidsgiverMetadata, is RadgiverMetadata -> resendUtenFullmakt(skjema.fnr, skjema.orgnr, metadata, dryRun)
             else -> {
                 log.info { "Resend: ${metadata.representasjonstype} (skjema $skjemaId) er ikke handlingspliktig, hopper over" }
                 false
@@ -125,10 +127,14 @@ class ArbeidstakerVarslingService(
         }
     }
 
-    private fun resendUtenFullmakt(fnr: String, orgnr: String, metadata: UtsendtArbeidstakerMetadata): Boolean {
+    private fun resendUtenFullmakt(fnr: String, orgnr: String, metadata: UtsendtArbeidstakerMetadata, dryRun: Boolean): Boolean {
         if (harEksisterendeArbeidstakerUtkast(fnr, metadata.juridiskEnhetOrgnr)) {
             log.info { "Resend: arbeidstaker har eksisterende utkast, sender ikke varsel" }
             return false
+        }
+
+        if (dryRun) {
+            return true
         }
 
         val navn = arbeidsgiverVisningsnavnForResend(metadata, orgnr)

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -684,14 +684,47 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
             lagInnsendtDel(Skjemadel.ARBEIDSTAKERS_DEL, Representasjonstype.DEG_SELV, fnr, periode, foerCutoff, juridiskEnhet)
 
-        private fun resend(): ResendVarslerResultatDto =
-            adminClient.post().uri("/admin/varsler/resend")
+        private fun resend(dryRun: Boolean = false): ResendVarslerResultatDto =
+            adminClient.post().uri("/admin/varsler/resend?dryRun=$dryRun")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk
                 .expectBody<ResendVarslerResultatDto>()
                 .returnResult().responseBody.shouldNotBeNull()
+
+        @Test
+        fun `dry-run teller kandidatene uten aa sende noe, og er default`() {
+            lagAgDel(fnr = "10000000030", saksnummer = "SAK-DRY")
+            // Utkast-guarden skal telle med i dry-run også: denne ville ikke fått varsel
+            lagAgDel(fnr = "10000000031", saksnummer = "SAK-UTKAST")
+            skjemaRepository.save(
+                skjemaMedDefaultVerdier(
+                    fnr = "10000000031",
+                    status = SkjemaStatus.UTKAST,
+                    metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                        representasjonstype = Representasjonstype.DEG_SELV,
+                        skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                    )
+                )
+            )
+
+            val eksplisitt = resend(dryRun = true)
+            eksplisitt.dryRun shouldBe true
+            eksplisitt.antallSendt shouldBe 1
+            eksplisitt.saksnumre shouldBe listOf("SAK-DRY")
+
+            val defaultKall = adminClient.post().uri("/admin/varsler/resend")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<ResendVarslerResultatDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+            defaultKall.dryRun shouldBe true
+
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
 
         @Test
         fun `skal sende varsel med korrekt lenke og ignorer-tekst for handlingspliktig AG-del foer cutoff som venter paa AT-del`() {


### PR DESCRIPTION
`POST /admin/varsler/resend?dryRun=true` (default) teller opp og lister hvem som VILLE fått varsel — inkludert utkast-guarden — uten å sende noe. `dryRun=false` sender som før. Responsen har fått `dryRun`-felt.