### PR TITLE
MELOSYS-8084 Bruksstatistikk v2: kohort-semantikk, håndregnbare kontrollsummer, initiativ og saksnumre per virksomhet

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -68,6 +68,25 @@ class AdminController(
         return adminService.hentBruksstatistikk(fraOgMed, tilOgMed)
     }
 
+    @GetMapping("/statistikk/bruk/virksomheter/{rang}/saksnumre")
+    @Operation(
+        summary = "Hent saksnumrene bak én rad i virksomhets-topplisten",
+        description = "Slår opp virksomheten på plass {rang} (1-basert) i topplisten fra " +
+            "/admin/statistikk/bruk – samme gruppering (juridisk enhet), sortering og periodefilter – " +
+            "og returnerer saksnumrene til innsendingene dens. Innsendinger uten saksnummer " +
+            "representeres med skjema-id. Svaret inneholder bevisst ingen orgnr, navn eller fnr."
+    )
+    @ApiResponse(responseCode = "200", description = "Saksnumre hentet")
+    @ApiResponse(responseCode = "404", description = "Ingen virksomhet på oppgitt rang i perioden")
+    fun hentVirksomhetSaksnumre(
+        @PathVariable rang: Int,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) fraOgMed: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) tilOgMed: LocalDate?
+    ): VirksomhetSaksnumreDto {
+        log.info { "Admin: Henter saksnumre for toppliste-virksomhet rang=$rang (fraOgMed=$fraOgMed, tilOgMed=$tilOgMed)" }
+        return adminService.hentVirksomhetSaksnumre(rang, fraOgMed, tilOgMed)
+    }
+
     @GetMapping("/innsendinger/feilede")
     @Operation(summary = "List innsendinger som har feilet Kafka-sending (KAFKA_FEILET)")
     @ApiResponse(responseCode = "200", description = "Feilede innsendinger hentet")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -109,12 +109,26 @@ data class BrukStatistikkDto(
     val motpartCta: MotpartCtaStatistikkDto,
     /** Unike personer (fnr) blant innsendte skjema. */
     val antallUnikePersoner: Long,
-    /** Unike virksomheter (orgnr) blant innsendte skjema. */
+    /**
+     * Unike virksomheter blant innsendte skjema, talt på skjemaets orgnr – altså UNDERENHETER, der
+     * flere underenheter av samme juridiske enhet telles hver for seg. Erstattede versjoner er med.
+     */
     val antallUnikeVirksomheter: Long,
+    /**
+     * Unike juridiske enheter blant innsendte skjema – samme grunnlag som [antallUnikeVirksomheter]
+     * (inkl. erstattede versjoner), men talt på juridisk enhet. Er alltid ≤ [antallUnikeVirksomheter],
+     * og er nøkkelen [topplisteVirksomheter] grupperer på.
+     */
+    val antallUnikeJuridiskeEnheter: Long = 0,
     /**
      * Anonym toppliste over de mest aktive virksomhetene (juridiske enheter), sortert synkende på
      * antall innsendinger. Inneholder bevisst kun tall (rang 1, 2, 3 ...), ikke orgnr eller navn.
      * Saksnumrene bak en rad kan hentes via `/admin/statistikk/bruk/virksomheter/{rang}/saksnumre`.
+     *
+     * NB – annet grunnlag enn tallene over: topplisten grupperer på JURIDISK ENHET (underenheter slås
+     * sammen) og teller kun GJELDENDE innsendinger (erstattede versjoner er holdt utenfor). Antall rader
+     * kan derfor avvike fra både [antallUnikeVirksomheter] og [antallUnikeJuridiskeEnheter], og summen
+     * av `antallInnsendinger` fra [totaltInnsendt].
      */
     val topplisteVirksomheter: List<VirksomhetStatistikkDto>
 )
@@ -136,9 +150,19 @@ data class SaksdekningDto(
     /** Gjeldende skjema sendt som ett samlet skjema (begge deler i én innsending). */
     val antallKomplette: Long,
     /**
-     * Antall unike saker (person + juridisk enhet) der begge deler er dekket – enten via et komplett
-     * skjema, eller via en separat arbeidstaker-del og arbeidsgiver-del som matcher (overlappende
-     * periode). Samme sak telles kun én gang selv om den har både komplett skjema og separate deler.
+     * Komplette skjema i perioden som er erstattet av en nyere versjon. Holdt utenfor [antallKomplette],
+     * men tatt med her slik at tallene kan avstemmes mot fordelingen:
+     * `innsendtPerSkjemadel[ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] = antallKomplette + antallErstattedeKomplette`.
+     */
+    val antallErstattedeKomplette: Long = 0,
+    /**
+     * Antall unike saker der begge deler er dekket – enten via et komplett skjema, eller via en separat
+     * arbeidstaker-del og arbeidsgiver-del som matcher (overlappende periode). Samme sak telles kun én
+     * gang selv om den har både komplett skjema og separate deler.
+     *
+     * NB – «sak» er her PERSON + JURIDISK ENHET, uansett periode. Er saken først dekket, telles den som
+     * dekket for alle periodene til den personen i den enheten. Se [antallSakerMedKomplett] for hva det
+     * betyr mot del-nivå-tallene.
      *
      * Dekomponeres av [antallSakerMedKomplett], [antallSakerMedMatchendeSeparateDeler] og
      * [antallSakerMedBaadeKomplettOgSeparate]:
@@ -146,7 +170,14 @@ data class SaksdekningDto(
      * - antallSakerMedBaadeKomplettOgSeparate`.
      */
     val antallSakerMedBeggeDeler: Long,
-    /** Del av [antallSakerMedBeggeDeler]: saker som er dekket av et gjeldende komplett skjema. */
+    /**
+     * Del av [antallSakerMedBeggeDeler]: saker som er dekket av et gjeldende komplett skjema.
+     *
+     * Nøkkelen er PERSON + JURIDISK ENHET uten periode: finnes det ett komplett skjema for personen i
+     * enheten, teller saken som dekket uavhengig av om periodene overlapper. Del-nivå-tallet
+     * [DelStatusDto.dekketAvKomplettSkjema] krever derimot periodeoverlapp, så en enkelt del kan stå
+     * som ventende samtidig som saken telles her.
+     */
     val antallSakerMedKomplett: Long = 0,
     /** Del av [antallSakerMedBeggeDeler]: saker som er dekket av to matchende separate deler. */
     val antallSakerMedMatchendeSeparateDeler: Long = 0,
@@ -166,10 +197,12 @@ data class SaksdekningDto(
     /** Ett element per tilfelle i [antallMuligeDobbeltinnsendinger], med saksnummer-kontekst for oppfølging. */
     val muligeDobbeltinnsendinger: List<DobbeltinnsendingDto> = emptyList(),
     /**
-     * Antall saker der minst én deltype er sendt mer enn én gang med overlappende periode (samme
-     * person + juridisk enhet). Dekker BÅDE versjons-erstatninger og mulige dobbeltinnsendinger, og
-     * regnes over hele den innsendte populasjonen (ikke bare periodevinduet, ikke bare gjeldende
-     * deler). Versjoner med ikke-overlappende perioder telles ikke.
+     * Antall saker i perioden der minst én deltype er sendt mer enn én gang med overlappende periode
+     * (samme person + juridisk enhet). Dekker BÅDE versjons-erstatninger og mulige dobbeltinnsendinger.
+     *
+     * Som for de andre sak-tallene telles kun saker som berøres av kohorten, mens selve egenskapen
+     * «flere versjoner» måles mot HELE den innsendte populasjonen (også erstattede versjoner og
+     * versjoner sendt utenfor periodevinduet). Versjoner med ikke-overlappende perioder telles ikke.
      */
     val antallSakerMedFlereVersjoner: Long,
     /**
@@ -181,9 +214,10 @@ data class SaksdekningDto(
     /**
      * Par der arbeidsgiversiden tok initiativet: arbeidstakerens skjema ble PÅBEGYNT (utkast startet)
      * etter at arbeidsgiverens del var SENDT INN. Måles kun for saker med matchende separate deler,
-     * per unik sak (ikke per rad); ved flere versjoner brukes tidligste utkast-start og tidligste
-     * innsending på hver side. [parInitiertAvArbeidsgiver] + [parInitiertAvArbeidstaker] +
-     * [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
+     * per unik sak (ikke per rad), og kun på delene som faktisk inngår i et match – deler på samme sak
+     * som aldri matchet en motpart påvirker ikke tallet. Ved flere versjoner av en matchende del brukes
+     * tidligste utkast-start og tidligste innsending på hver side. [parInitiertAvArbeidsgiver] +
+     * [parInitiertAvArbeidstaker] + [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
      */
     val parInitiertAvArbeidsgiver: Long = 0,
     /** Par der arbeidsgiverens skjema ble påbegynt etter at arbeidstakerens del var sendt inn – se [parInitiertAvArbeidsgiver]. */
@@ -204,7 +238,8 @@ data class SaksdekningDto(
 
 /**
  * Ett tilfelle av mulig dobbeltinnsending: en gruppe gjeldende deler av samme type for samme person
- * og juridiske enhet med overlappende perioder. Inneholder bevisst ingen personopplysninger.
+ * og juridiske enhet med overlappende perioder. Inneholder bevisst ingen direkte identifikatorer
+ * (fnr/orgnr/navn); saksnumrene kan slås opp i Melosys av autorisert personell.
  */
 data class DobbeltinnsendingDto(
     /** Antall innsendinger i gruppen (alltid minst 2). */
@@ -330,7 +365,8 @@ data class VirksomhetStatistikkDto(
 
 /**
  * Saksnumrene bak én rad i topplisten, slik at en aktiv virksomhet kan følges opp i Melosys.
- * Inneholder bevisst KUN saksnumre – ingen orgnr, virksomhetsnavn eller personopplysninger.
+ * Inneholder bevisst KUN saksnumre – ingen direkte identifikatorer (fnr/orgnr/navn); saksnumrene kan
+ * slås opp i Melosys av autorisert personell.
  */
 data class VirksomhetSaksnumreDto(
     /** Plasseringen i topplisten som ble slått opp (1-basert, samme sortering som `topplisteVirksomheter`). */

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -220,9 +220,14 @@ data class SaksdekningDto(
      * per unik sak (ikke per rad), og kun på delene som faktisk inngår i et match – deler på samme sak
      * som aldri matchet en motpart påvirker ikke tallet. Har samme person + enhet flere separate
      * utsendelser (ikke-overlappende perioder), måles initiativet på den TIDLIGSTE utsendelsen som har
-     * et matchende par. Ved flere versjoner av en matchende del brukes tidligste utkast-start og
-     * tidligste innsending på hver side. [parInitiertAvArbeidsgiver] +
-     * [parInitiertAvArbeidstaker] + [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
+     * et matchende par. Valget ser kun på GJELDENDE deler, så en sak der den første utsendelsen ble
+     * korrigert sent, klassifiseres på den gjeldende tilstanden.
+     *
+     * Erstattede versjoner teller med i tidspunktene når de ligger i samme VERSJONSKJEDE som en av
+     * utsendelsens matchende deler (koblet via erstatterSkjemaId, ikke via periode) – da brukes tidligste
+     * utkast-start og tidligste innsending i kjeden på hver side, siden den tidligste versjonen sier når
+     * siden faktisk startet. [parInitiertAvArbeidsgiver] + [parInitiertAvArbeidstaker] +
+     * [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
      */
     val parInitiertAvArbeidsgiver: Long = 0,
     /** Par der arbeidsgiverens skjema ble påbegynt etter at arbeidstakerens del var sendt inn – se [parInitiertAvArbeidsgiver]. */

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -112,8 +112,9 @@ data class BrukStatistikkDto(
     /** Unike virksomheter (orgnr) blant innsendte skjema. */
     val antallUnikeVirksomheter: Long,
     /**
-     * Anonym toppliste over de mest aktive virksomhetene, sortert synkende på antall innsendinger.
-     * Inneholder bevisst kun tall (rang 1, 2, 3 ...), ikke orgnr eller navn.
+     * Anonym toppliste over de mest aktive virksomhetene (juridiske enheter), sortert synkende på
+     * antall innsendinger. Inneholder bevisst kun tall (rang 1, 2, 3 ...), ikke orgnr eller navn.
+     * Saksnumrene bak en rad kan hentes via `/admin/statistikk/bruk/virksomheter/{rang}/saksnumre`.
      */
     val topplisteVirksomheter: List<VirksomhetStatistikkDto>
 )
@@ -124,36 +125,95 @@ data class BrukStatistikkDto(
  *
  * Tallene regnes ut fra **faktiske verdier** (samme fnr + samme juridiske enhet + overlappende
  * utsendelsesperiode) — samme matching som mottak bruker for å gruppere relaterte deler.
+ *
+ * To prinsipper gjelder for alle feltene her:
+ * 1. **Kohort:** periodefilteret avgjør kun hvilke deler som TELLES (innsendingsdato i vinduet).
+ *    Egenskapene deres (motpart, komplett-dekning, erstattet, duplikat-grupper) måles alltid mot
+ *    HELE den innsendte populasjonen, så et par som er sendt i hver sin måned ikke brytes.
+ * 2. **Gjeldende deler:** rader som er erstattet av en nyere versjon holdes utenfor tellingene.
  */
 data class SaksdekningDto(
-    /** Skjema sendt som ett samlet skjema (begge deler i én innsending). */
+    /** Gjeldende skjema sendt som ett samlet skjema (begge deler i én innsending). */
     val antallKomplette: Long,
     /**
      * Antall unike saker (person + juridisk enhet) der begge deler er dekket – enten via et komplett
      * skjema, eller via en separat arbeidstaker-del og arbeidsgiver-del som matcher (overlappende
      * periode). Samme sak telles kun én gang selv om den har både komplett skjema og separate deler.
+     *
+     * Dekomponeres av [antallSakerMedKomplett], [antallSakerMedMatchendeSeparateDeler] og
+     * [antallSakerMedBaadeKomplettOgSeparate]:
+     * `antallSakerMedBeggeDeler = antallSakerMedKomplett + antallSakerMedMatchendeSeparateDeler
+     * - antallSakerMedBaadeKomplettOgSeparate`.
      */
     val antallSakerMedBeggeDeler: Long,
-    /** Status for separate arbeidstaker-deler (med motpart / venter). */
+    /** Del av [antallSakerMedBeggeDeler]: saker som er dekket av et gjeldende komplett skjema. */
+    val antallSakerMedKomplett: Long = 0,
+    /** Del av [antallSakerMedBeggeDeler]: saker som er dekket av to matchende separate deler. */
+    val antallSakerMedMatchendeSeparateDeler: Long = 0,
+    /** Overlappet mellom [antallSakerMedKomplett] og [antallSakerMedMatchendeSeparateDeler] – saker som har begge. */
+    val antallSakerMedBaadeKomplettOgSeparate: Long = 0,
+    /** Status for separate arbeidstaker-deler (med motpart / dekket av komplett / venter). */
     val arbeidstakerDeler: DelStatusDto,
-    /** Status for separate arbeidsgiver-deler (med motpart / venter). */
+    /** Status for separate arbeidsgiver-deler (med motpart / dekket av komplett / venter). */
     val arbeidsgiverDeler: DelStatusDto,
     /**
-     * Mulige dobbeltinnsendinger: samme person har sendt samme del for samme juridiske enhet med
-     * overlappende periode flere ganger. Versjons-erstatninger (erstatterSkjemaId) er holdt utenfor,
-     * så dette er ekte mulige duplikater – ikke nye versjoner av samme søknad.
+     * Antall TILFELLER (grupper) av mulig dobbeltinnsending – ikke antall rader. Ett tilfelle er to
+     * eller flere gjeldende deler av samme type for samme person + juridiske enhet med overlappende
+     * periode. Versjons-erstatninger (erstatterSkjemaId) er holdt utenfor, så dette er ekte mulige
+     * duplikater – ikke nye versjoner av samme søknad. Lik `muligeDobbeltinnsendinger.size`.
      */
     val antallMuligeDobbeltinnsendinger: Long,
+    /** Ett element per tilfelle i [antallMuligeDobbeltinnsendinger], med saksnummer-kontekst for oppfølging. */
+    val muligeDobbeltinnsendinger: List<DobbeltinnsendingDto> = emptyList(),
     /**
-     * Antall saker der minst én del er sendt i flere versjoner (samme person + juridisk enhet + del
-     * sendt mer enn én gang). Inkluderer versjons-erstatninger – altså saker med «mer enn to deler».
+     * Antall saker der minst én deltype er sendt mer enn én gang med overlappende periode (samme
+     * person + juridisk enhet). Dekker BÅDE versjons-erstatninger og mulige dobbeltinnsendinger, og
+     * regnes over hele den innsendte populasjonen (ikke bare periodevinduet, ikke bare gjeldende
+     * deler). Versjoner med ikke-overlappende perioder telles ikke.
      */
     val antallSakerMedFlereVersjoner: Long,
     /**
      * Deler som står som ventende hos oss (mangler innsendt motpart), men der saken er AVSLUTTET
      * i Melosys – motpartens del kom trolig via en annen kanal. Disse skal ikke purres.
+     * Summen av venter-avsluttet for begge deltypene.
      */
-    val antallVentendeMedAvsluttetSak: Long
+    val antallVentendeMedAvsluttetSak: Long,
+    /**
+     * Par der arbeidsgiversiden tok initiativet: arbeidstakerens skjema ble PÅBEGYNT (utkast startet)
+     * etter at arbeidsgiverens del var SENDT INN. Måles kun for saker med matchende separate deler,
+     * per unik sak (ikke per rad); ved flere versjoner brukes tidligste utkast-start og tidligste
+     * innsending på hver side. [parInitiertAvArbeidsgiver] + [parInitiertAvArbeidstaker] +
+     * [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
+     */
+    val parInitiertAvArbeidsgiver: Long = 0,
+    /** Par der arbeidsgiverens skjema ble påbegynt etter at arbeidstakerens del var sendt inn – se [parInitiertAvArbeidsgiver]. */
+    val parInitiertAvArbeidstaker: Long = 0,
+    /** Par der begge sider startet utkastet sitt før noen av delene var sendt inn – ingen av dem utløste den andre. */
+    val parUavhengigStartet: Long = 0,
+    /**
+     * Gjeldende komplette skjema fordelt på representasjonstype – skiller arbeidsgiver med fullmakt
+     * fra rådgiver med fullmakt. Summerer til [antallKomplette].
+     */
+    val komplettPerFlyt: Map<Representasjonstype, Long> = emptyMap(),
+    /**
+     * Gjeldende separate deler uten utfylt utsendelsesperiode. Disse kan aldri matche en motpart og
+     * havner alltid i venter-kategoriene – et datakvalitetsmål, ikke et reelt etterslep.
+     */
+    val antallDelerUtenPeriode: Long = 0
+)
+
+/**
+ * Ett tilfelle av mulig dobbeltinnsending: en gruppe gjeldende deler av samme type for samme person
+ * og juridiske enhet med overlappende perioder. Inneholder bevisst ingen personopplysninger.
+ */
+data class DobbeltinnsendingDto(
+    /** Antall innsendinger i gruppen (alltid minst 2). */
+    val antallInnsendinger: Int,
+    /**
+     * Saksnumrene til innsendingene i gruppen, slik at tilfellet kan slås opp i Melosys.
+     * Innsendinger uten saksnummer representeres med skjema-id-en sin.
+     */
+    val saksnumre: List<String>
 )
 
 /**
@@ -199,17 +259,41 @@ data class MotpartCtaStatistikkDto(
 )
 
 /**
- * Status for en deltype (arbeidstaker- eller arbeidsgiver-deler) som er sendt hver for seg. Viser om
- * delen har en matchende motpart, og for de som venter: om motparten har påbegynt et utkast eller ikke.
+ * Status for en deltype (arbeidstaker- eller arbeidsgiver-deler) som er sendt hver for seg.
+ *
+ * Kategoriene [medMotpart], [dekketAvKomplettSkjema], [venterMotpartHarUtkast] og
+ * [venterIngenMotpart] er gjensidig utelukkende og prioriteres i den rekkefølgen:
+ * `totalt = medMotpart + dekketAvKomplettSkjema + venterMotpartHarUtkast + venterIngenMotpart`.
+ *
+ * Kontrollsum mot fordelingen: `innsendtPerSkjemadel[del] = totalt + antallErstattedeVersjoner`.
  */
 data class DelStatusDto(
-    /** Totalt antall separate deler av denne typen. */
+    /** Antall GJELDENDE (ikke erstattede) separate deler av denne typen. */
     val totalt: Long,
-    /** Har en matchende, innsendt motpart (samme person + juridisk enhet + overlappende periode). */
+    /**
+     * Deler av denne typen i perioden som er erstattet av en nyere versjon. Holdt utenfor [totalt]
+     * og alle kategoriene, men tatt med her slik at tallene kan avstemmes mot `innsendtPerSkjemadel`.
+     */
+    val antallErstattedeVersjoner: Long = 0,
+    /** Har en matchende, innsendt motpartsdel (samme person + juridisk enhet + overlappende periode). */
     val medMotpart: Long,
-    /** Mangler innsendt motpart, men motparten har påbegynt et utkast (under arbeid). */
+    /** Del av [medMotpart] der saken IKKE er avsluttet i Melosys (inkl. ikke synket). */
+    val medMotpartAktivSak: Long = 0,
+    /** Del av [medMotpart] der saken er AVSLUTTET i Melosys. */
+    val medMotpartAvsluttetSak: Long = 0,
+    /**
+     * Har ingen separat motpartsdel, men saken er likevel dekket av et komplett skjema (begge deler i
+     * én innsending) for samme person + juridiske enhet med overlappende periode. Disse venter ikke
+     * på noe, selv om delen isolert sett mangler en motpart.
+     */
+    val dekketAvKomplettSkjema: Long = 0,
+    /** Del av [dekketAvKomplettSkjema] der saken IKKE er avsluttet i Melosys (inkl. ikke synket). */
+    val dekketAvKomplettSkjemaAktivSak: Long = 0,
+    /** Del av [dekketAvKomplettSkjema] der saken er AVSLUTTET i Melosys. */
+    val dekketAvKomplettSkjemaAvsluttetSak: Long = 0,
+    /** Udekket, men motparten har påbegynt et utkast (under arbeid). */
     val venterMotpartHarUtkast: Long,
-    /** Mangler motpart helt – verken innsendt eller påbegynt utkast. */
+    /** Udekket, og motparten har ikke startet noe – verken innsendt del eller påbegynt utkast. */
     val venterIngenMotpart: Long,
     /** Del av [venterMotpartHarUtkast] der saken IKKE er avsluttet i Melosys (inkl. ikke synket). */
     val venterMotpartHarUtkastAktivSak: Long,
@@ -222,8 +306,10 @@ data class DelStatusDto(
 )
 
 /**
- * Anonym statistikk for én virksomhet i topplisten – kun tall, ingen orgnr eller navn. Brukerne
- * (innsendere) kan være flere personer som jobber for samme virksomhet.
+ * Anonym statistikk for én virksomhet i topplisten – kun tall, ingen orgnr eller navn. Virksomheten
+ * er den JURIDISKE ENHETEN (samme nøkkel som saksdekningen bruker), så underenheter er slått sammen.
+ * Brukerne (innsendere) kan være flere personer som jobber for samme virksomhet.
+ * Tallene dekker virksomhetens gjeldende innsendinger i perioden.
  */
 data class VirksomhetStatistikkDto(
     val antallInnsendinger: Long,
@@ -233,7 +319,29 @@ data class VirksomhetStatistikkDto(
     val antallArbeidsgiverDel: Long,
     val antallKomplett: Long,
     /** Saker (person + juridisk enhet) i virksomheten der begge deler er dekket. */
-    val antallSakerMedBeggeDeler: Long
+    val antallSakerMedBeggeDeler: Long,
+    /** Virksomhetens innsendinger med saksstatus MOTTATT i Melosys. */
+    val antallMottatt: Long = 0,
+    /** Virksomhetens innsendinger med saksstatus AVSLUTTET i Melosys. */
+    val antallAvsluttet: Long = 0,
+    /** Virksomhetens innsendinger uten synket saksstatus. */
+    val antallUkjent: Long = 0
+)
+
+/**
+ * Saksnumrene bak én rad i topplisten, slik at en aktiv virksomhet kan følges opp i Melosys.
+ * Inneholder bevisst KUN saksnumre – ingen orgnr, virksomhetsnavn eller personopplysninger.
+ */
+data class VirksomhetSaksnumreDto(
+    /** Plasseringen i topplisten som ble slått opp (1-basert, samme sortering som `topplisteVirksomheter`). */
+    val rang: Int,
+    /** Antall innsendinger for virksomheten – identisk med `antallInnsendinger` på samme rad i topplisten. */
+    val antallInnsendinger: Long,
+    /**
+     * Saksnumrene til virksomhetens innsendinger i perioden. Innsendinger uten saksnummer
+     * representeres med skjema-id-en sin, så ingen innsending blir usynlig.
+     */
+    val saksnumre: List<String>
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -116,8 +116,9 @@ data class BrukStatistikkDto(
     val antallUnikeVirksomheter: Long,
     /**
      * Unike juridiske enheter blant innsendte skjema – samme grunnlag som [antallUnikeVirksomheter]
-     * (inkl. erstattede versjoner), men talt på juridisk enhet. Er alltid ≤ [antallUnikeVirksomheter],
-     * og er nøkkelen [topplisteVirksomheter] grupperer på.
+     * (inkl. erstattede versjoner), men talt på juridisk enhet. Normalt ≤ [antallUnikeVirksomheter]
+     * (kan avvike hvis en underenhet har byttet juridisk enhet i perioden, siden juridisk enhet
+     * snapshottes ved opprettelse). Dette er nøkkelen [topplisteVirksomheter] grupperer på.
      */
     val antallUnikeJuridiskeEnheter: Long = 0,
     /**
@@ -215,8 +216,10 @@ data class SaksdekningDto(
      * Par der arbeidsgiversiden tok initiativet: arbeidstakerens skjema ble PÅBEGYNT (utkast startet)
      * etter at arbeidsgiverens del var SENDT INN. Måles kun for saker med matchende separate deler,
      * per unik sak (ikke per rad), og kun på delene som faktisk inngår i et match – deler på samme sak
-     * som aldri matchet en motpart påvirker ikke tallet. Ved flere versjoner av en matchende del brukes
-     * tidligste utkast-start og tidligste innsending på hver side. [parInitiertAvArbeidsgiver] +
+     * som aldri matchet en motpart påvirker ikke tallet. Har samme person + enhet flere separate
+     * utsendelser (ikke-overlappende perioder), måles initiativet på den TIDLIGSTE utsendelsen som har
+     * et matchende par. Ved flere versjoner av en matchende del brukes tidligste utkast-start og
+     * tidligste innsending på hver side. [parInitiertAvArbeidsgiver] +
      * [parInitiertAvArbeidstaker] + [parUavhengigStartet] = [antallSakerMedMatchendeSeparateDeler].
      */
     val parInitiertAvArbeidsgiver: Long = 0,

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -118,7 +118,8 @@ data class BrukStatistikkDto(
      * Unike juridiske enheter blant innsendte skjema – samme grunnlag som [antallUnikeVirksomheter]
      * (inkl. erstattede versjoner), men talt på juridisk enhet. Normalt ≤ [antallUnikeVirksomheter]
      * (kan avvike hvis en underenhet har byttet juridisk enhet i perioden, siden juridisk enhet
-     * snapshottes ved opprettelse). Dette er nøkkelen [topplisteVirksomheter] grupperer på.
+     * snapshottes ved opprettelse). Dette er nøkkelen [topplisteVirksomheter] grupperer på, men tallet
+     * kan være høyere enn `topplisteVirksomheter.size`, som kun teller gjeldende deler.
      */
     val antallUnikeJuridiskeEnheter: Long = 0,
     /**
@@ -201,9 +202,10 @@ data class SaksdekningDto(
      * Antall saker i perioden der minst én deltype er sendt mer enn én gang med overlappende periode
      * (samme person + juridisk enhet). Dekker BÅDE versjons-erstatninger og mulige dobbeltinnsendinger.
      *
-     * Som for de andre sak-tallene telles kun saker som berøres av kohorten, mens selve egenskapen
-     * «flere versjoner» måles mot HELE den innsendte populasjonen (også erstattede versjoner og
-     * versjoner sendt utenfor periodevinduet). Versjoner med ikke-overlappende perioder telles ikke.
+     * Selve egenskapen «flere versjoner» måles mot HELE den innsendte populasjonen (også erstattede
+     * versjoner og versjoner sendt utenfor periodevinduet). I motsetning til de andre sak-tallene teller
+     * en sak også når kun den erstattede versjonen ligger i vinduet – ellers ville feltet vist 0 samtidig
+     * som `antallErstattedeVersjoner` viste 1. Versjoner med ikke-overlappende perioder telles ikke.
      */
     val antallSakerMedFlereVersjoner: Long,
     /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -150,12 +150,16 @@ class AdminService(
         )
     }
 
-    /** Alle innsendte utsendt-arbeidstaker-deler med erstattet-markering satt fra hele populasjonen. */
+    /** Alle innsendte utsendt-arbeidstaker-deler med versjonslenken satt fra hele populasjonen. */
     private fun hentInnsendtPopulasjon(): List<InnsendtSkjema> {
         val alle = innsendingRepository.finnAlleInnsendteMedSkjema()
-        val erstattedeIder: Set<UUID> = alle
-            .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
-            .toSet()
+        // Versjonslenken snus: erstattet skjema -> versjonen som erstattet det.
+        val erstattetAv: Map<UUID, UUID> = alle
+            .mapNotNull { innsending ->
+                val erstatter = (innsending.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId
+                erstatter?.let { it to innsending.skjema.id!! }
+            }
+            .toMap()
         return alle.mapNotNull { innsending ->
             val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
             InnsendtSkjema(
@@ -168,7 +172,7 @@ class AdminService(
                 flyt = metadata.representasjonstype,
                 sprak = innsending.innsendtSprak,
                 periode = innsending.skjema.utsendelsePeriode(),
-                erstattet = innsending.skjema.id in erstattedeIder,
+                erstattetAv = erstattetAv[innsending.skjema.id],
                 saksstatus = innsending.saksstatus,
                 saksnummer = innsending.saksnummer,
                 opprettetVia = innsending.skjema.opprettetVia,
@@ -365,35 +369,67 @@ class AdminService(
      * initiativet regnes på den tidligste klyngen som har et faktisk par. Dermed blandes ikke tidspunkter
      * på tvers av to ulike utsendelser for samme person + enhet. Hver sak klassifiseres kun én gang.
      *
-     * Se [initiativPar] for hvilke deler i klyngen som utgjør tidspunkt-grunnlaget.
+     * Se [initiativPar] for hvilke deler i klyngen som utgjør tidspunkt-grunnlaget, og hvordan tidligere
+     * versjoner knyttes til klyngen via versjonslenken.
      */
     private fun beregnInitiativ(saker: Set<Pair<String, String>>, populasjon: List<InnsendtSkjema>): InitiativFordeling {
         val separateDelerPerSak = populasjon
             .filter { it.skjemadel != Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
             .groupBy { it.sakNokkel() }
+        val gjeldendeVersjon = gjeldendeVersjonPerErstattetDel(populasjon)
         var arbeidsgiver = 0L
         var arbeidstaker = 0L
         var uavhengig = 0L
+        var utenPar = 0
         for (sak in saker) {
             val (gjeldende, erstattede) = separateDelerPerSak[sak].orEmpty().partition { !it.erstattet }
             // Klyngegrensene forankres i gjeldende data: en erstattet versjon med feil periode skal ikke
             // kunne lime to reelle utsendelser sammen. Erstattede deler knyttes til klyngen i [initiativPar].
             val par = overlappendeGrupper(gjeldende)
-                .mapNotNull { klynge -> initiativPar(klynge, erstattede) }
+                .mapNotNull { klynge -> initiativPar(klynge, erstattede, gjeldendeVersjon) }
                 // Tidligste utsendelse vinner; id-en bryter likhet, siden innsendingene ikke har noen annen
                 // deterministisk rekkefølge.
                 .minWithOrNull(compareBy({ it.valgtEtterInnsending }, { it.valgtEtterId }))
-                // Uoppnåelig i dag: nøkkelen er i medSeparate, altså finnes det en direkte AT↔AG-kant
-                // mellom to gjeldende deler, og de to havner alltid i samme klynge. Brytes invarianten,
-                // forsvinner saken stille ut av kontrollsummen mot antallSakerMedMatchendeSeparateDeler.
-                ?: continue
+            if (par == null) {
+                // Uoppnåelig så lenge [saker] og [populasjon] er utledet av samme datasett: nøkkelen er i
+                // medSeparate, altså finnes det en direkte AT↔AG-kant mellom to gjeldende deler, og de to
+                // havner alltid i samme klynge. Telles og logges, så saken ikke forsvinner stille ut av
+                // kontrollsummen mot antallSakerMedMatchendeSeparateDeler.
+                utenPar++
+                continue
+            }
             when {
                 par.atStartet.isAfter(par.agInnsendt) -> arbeidsgiver++
                 par.agStartet.isAfter(par.atInnsendt) -> arbeidstaker++
                 else -> uavhengig++
             }
         }
+        if (utenPar > 0) {
+            log.warn {
+                "Bruksstatistikk: $utenPar sak(er) med matchende separate deler manglet en klynge med " +
+                    "faktisk par – initiativ-tallene summerer ikke til antallSakerMedMatchendeSeparateDeler"
+            }
+        }
         return InitiativFordeling(arbeidsgiver, arbeidstaker, uavhengig)
+    }
+
+    /**
+     * Kobler hver erstattede del til den gjeldende versjonen den til slutt ble erstattet av, ved å følge
+     * versjonslenken (erstatterSkjemaId) transitivt gjennom mellomliggende versjoner. Lenken er eksakt og
+     * uavhengig av hvilke perioder versjonene er utfylt med. En sykel i lenken stopper gjennomgangen.
+     */
+    private fun gjeldendeVersjonPerErstattetDel(populasjon: List<InnsendtSkjema>): Map<UUID, UUID> {
+        val nesteVersjon = populasjon.mapNotNull { del -> del.erstattetAv?.let { del.id to it } }.toMap()
+        return nesteVersjon.keys.associateWith { erstattetId ->
+            var versjon = nesteVersjon.getValue(erstattetId)
+            val besokt = mutableSetOf(erstattetId, versjon)
+            while (true) {
+                val neste = nesteVersjon[versjon] ?: break
+                if (!besokt.add(neste)) break
+                versjon = neste
+            }
+            versjon
+        }
     }
 
     /** Tidspunktene ett par klassifiseres på, og nøkkelen paret velges på når saken har flere utsendelser. */
@@ -403,7 +439,7 @@ class AdminService(
         val atInnsendt: Instant,
         val agInnsendt: Instant,
         val valgtEtterInnsending: Instant,
-        val valgtEtterId: String
+        val valgtEtterId: UUID
     )
 
     /**
@@ -411,30 +447,36 @@ class AdminService(
      *
      * Kun deler som matcher minst én del på MOTSATT side teller: en del kan være transitivt koblet inn i
      * klyngen via en del på samme side uten selv å ha en motpart, og skal da ikke dra tidspunktene med seg.
+     *
      * [erstattede] versjoner tas med i tidspunktene (den tidligste versjonen sier når siden faktisk startet),
-     * med samme match-krav, men påvirker ikke hvilken klynge som velges.
+     * men kobles via VERSJONSLENKEN [gjeldendeVersjon] – ikke via periodeoverlapp – slik at en erstattet
+     * versjon med feil periode ikke kan forgifte tidsstemplene til en annen utsendelse. En erstattet del
+     * teller kun når versjonskjeden ender i en av klyngens matchende deler. Erstattede deler påvirker ikke
+     * hvilken klynge som velges.
      */
-    private fun initiativPar(klynge: List<InnsendtSkjema>, erstattede: List<InnsendtSkjema>): InitiativPar? {
+    private fun initiativPar(
+        klynge: List<InnsendtSkjema>,
+        erstattede: List<InnsendtSkjema>,
+        gjeldendeVersjon: Map<UUID, UUID>
+    ): InitiativPar? {
         val atIKlynge = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
         val agIKlynge = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
         val atMatchende = atIKlynge.filter { at -> agIKlynge.any { at.matcher(it) } }
         val agMatchende = agIKlynge.filter { ag -> atIKlynge.any { ag.matcher(it) } }
         if (atMatchende.isEmpty() || agMatchende.isEmpty()) return null
 
-        val atDeler = atMatchende + erstattede.filter { erstattet ->
-            erstattet.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL && agIKlynge.any { erstattet.matcher(it) }
-        }
-        val agDeler = agMatchende + erstattede.filter { erstattet ->
-            erstattet.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL && atIKlynge.any { erstattet.matcher(it) }
-        }
-        val matchendeGjeldende = atMatchende + agMatchende
+        val matchendeIder = (atMatchende + agMatchende).mapTo(mutableSetOf()) { it.id }
+        val tidligereVersjoner = erstattede.filter { gjeldendeVersjon[it.id] in matchendeIder }
+        val atDeler = atMatchende + tidligereVersjoner.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+        val agDeler = agMatchende + tidligereVersjoner.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
+        val tidligsteMatchende = (atMatchende + agMatchende).minWith(compareBy({ it.innsendtDato }, { it.id }))
         return InitiativPar(
             atStartet = atDeler.minOf { it.skjemaOpprettetDato },
             agStartet = agDeler.minOf { it.skjemaOpprettetDato },
             atInnsendt = atDeler.minOf { it.innsendtDato },
             agInnsendt = agDeler.minOf { it.innsendtDato },
-            valgtEtterInnsending = matchendeGjeldende.minOf { it.innsendtDato },
-            valgtEtterId = matchendeGjeldende.minOf { it.id.toString() }
+            valgtEtterInnsending = tidligsteMatchende.innsendtDato,
+            valgtEtterId = tidligsteMatchende.id
         )
     }
 
@@ -558,7 +600,8 @@ class AdminService(
         val flyt: Representasjonstype,
         val sprak: Språk,
         override val periode: PeriodeDto?,
-        val erstattet: Boolean,
+        /** Skjema-id-en til versjonen som erstattet denne, eller null hvis denne er gjeldende. */
+        val erstattetAv: UUID?,
         val saksstatus: Saksstatus?,
         val saksnummer: String?,
         val opprettetVia: OpprettetVia?,
@@ -566,7 +609,9 @@ class AdminService(
         val skjemaOpprettetDato: Instant,
         /** Da skjemaet ble sendt inn – styrer periodefilteret. */
         val innsendtDato: Instant
-    ) : SakDel
+    ) : SakDel {
+        val erstattet: Boolean get() = erstattetAv != null
+    }
 
     private data class UtkastSkjema(
         override val fnr: String,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -153,13 +153,7 @@ class AdminService(
     /** Alle innsendte utsendt-arbeidstaker-deler med versjonslenken satt fra hele populasjonen. */
     private fun hentInnsendtPopulasjon(): List<InnsendtSkjema> {
         val alle = innsendingRepository.finnAlleInnsendteMedSkjema()
-        // Versjonslenken snus: erstattet skjema -> versjonen som erstattet det.
-        val erstattetAv: Map<UUID, UUID> = alle
-            .mapNotNull { innsending ->
-                val erstatter = (innsending.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId
-                erstatter?.let { it to innsending.skjema.id!! }
-            }
-            .toMap()
+        val erstattetAv = snuVersjonslenken(alle)
         return alle.mapNotNull { innsending ->
             val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
             InnsendtSkjema(
@@ -180,6 +174,34 @@ class AdminService(
                 innsendtDato = innsending.opprettetDato
             )
         }
+    }
+
+    /** Én kobling i versjonslenken: skjemaet som ble erstattet, og versjonen som erstattet det. */
+    private data class Erstatterkobling(val erstattet: UUID, val erstatter: UUID, val erstatterInnsendt: Instant)
+
+    /**
+     * Snur versjonslenken til oppslaget «erstattet skjema -> versjonen som erstattet det».
+     *
+     * `erstatterSkjemaId` er ikke garantert unik, så et skjema kan ha flere erstattere. Koblingene
+     * sorteres derfor deterministisk før de slås sammen, slik at nyeste erstatter vinner og to identiske
+     * kall gir samme svar uavhengig av radenes rekkefølge fra databasen.
+     */
+    private fun snuVersjonslenken(alle: List<Innsending>): Map<UUID, UUID> {
+        val koblinger = alle.mapNotNull { innsending ->
+            (innsending.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId?.let { erstattet ->
+                Erstatterkobling(erstattet, innsending.skjema.id!!, innsending.opprettetDato)
+            }
+        }
+        val forgrenede = koblinger.groupingBy { it.erstattet }.eachCount().count { it.value > 1 }
+        if (forgrenede > 0) {
+            log.warn {
+                "Bruksstatistikk: $forgrenede skjema har mer enn én erstatter-versjon – nyeste innsending " +
+                    "brukes som gjeldende versjon i statistikken"
+            }
+        }
+        return koblinger
+            .sortedWith(compareBy({ it.erstatterInnsendt }, { it.erstatter }))
+            .associate { it.erstattet to it.erstatter }
     }
 
     private fun filtrerPaaPeriode(
@@ -416,7 +438,8 @@ class AdminService(
     /**
      * Kobler hver erstattede del til den gjeldende versjonen den til slutt ble erstattet av, ved å følge
      * versjonslenken (erstatterSkjemaId) transitivt gjennom mellomliggende versjoner. Lenken er eksakt og
-     * uavhengig av hvilke perioder versjonene er utfylt med. En sykel i lenken stopper gjennomgangen.
+     * uavhengig av hvilke perioder versjonene er utfylt med. En sykel i lenken stopper gjennomgangen, og
+     * delen ender da på en id som selv er erstattet – den faller dermed utenfor klyngens matchende deler.
      */
     private fun gjeldendeVersjonPerErstattetDel(populasjon: List<InnsendtSkjema>): Map<UUID, UUID> {
         val nesteVersjon = populasjon.mapNotNull { del -> del.erstattetAv?.let { del.id to it } }.toMap()
@@ -425,7 +448,10 @@ class AdminService(
             val besokt = mutableSetOf(erstattetId, versjon)
             while (true) {
                 val neste = nesteVersjon[versjon] ?: break
-                if (!besokt.add(neste)) break
+                if (!besokt.add(neste)) {
+                    log.warn { "Sirkulær erstatter-referanse oppdaget ved skjema $neste" }
+                    break
+                }
                 versjon = neste
             }
             versjon
@@ -451,8 +477,10 @@ class AdminService(
      * [erstattede] versjoner tas med i tidspunktene (den tidligste versjonen sier når siden faktisk startet),
      * men kobles via VERSJONSLENKEN [gjeldendeVersjon] – ikke via periodeoverlapp – slik at en erstattet
      * versjon med feil periode ikke kan forgifte tidsstemplene til en annen utsendelse. En erstattet del
-     * teller kun når versjonskjeden ender i en av klyngens matchende deler. Erstattede deler påvirker ikke
-     * hvilken klynge som velges.
+     * teller kun når versjonskjeden ender i en av klyngens matchende deler. Merk at det er ETTERFØLGEREN
+     * som må være en av klyngens matchende deler, ikke den erstattede delen selv: en gammel versjon som i
+     * sin tid matchet motparten, men som ble korrigert inn i en annen utsendelse, følger etterfølgeren sin
+     * og teller ikke her. Erstattede deler påvirker ikke hvilken klynge som velges.
      */
     private fun initiativPar(
         klynge: List<InnsendtSkjema>,

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -273,7 +273,9 @@ class AdminService(
             arbeidsgiverDeler = arbeidsgiverStatus,
             antallMuligeDobbeltinnsendinger = dobbeltinnsendinger.size.toLong(),
             muligeDobbeltinnsendinger = dobbeltinnsendinger,
-            antallSakerMedFlereVersjoner = kohortNokler.count { indeks.harFlereVersjoner(it) }.toLong(),
+            // Egen nøkkelmengde: en sak kan ha bare den erstattede versjonen i vinduet, og skal likevel telles.
+            antallSakerMedFlereVersjoner = kohort.mapTo(mutableSetOf()) { it.sakNokkel() }
+                .count { indeks.harFlereVersjoner(it) }.toLong(),
             antallVentendeMedAvsluttetSak = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
                 it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
             },
@@ -358,22 +360,30 @@ class AdminService(
      * (innsending.opprettetDato) – da fikk den siden trolig beskjed om at motparten hadde levert.
      * Startet begge sider før noen av delene var innsendt, er de uavhengige initiativ.
      *
-     * Tidspunktene måles kun over delene som faktisk inngår i et par (en del som matcher minst én del
-     * på motsatt side), slik at et ikke-matchende par på samme nøkkel ikke stjeler initiativet. Innenfor
-     * de matchende delene brukes tidligste utkast-start og tidligste innsending på hver side – erstattede
-     * versjoner teller med, siden den tidligste versjonen sier når siden faktisk startet.
+     * Tidspunktene måles innenfor ÉN utsendelse: de separate delene på nøkkelen grupperes i klynger av
+     * overlappende perioder (samme transitive lukning som duplikat-grupperingen), og initiativet regnes
+     * på den tidligste klyngen som har begge sider. Dermed blandes ikke tidspunkter på tvers av to ulike
+     * utsendelser for samme person + enhet. Innenfor klyngen brukes tidligste utkast-start og tidligste
+     * innsending på hver side – erstattede versjoner teller med, siden den tidligste versjonen sier når
+     * siden faktisk startet. Hver sak klassifiseres kun én gang.
      */
     private fun beregnInitiativ(saker: Set<Pair<String, String>>, populasjon: List<InnsendtSkjema>): InitiativFordeling {
-        val perSakOgDel = populasjon.groupBy { it.sakNokkel() to it.skjemadel }
+        val separateDelerPerSak = populasjon
+            .filter { it.skjemadel != Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+            .groupBy { it.sakNokkel() }
         var arbeidsgiver = 0L
         var arbeidstaker = 0L
         var uavhengig = 0L
         for (sak in saker) {
-            val alleAtDeler = perSakOgDel[sak to Skjemadel.ARBEIDSTAKERS_DEL].orEmpty()
-            val alleAgDeler = perSakOgDel[sak to Skjemadel.ARBEIDSGIVERS_DEL].orEmpty()
-            val atDeler = alleAtDeler.filter { at -> alleAgDeler.any { at.matcher(it) } }
-            val agDeler = alleAgDeler.filter { ag -> alleAtDeler.any { ag.matcher(it) } }
-            if (atDeler.isEmpty() || agDeler.isEmpty()) continue
+            val klynge = overlappendeGrupper(separateDelerPerSak[sak].orEmpty())
+                .filter { gruppe ->
+                    gruppe.any { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL } &&
+                        gruppe.any { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
+                }
+                .minByOrNull { gruppe -> gruppe.minOf { it.innsendtDato } }
+                ?: continue
+            val atDeler = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+            val agDeler = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
             val atStartet = atDeler.minOf { it.skjemaOpprettetDato }
             val agStartet = agDeler.minOf { it.skjemaOpprettetDato }
             val atInnsendt = atDeler.minOf { it.innsendtDato }
@@ -441,8 +451,11 @@ class AdminService(
     )
 
     /**
-     * Oppslag på hele den innsendte populasjonen, bygget av gjeldende (ikke erstattede) deler. Alle
-     * egenskaps-spørsmål i statistikken stilles hit, slik at et periodefilter aldri bryter et par.
+     * Oppslag på hele den innsendte populasjonen. Alle egenskaps-spørsmål i statistikken stilles hit,
+     * slik at et periodefilter aldri bryter et par. Indeksen har to grunnlag:
+     * - gjeldende (ikke erstattede) deler for dekning og motpart-match ([harKomplett],
+     *   [harMatchendeSeparateDeler], [dobbeltinnsendinger])
+     * - hele populasjonen, inkl. erstattede versjoner, for versjonstellingen ([harFlereVersjoner])
      */
     private inner class SaksIndeks(populasjon: List<InnsendtSkjema>) {
         private val gjeldende = populasjon.filter { !it.erstattet }

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -125,13 +125,14 @@ class AdminService(
             ),
             antallUnikePersoner = kohort.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
             antallUnikeVirksomheter = kohort.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
+            antallUnikeJuridiskeEnheter = kohort.mapTo(mutableSetOf()) { it.juridiskEnhet }.size.toLong(),
             topplisteVirksomheter = grupperVirksomheter(kohort).map { gruppe -> gruppe.tilDto(indeks) }
         )
     }
 
     /**
      * Saksnumrene bak én rad i topplisten (1-basert [rang], samme gruppering/sortering/periode som
-     * `topplisteVirksomheter`). Returnerer kun saksnumre – ingen orgnr, navn eller personopplysninger.
+     * `topplisteVirksomheter`). Returnerer kun saksnumre – ingen direkte identifikatorer (fnr/orgnr/navn).
      *
      * @throws NoSuchElementException hvis [rang] er utenfor topplisten for perioden
      */
@@ -261,6 +262,9 @@ class AdminService(
 
         return SaksdekningDto(
             antallKomplette = komplette.size.toLong(),
+            antallErstattedeKomplette = kohort.count {
+                it.erstattet && it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL
+            }.toLong(),
             antallSakerMedBeggeDeler = (medKomplett + medSeparate).size.toLong(),
             antallSakerMedKomplett = medKomplett.size.toLong(),
             antallSakerMedMatchendeSeparateDeler = medSeparate.size.toLong(),
@@ -269,7 +273,7 @@ class AdminService(
             arbeidsgiverDeler = arbeidsgiverStatus,
             antallMuligeDobbeltinnsendinger = dobbeltinnsendinger.size.toLong(),
             muligeDobbeltinnsendinger = dobbeltinnsendinger,
-            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(populasjon),
+            antallSakerMedFlereVersjoner = kohortNokler.count { indeks.harFlereVersjoner(it) }.toLong(),
             antallVentendeMedAvsluttetSak = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
                 it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
             },
@@ -354,8 +358,10 @@ class AdminService(
      * (innsending.opprettetDato) – da fikk den siden trolig beskjed om at motparten hadde levert.
      * Startet begge sider før noen av delene var innsendt, er de uavhengige initiativ.
      *
-     * Tidspunktene tas per side av paret over ALLE versjoner av den siden (tidligste utkast-start og
-     * tidligste innsending), slik at en senere korreksjon ikke endrer hvem som startet.
+     * Tidspunktene måles kun over delene som faktisk inngår i et par (en del som matcher minst én del
+     * på motsatt side), slik at et ikke-matchende par på samme nøkkel ikke stjeler initiativet. Innenfor
+     * de matchende delene brukes tidligste utkast-start og tidligste innsending på hver side – erstattede
+     * versjoner teller med, siden den tidligste versjonen sier når siden faktisk startet.
      */
     private fun beregnInitiativ(saker: Set<Pair<String, String>>, populasjon: List<InnsendtSkjema>): InitiativFordeling {
         val perSakOgDel = populasjon.groupBy { it.sakNokkel() to it.skjemadel }
@@ -363,8 +369,10 @@ class AdminService(
         var arbeidstaker = 0L
         var uavhengig = 0L
         for (sak in saker) {
-            val atDeler = perSakOgDel[sak to Skjemadel.ARBEIDSTAKERS_DEL].orEmpty()
-            val agDeler = perSakOgDel[sak to Skjemadel.ARBEIDSGIVERS_DEL].orEmpty()
+            val alleAtDeler = perSakOgDel[sak to Skjemadel.ARBEIDSTAKERS_DEL].orEmpty()
+            val alleAgDeler = perSakOgDel[sak to Skjemadel.ARBEIDSGIVERS_DEL].orEmpty()
+            val atDeler = alleAtDeler.filter { at -> alleAgDeler.any { at.matcher(it) } }
+            val agDeler = alleAgDeler.filter { ag -> alleAtDeler.any { ag.matcher(it) } }
             if (atDeler.isEmpty() || agDeler.isEmpty()) continue
             val atStartet = atDeler.minOf { it.skjemaOpprettetDato }
             val agStartet = agDeler.minOf { it.skjemaOpprettetDato }
@@ -378,14 +386,6 @@ class AdminService(
         }
         return InitiativFordeling(arbeidsgiver, arbeidstaker, uavhengig)
     }
-
-    /** Saker der minst én deltype er sendt i flere overlappende versjoner (inkl. erstatninger). */
-    private fun antallSakerMedFlereVersjoner(innsendt: List<InnsendtSkjema>): Long =
-        innsendt.groupBy { it.sakNokkel() }.count { (_, saksdeler) ->
-            saksdeler.groupBy { it.skjemadel }.values.any { sammeDel ->
-                sammeDel.any { del -> sammeDel.any { it.id != del.id && del.matcher(it) } }
-            }
-        }.toLong()
 
     /**
      * Grupperer deler som overlapper hverandre i tid til sammenhengende grupper (transitiv lukning av
@@ -446,6 +446,10 @@ class AdminService(
      */
     private inner class SaksIndeks(populasjon: List<InnsendtSkjema>) {
         private val gjeldende = populasjon.filter { !it.erstattet }
+
+        /** Alle versjoner per sak, også de erstattede – grunnlaget for [harFlereVersjoner]. */
+        private val alleDelerPerSak = populasjon.groupBy { it.sakNokkel() }
+
         val komplettePerSak = gjeldende.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
             .groupBy { it.sakNokkel() }
         val arbeidstakerePerSak = gjeldende.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
@@ -466,6 +470,15 @@ class AdminService(
         }
 
         fun erDekket(nokkel: Pair<String, String>): Boolean = harKomplett(nokkel) || harMatchendeSeparateDeler(nokkel)
+
+        /**
+         * Minst én deltype på saken er sendt i flere versjoner med overlappende periode – både
+         * erstatninger og mulige dobbeltinnsendinger. Måles over hele populasjonen, inkl. erstattede.
+         */
+        fun harFlereVersjoner(nokkel: Pair<String, String>): Boolean =
+            alleDelerPerSak[nokkel].orEmpty().groupBy { it.skjemadel }.values.any { sammeDel ->
+                sammeDel.any { del -> sammeDel.any { it.id != del.id && del.matcher(it) } }
+            }
     }
 
     private interface SakDel {

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -140,8 +140,10 @@ class AdminService(
     fun hentVirksomhetSaksnumre(rang: Int, fraOgMed: LocalDate?, tilOgMed: LocalDate?): VirksomhetSaksnumreDto {
         val kohort = filtrerPaaPeriode(hentInnsendtPopulasjon(), fraOgMed, tilOgMed)
         val virksomheter = grupperVirksomheter(kohort)
-        val gruppe = virksomheter.getOrNull(rang - 1)
-            ?: throw NoSuchElementException("Ingen virksomhet med rang $rang i topplisten (${virksomheter.size} virksomheter i perioden)")
+        if (rang < 1 || rang > virksomheter.size) {
+            throw NoSuchElementException("Ingen virksomhet med rang $rang i topplisten (${virksomheter.size} virksomheter i perioden)")
+        }
+        val gruppe = virksomheter[rang - 1]
         return VirksomhetSaksnumreDto(
             rang = rang,
             antallInnsendinger = gruppe.deler.size.toLong(),

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -360,12 +360,12 @@ class AdminService(
      * (innsending.opprettetDato) – da fikk den siden trolig beskjed om at motparten hadde levert.
      * Startet begge sider før noen av delene var innsendt, er de uavhengige initiativ.
      *
-     * Tidspunktene måles innenfor ÉN utsendelse: de separate delene på nøkkelen grupperes i klynger av
-     * overlappende perioder (samme transitive lukning som duplikat-grupperingen), og initiativet regnes
-     * på den tidligste klyngen som har begge sider. Dermed blandes ikke tidspunkter på tvers av to ulike
-     * utsendelser for samme person + enhet. Innenfor klyngen brukes tidligste utkast-start og tidligste
-     * innsending på hver side – erstattede versjoner teller med, siden den tidligste versjonen sier når
-     * siden faktisk startet. Hver sak klassifiseres kun én gang.
+     * Tidspunktene måles innenfor ÉN utsendelse: de GJELDENDE separate delene på nøkkelen grupperes i
+     * klynger av overlappende perioder (samme transitive lukning som duplikat-grupperingen), og
+     * initiativet regnes på den tidligste klyngen som har et faktisk par. Dermed blandes ikke tidspunkter
+     * på tvers av to ulike utsendelser for samme person + enhet. Hver sak klassifiseres kun én gang.
+     *
+     * Se [initiativPar] for hvilke deler i klyngen som utgjør tidspunkt-grunnlaget.
      */
     private fun beregnInitiativ(saker: Set<Pair<String, String>>, populasjon: List<InnsendtSkjema>): InitiativFordeling {
         val separateDelerPerSak = populasjon
@@ -375,26 +375,67 @@ class AdminService(
         var arbeidstaker = 0L
         var uavhengig = 0L
         for (sak in saker) {
-            val klynge = overlappendeGrupper(separateDelerPerSak[sak].orEmpty())
-                .filter { gruppe ->
-                    gruppe.any { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL } &&
-                        gruppe.any { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
-                }
-                .minByOrNull { gruppe -> gruppe.minOf { it.innsendtDato } }
+            val (gjeldende, erstattede) = separateDelerPerSak[sak].orEmpty().partition { !it.erstattet }
+            // Klyngegrensene forankres i gjeldende data: en erstattet versjon med feil periode skal ikke
+            // kunne lime to reelle utsendelser sammen. Erstattede deler knyttes til klyngen i [initiativPar].
+            val par = overlappendeGrupper(gjeldende)
+                .mapNotNull { klynge -> initiativPar(klynge, erstattede) }
+                // Tidligste utsendelse vinner; id-en bryter likhet, siden innsendingene ikke har noen annen
+                // deterministisk rekkefølge.
+                .minWithOrNull(compareBy({ it.valgtEtterInnsending }, { it.valgtEtterId }))
+                // Uoppnåelig i dag: nøkkelen er i medSeparate, altså finnes det en direkte AT↔AG-kant
+                // mellom to gjeldende deler, og de to havner alltid i samme klynge. Brytes invarianten,
+                // forsvinner saken stille ut av kontrollsummen mot antallSakerMedMatchendeSeparateDeler.
                 ?: continue
-            val atDeler = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
-            val agDeler = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
-            val atStartet = atDeler.minOf { it.skjemaOpprettetDato }
-            val agStartet = agDeler.minOf { it.skjemaOpprettetDato }
-            val atInnsendt = atDeler.minOf { it.innsendtDato }
-            val agInnsendt = agDeler.minOf { it.innsendtDato }
             when {
-                atStartet.isAfter(agInnsendt) -> arbeidsgiver++
-                agStartet.isAfter(atInnsendt) -> arbeidstaker++
+                par.atStartet.isAfter(par.agInnsendt) -> arbeidsgiver++
+                par.agStartet.isAfter(par.atInnsendt) -> arbeidstaker++
                 else -> uavhengig++
             }
         }
         return InitiativFordeling(arbeidsgiver, arbeidstaker, uavhengig)
+    }
+
+    /** Tidspunktene ett par klassifiseres på, og nøkkelen paret velges på når saken har flere utsendelser. */
+    private data class InitiativPar(
+        val atStartet: Instant,
+        val agStartet: Instant,
+        val atInnsendt: Instant,
+        val agInnsendt: Instant,
+        val valgtEtterInnsending: Instant,
+        val valgtEtterId: String
+    )
+
+    /**
+     * Tidspunkt-grunnlaget for én klynge av gjeldende deler, eller null hvis klyngen ikke har et faktisk par.
+     *
+     * Kun deler som matcher minst én del på MOTSATT side teller: en del kan være transitivt koblet inn i
+     * klyngen via en del på samme side uten selv å ha en motpart, og skal da ikke dra tidspunktene med seg.
+     * [erstattede] versjoner tas med i tidspunktene (den tidligste versjonen sier når siden faktisk startet),
+     * med samme match-krav, men påvirker ikke hvilken klynge som velges.
+     */
+    private fun initiativPar(klynge: List<InnsendtSkjema>, erstattede: List<InnsendtSkjema>): InitiativPar? {
+        val atIKlynge = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
+        val agIKlynge = klynge.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
+        val atMatchende = atIKlynge.filter { at -> agIKlynge.any { at.matcher(it) } }
+        val agMatchende = agIKlynge.filter { ag -> atIKlynge.any { ag.matcher(it) } }
+        if (atMatchende.isEmpty() || agMatchende.isEmpty()) return null
+
+        val atDeler = atMatchende + erstattede.filter { erstattet ->
+            erstattet.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL && agIKlynge.any { erstattet.matcher(it) }
+        }
+        val agDeler = agMatchende + erstattede.filter { erstattet ->
+            erstattet.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL && atIKlynge.any { erstattet.matcher(it) }
+        }
+        val matchendeGjeldende = atMatchende + agMatchende
+        return InitiativPar(
+            atStartet = atDeler.minOf { it.skjemaOpprettetDato },
+            agStartet = agDeler.minOf { it.skjemaOpprettetDato },
+            atInnsendt = atDeler.minOf { it.innsendtDato },
+            agInnsendt = agDeler.minOf { it.innsendtDato },
+            valgtEtterInnsending = matchendeGjeldende.minOf { it.innsendtDato },
+            valgtEtterId = matchendeGjeldende.minOf { it.id.toString() }
+        )
     }
 
     /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 import no.nav.melosys.skjema.controller.admin.AdminStatistikkDto
 import no.nav.melosys.skjema.controller.admin.BrukStatistikkDto
 import no.nav.melosys.skjema.controller.admin.DelStatusDto
+import no.nav.melosys.skjema.controller.admin.DobbeltinnsendingDto
 import no.nav.melosys.skjema.controller.admin.MotpartCtaStatistikkDto
 import no.nav.melosys.skjema.controller.admin.SaksstatusFordelingDto
 import no.nav.melosys.skjema.controller.admin.SaksstatusUttrekkDto
@@ -19,6 +20,7 @@ import no.nav.melosys.skjema.controller.admin.RetryResultatDto
 import no.nav.melosys.skjema.controller.admin.SaksdekningDto
 import no.nav.melosys.skjema.controller.admin.RyddUtkastResultatDto
 import no.nav.melosys.skjema.controller.admin.UtkastStatistikkDto
+import no.nav.melosys.skjema.controller.admin.VirksomhetSaksnumreDto
 import no.nav.melosys.skjema.controller.admin.VirksomhetStatistikkDto
 import no.nav.melosys.skjema.domain.InnsendingStatus
 import no.nav.melosys.skjema.entity.Innsending
@@ -76,37 +78,15 @@ class AdminService(
      * Bruksstatistikk. Innsendt-statistikken (fordelinger, saksdekning, toppliste, unike) regnes i
      * minnet fra innsendinger med skjema, filtrert på innsendingsdato [fraOgMed]–[tilOgMed] (begge
      * valgfrie; null = ingen grense). Utkast og innsendt-trend er nåtilstand og påvirkes ikke av perioden.
+     *
+     * Periodefilteret avgjør kun hvilke deler som TELLES; egenskapene deres (motpart, komplett-dekning,
+     * erstattet-markering, duplikat-grupper) måles alltid mot hele den innsendte populasjonen.
      */
     @Transactional(readOnly = true)
     fun hentBruksstatistikk(fraOgMed: LocalDate?, tilOgMed: LocalDate?): BrukStatistikkDto {
         val naa = Instant.now()
-        val fraGrense = fraOgMed?.atStartOfDay(OSLO)?.toInstant()
-        val tilGrenseEksklusiv = tilOgMed?.plusDays(1)?.atStartOfDay(OSLO)?.toInstant()
-
-        val iPeriode = innsendingRepository.finnAlleInnsendteMedSkjema()
-            .filter { innenfor(it.opprettetDato, fraGrense, tilGrenseEksklusiv) }
-        // Id-er som er erstattet av en nyere versjon innenfor perioden (holdes utenfor duplikat-tellingen).
-        val erstattedeIder: Set<UUID> = iPeriode
-            .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
-            .toSet()
-
-        val innsendt = iPeriode.mapNotNull { innsending ->
-            val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
-            InnsendtSkjema(
-                id = innsending.skjema.id!!,
-                fnr = innsending.skjema.fnr,
-                orgnr = innsending.skjema.orgnr,
-                innsenderFnr = innsending.innsenderFnr,
-                juridiskEnhet = metadata.juridiskEnhetOrgnr,
-                skjemadel = metadata.skjemadel,
-                flyt = metadata.representasjonstype,
-                sprak = innsending.innsendtSprak,
-                periode = innsending.skjema.utsendelsePeriode(),
-                erstattet = innsending.skjema.id in erstattedeIder,
-                saksstatus = innsending.saksstatus,
-                opprettetVia = innsending.skjema.opprettetVia
-            )
-        }
+        val populasjon = hentInnsendtPopulasjon()
+        val kohort = filtrerPaaPeriode(populasjon, fraOgMed, tilOgMed)
 
         val utkastSkjemaer = adminStatistikkRepository.finnAlleUtkast()
         val utkast = utkastSkjemaer.mapNotNull { skjema ->
@@ -120,32 +100,91 @@ class AdminService(
             grense30d = naa.minus(30, ChronoUnit.DAYS)
         )
 
+        val indeks = SaksIndeks(populasjon)
         return BrukStatistikkDto(
             tidspunkt = naa,
             periodeFraOgMed = fraOgMed,
             periodeTilOgMed = tilOgMed,
             utkast = hentUtkastStatistikk(naa, utkast),
-            totaltInnsendt = innsendt.size.toLong(),
+            totaltInnsendt = kohort.size.toLong(),
             innsendtSisteDoegn = trend.sisteDoegn,
             innsendtSiste7Dager = trend.siste7Dager,
             innsendtSiste30Dager = trend.siste30Dager,
-            innsendtPerSkjemadel = Skjemadel.entries.associateWith { sd -> innsendt.count { it.skjemadel == sd }.toLong() },
-            innsendtPerFlyt = Representasjonstype.entries.associateWith { f -> innsendt.count { it.flyt == f }.toLong() },
-            innsendtPerSprak = Språk.entries.associateWith { sp -> innsendt.count { it.sprak == sp }.toLong() },
-            saksdekning = beregnSaksdekning(innsendt, utkast),
+            innsendtPerSkjemadel = Skjemadel.entries.associateWith { sd -> kohort.count { it.skjemadel == sd }.toLong() },
+            innsendtPerFlyt = Representasjonstype.entries.associateWith { f -> kohort.count { it.flyt == f }.toLong() },
+            innsendtPerSprak = Språk.entries.associateWith { sp -> kohort.count { it.sprak == sp }.toLong() },
+            saksdekning = beregnSaksdekning(kohort, populasjon, indeks, utkast),
             saksstatusFordeling = SaksstatusFordelingDto(
-                mottatt = innsendt.count { it.saksstatus == Saksstatus.MOTTATT }.toLong(),
-                avsluttet = innsendt.count { it.saksstatus == Saksstatus.AVSLUTTET }.toLong(),
-                ukjent = innsendt.count { it.saksstatus == null }.toLong()
+                mottatt = kohort.count { it.saksstatus == Saksstatus.MOTTATT }.toLong(),
+                avsluttet = kohort.count { it.saksstatus == Saksstatus.AVSLUTTET }.toLong(),
+                ukjent = kohort.count { it.saksstatus == null }.toLong()
             ),
             motpartCta = MotpartCtaStatistikkDto(
                 antallUtkastViaCta = utkastSkjemaer.count { it.opprettetVia == OpprettetVia.MOTPART_CTA }.toLong(),
-                antallInnsendtViaCta = innsendt.count { it.opprettetVia == OpprettetVia.MOTPART_CTA }.toLong()
+                antallInnsendtViaCta = kohort.count { it.opprettetVia == OpprettetVia.MOTPART_CTA }.toLong()
             ),
-            antallUnikePersoner = innsendt.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
-            antallUnikeVirksomheter = innsendt.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
-            topplisteVirksomheter = beregnToppliste(innsendt)
+            antallUnikePersoner = kohort.mapTo(mutableSetOf()) { it.fnr }.size.toLong(),
+            antallUnikeVirksomheter = kohort.mapTo(mutableSetOf()) { it.orgnr }.size.toLong(),
+            topplisteVirksomheter = grupperVirksomheter(kohort).map { gruppe -> gruppe.tilDto(indeks) }
         )
+    }
+
+    /**
+     * Saksnumrene bak én rad i topplisten (1-basert [rang], samme gruppering/sortering/periode som
+     * `topplisteVirksomheter`). Returnerer kun saksnumre – ingen orgnr, navn eller personopplysninger.
+     *
+     * @throws NoSuchElementException hvis [rang] er utenfor topplisten for perioden
+     */
+    @Transactional(readOnly = true)
+    fun hentVirksomhetSaksnumre(rang: Int, fraOgMed: LocalDate?, tilOgMed: LocalDate?): VirksomhetSaksnumreDto {
+        val kohort = filtrerPaaPeriode(hentInnsendtPopulasjon(), fraOgMed, tilOgMed)
+        val virksomheter = grupperVirksomheter(kohort)
+        val gruppe = virksomheter.getOrNull(rang - 1)
+            ?: throw NoSuchElementException("Ingen virksomhet med rang $rang i topplisten (${virksomheter.size} virksomheter i perioden)")
+        return VirksomhetSaksnumreDto(
+            rang = rang,
+            antallInnsendinger = gruppe.deler.size.toLong(),
+            // Innsendinger uten saksnummer representeres med skjema-id-en, så ingen blir usynlig.
+            saksnumre = gruppe.deler.map { it.saksnummer ?: it.id.toString() }.sorted()
+        )
+    }
+
+    /** Alle innsendte utsendt-arbeidstaker-deler med erstattet-markering satt fra hele populasjonen. */
+    private fun hentInnsendtPopulasjon(): List<InnsendtSkjema> {
+        val alle = innsendingRepository.finnAlleInnsendteMedSkjema()
+        val erstattedeIder: Set<UUID> = alle
+            .mapNotNull { (it.skjema.metadata as? UtsendtArbeidstakerMetadata)?.erstatterSkjemaId }
+            .toSet()
+        return alle.mapNotNull { innsending ->
+            val metadata = innsending.skjema.metadata as? UtsendtArbeidstakerMetadata ?: return@mapNotNull null
+            InnsendtSkjema(
+                id = innsending.skjema.id!!,
+                fnr = innsending.skjema.fnr,
+                orgnr = innsending.skjema.orgnr,
+                innsenderFnr = innsending.innsenderFnr,
+                juridiskEnhet = metadata.juridiskEnhetOrgnr,
+                skjemadel = metadata.skjemadel,
+                flyt = metadata.representasjonstype,
+                sprak = innsending.innsendtSprak,
+                periode = innsending.skjema.utsendelsePeriode(),
+                erstattet = innsending.skjema.id in erstattedeIder,
+                saksstatus = innsending.saksstatus,
+                saksnummer = innsending.saksnummer,
+                opprettetVia = innsending.skjema.opprettetVia,
+                skjemaOpprettetDato = innsending.skjema.opprettetDato,
+                innsendtDato = innsending.opprettetDato
+            )
+        }
+    }
+
+    private fun filtrerPaaPeriode(
+        populasjon: List<InnsendtSkjema>,
+        fraOgMed: LocalDate?,
+        tilOgMed: LocalDate?
+    ): List<InnsendtSkjema> {
+        val fraGrense = fraOgMed?.atStartOfDay(OSLO)?.toInstant()
+        val tilGrenseEksklusiv = tilOgMed?.plusDays(1)?.atStartOfDay(OSLO)?.toInstant()
+        return populasjon.filter { innenfor(it.innsendtDato, fraGrense, tilGrenseEksklusiv) }
     }
 
     /**
@@ -173,53 +212,111 @@ class AdminService(
      * Beregner saksdekning ut fra faktiske verdier: to deler hører til samme sak når de har samme
      * fnr + samme juridiske enhet + overlappende utsendelsesperiode — samme matching som mottak
      * bruker for å gruppere relaterte deler. For ventende deler ses det også mot påbegynte utkast.
+     *
+     * [kohort] er delene som telles (innenfor periodefilteret), [populasjon] er alle innsendte deler
+     * og avgjør egenskapene deres via [indeks]. Erstattede versjoner holdes utenfor tellingene.
      */
-    private fun beregnSaksdekning(innsendt: List<InnsendtSkjema>, utkast: List<UtkastSkjema>): SaksdekningDto {
-        val arbeidstakerDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }
-        val arbeidsgiverDeler = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }
-        val arbeidstakerePerSak = arbeidstakerDeler.groupBy { it.sakNokkel() }
-        val arbeidsgiverePerSak = arbeidsgiverDeler.groupBy { it.sakNokkel() }
+    private fun beregnSaksdekning(
+        kohort: List<InnsendtSkjema>,
+        populasjon: List<InnsendtSkjema>,
+        indeks: SaksIndeks,
+        utkast: List<UtkastSkjema>
+    ): SaksdekningDto {
         val utkastArbeidstakerPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
         val utkastArbeidsgiverPerSak = utkast.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
 
-        val arbeidstakerStatus = delStatus(arbeidstakerDeler, arbeidsgiverePerSak, utkastArbeidsgiverPerSak)
-        val arbeidsgiverStatus = delStatus(arbeidsgiverDeler, arbeidstakerePerSak, utkastArbeidstakerPerSak)
+        val arbeidstakerStatus = delStatus(
+            kohort.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL },
+            indeks.arbeidsgiverePerSak,
+            indeks,
+            utkastArbeidsgiverPerSak
+        )
+        val arbeidsgiverStatus = delStatus(
+            kohort.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL },
+            indeks.arbeidstakerePerSak,
+            indeks,
+            utkastArbeidstakerPerSak
+        )
+
+        val gjeldendeKohort = kohort.filter { !it.erstattet }
+        val komplette = gjeldendeKohort.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+        val separateKohort = gjeldendeKohort.filter { it.skjemadel != Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+
+        val kohortNokler = gjeldendeKohort.mapTo(mutableSetOf()) { it.sakNokkel() }
+        val medKomplett = kohortNokler.filterTo(mutableSetOf()) { indeks.harKomplett(it) }
+        val medSeparate = kohortNokler.filterTo(mutableSetOf()) { indeks.harMatchendeSeparateDeler(it) }
+        val initiativ = beregnInitiativ(medSeparate, populasjon)
+
+        // Gruppene bygges over hele populasjonen, men telles kun når de berører kohorten.
+        val kohortIder = gjeldendeKohort.mapTo(mutableSetOf()) { it.id }
+        val dobbeltinnsendinger = indeks.dobbeltinnsendinger
+            .filter { gruppe -> gruppe.any { it.id in kohortIder } }
+            .map { gruppe ->
+                DobbeltinnsendingDto(
+                    antallInnsendinger = gruppe.size,
+                    saksnumre = gruppe.map { it.saksnummer ?: it.id.toString() }.sorted()
+                )
+            }
+            .sortedWith(compareByDescending<DobbeltinnsendingDto> { it.antallInnsendinger }.thenBy { it.saksnumre.first() })
+
         return SaksdekningDto(
-            antallKomplette = innsendt.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
-            antallSakerMedBeggeDeler = antallSakerMedBeggeDeler(innsendt),
+            antallKomplette = komplette.size.toLong(),
+            antallSakerMedBeggeDeler = (medKomplett + medSeparate).size.toLong(),
+            antallSakerMedKomplett = medKomplett.size.toLong(),
+            antallSakerMedMatchendeSeparateDeler = medSeparate.size.toLong(),
+            antallSakerMedBaadeKomplettOgSeparate = medKomplett.intersect(medSeparate).size.toLong(),
             arbeidstakerDeler = arbeidstakerStatus,
             arbeidsgiverDeler = arbeidsgiverStatus,
-            antallMuligeDobbeltinnsendinger = antallDuplikater(arbeidstakerDeler) + antallDuplikater(arbeidsgiverDeler),
-            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(innsendt),
+            antallMuligeDobbeltinnsendinger = dobbeltinnsendinger.size.toLong(),
+            muligeDobbeltinnsendinger = dobbeltinnsendinger,
+            antallSakerMedFlereVersjoner = antallSakerMedFlereVersjoner(populasjon),
             antallVentendeMedAvsluttetSak = listOf(arbeidstakerStatus, arbeidsgiverStatus).sumOf {
                 it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
-            }
+            },
+            parInitiertAvArbeidsgiver = initiativ.arbeidsgiver,
+            parInitiertAvArbeidstaker = initiativ.arbeidstaker,
+            parUavhengigStartet = initiativ.uavhengig,
+            komplettPerFlyt = Representasjonstype.entries.associateWith { f -> komplette.count { it.flyt == f }.toLong() },
+            antallDelerUtenPeriode = separateKohort.count { it.periode == null }.toLong()
         )
     }
 
     /**
-     * Status for en deltype: har en innsendt motpart (overlappende periode), eller venter.
-     * For de som venter skilles det på om motparten har påbegynt et utkast eller ikke.
+     * Status for en gjeldende del: har en innsendt separat motpart, er dekket av et komplett skjema,
+     * eller venter. For de som venter skilles det på om motparten har påbegynt et utkast eller ikke.
+     * Kategoriene er gjensidig utelukkende og prioriteres i den rekkefølgen.
      *
      * Merk – med vilje to ulike matchekriterier:
-     * - innsendt motpart krever overlappende periode (en reell, fullført sak).
+     * - innsendt motpart / komplett skjema krever overlappende periode (en reell, fullført sak).
      * - utkast-motpart matcher kun på samme person + juridisk enhet (ikke periode), fordi et utkast
      *   under arbeid ofte ikke har fylt inn periode ennå. Hensikten er «har motparten startet noe».
      */
     private fun delStatus(
-        deler: List<InnsendtSkjema>,
+        kohortDeler: List<InnsendtSkjema>,
         motpartSendtPerSak: Map<Pair<String, String>, List<InnsendtSkjema>>,
+        indeks: SaksIndeks,
         motpartUtkastPerSak: Map<Pair<String, String>, List<UtkastSkjema>>
     ): DelStatusDto {
         var medMotpart = 0L
+        var medMotpartAvsluttet = 0L
+        var dekketAvKomplett = 0L
+        var dekketAvKomplettAvsluttet = 0L
         var venterMotpartHarUtkast = 0L
         var venterMotpartHarUtkastAvsluttet = 0L
         var venterIngenMotpart = 0L
         var venterIngenMotpartAvsluttet = 0L
-        for (del in deler) {
+        val gjeldende = kohortDeler.filter { !it.erstattet }
+        for (del in gjeldende) {
             val avsluttet = del.saksstatus == Saksstatus.AVSLUTTET
             when {
-                motpartSendtPerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> medMotpart++
+                motpartSendtPerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> {
+                    medMotpart++
+                    if (avsluttet) medMotpartAvsluttet++
+                }
+                indeks.komplettePerSak[del.sakNokkel()]?.any { del.matcher(it) } == true -> {
+                    dekketAvKomplett++
+                    if (avsluttet) dekketAvKomplettAvsluttet++
+                }
                 // Bevisst kun person + juridisk enhet (ikke periode): se kommentar over.
                 motpartUtkastPerSak[del.sakNokkel()]?.isNotEmpty() == true -> {
                     venterMotpartHarUtkast++
@@ -232,8 +329,14 @@ class AdminService(
             }
         }
         return DelStatusDto(
-            totalt = deler.size.toLong(),
+            totalt = gjeldende.size.toLong(),
+            antallErstattedeVersjoner = (kohortDeler.size - gjeldende.size).toLong(),
             medMotpart = medMotpart,
+            medMotpartAktivSak = medMotpart - medMotpartAvsluttet,
+            medMotpartAvsluttetSak = medMotpartAvsluttet,
+            dekketAvKomplettSkjema = dekketAvKomplett,
+            dekketAvKomplettSkjemaAktivSak = dekketAvKomplett - dekketAvKomplettAvsluttet,
+            dekketAvKomplettSkjemaAvsluttetSak = dekketAvKomplettAvsluttet,
             venterMotpartHarUtkast = venterMotpartHarUtkast,
             venterIngenMotpart = venterIngenMotpart,
             venterMotpartHarUtkastAktivSak = venterMotpartHarUtkast - venterMotpartHarUtkastAvsluttet,
@@ -243,16 +346,37 @@ class AdminService(
         )
     }
 
-    /** Saker (person + juridisk enhet) der begge deler er dekket – komplett eller matchende separate deler. */
-    private fun antallSakerMedBeggeDeler(innsendt: List<InnsendtSkjema>): Long {
-        val komplettSaker = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
-            .mapTo(mutableSetOf()) { it.sakNokkel() }
-        val ats = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
-        val ags = innsendt.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
-        val separateSaker = ats.keys.intersect(ags.keys).filterTo(mutableSetOf()) { nokkel ->
-            ats.getValue(nokkel).any { at -> ags.getValue(nokkel).any { at.matcher(it) } }
+    private data class InitiativFordeling(val arbeidsgiver: Long, val arbeidstaker: Long, val uavhengig: Long)
+
+    /**
+     * Fordeler saker med matchende separate deler på hvem som utløste paret. Signalet er om den ene
+     * sidens skjema ble PÅBEGYNT (skjema.opprettetDato) etter at den andre sidens del var SENDT INN
+     * (innsending.opprettetDato) – da fikk den siden trolig beskjed om at motparten hadde levert.
+     * Startet begge sider før noen av delene var innsendt, er de uavhengige initiativ.
+     *
+     * Tidspunktene tas per side av paret over ALLE versjoner av den siden (tidligste utkast-start og
+     * tidligste innsending), slik at en senere korreksjon ikke endrer hvem som startet.
+     */
+    private fun beregnInitiativ(saker: Set<Pair<String, String>>, populasjon: List<InnsendtSkjema>): InitiativFordeling {
+        val perSakOgDel = populasjon.groupBy { it.sakNokkel() to it.skjemadel }
+        var arbeidsgiver = 0L
+        var arbeidstaker = 0L
+        var uavhengig = 0L
+        for (sak in saker) {
+            val atDeler = perSakOgDel[sak to Skjemadel.ARBEIDSTAKERS_DEL].orEmpty()
+            val agDeler = perSakOgDel[sak to Skjemadel.ARBEIDSGIVERS_DEL].orEmpty()
+            if (atDeler.isEmpty() || agDeler.isEmpty()) continue
+            val atStartet = atDeler.minOf { it.skjemaOpprettetDato }
+            val agStartet = agDeler.minOf { it.skjemaOpprettetDato }
+            val atInnsendt = atDeler.minOf { it.innsendtDato }
+            val agInnsendt = agDeler.minOf { it.innsendtDato }
+            when {
+                atStartet.isAfter(agInnsendt) -> arbeidsgiver++
+                agStartet.isAfter(atInnsendt) -> arbeidstaker++
+                else -> uavhengig++
+            }
         }
-        return (komplettSaker + separateSaker).size.toLong()
+        return InitiativFordeling(arbeidsgiver, arbeidstaker, uavhengig)
     }
 
     /** Saker der minst én deltype er sendt i flere overlappende versjoner (inkl. erstatninger). */
@@ -263,27 +387,86 @@ class AdminService(
             }
         }.toLong()
 
-    /** Antall deler som overlapper med en annen gjeldende del av samme type/sak (mulig dobbeltinnsending). */
-    private fun antallDuplikater(deler: List<InnsendtSkjema>): Long =
-        deler.filter { !it.erstattet }
-            .groupBy { it.sakNokkel() }
-            .values
-            .sumOf { gruppe -> gruppe.count { del -> gruppe.any { it.id != del.id && del.matcher(it) } }.toLong() }
-
-    /** Anonym toppliste per virksomhet (orgnr), sortert synkende på antall innsendinger. */
-    private fun beregnToppliste(innsendt: List<InnsendtSkjema>): List<VirksomhetStatistikkDto> =
-        innsendt.groupBy { it.orgnr }.values
-            .map { deler ->
-                VirksomhetStatistikkDto(
-                    antallInnsendinger = deler.size.toLong(),
-                    antallUnikeInnsendere = deler.mapTo(mutableSetOf()) { it.innsenderFnr }.size.toLong(),
-                    antallArbeidstakerDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.toLong(),
-                    antallArbeidsgiverDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.toLong(),
-                    antallKomplett = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
-                    antallSakerMedBeggeDeler = antallSakerMedBeggeDeler(deler)
-                )
+    /**
+     * Grupperer deler som overlapper hverandre i tid til sammenhengende grupper (transitiv lukning av
+     * overlapp), slik at ett tilfelle av dobbeltinnsending telles én gang uansett antall versjoner.
+     */
+    private fun overlappendeGrupper(deler: List<InnsendtSkjema>): List<List<InnsendtSkjema>> {
+        val gjenstaaende = ArrayDeque(deler)
+        val grupper = mutableListOf<List<InnsendtSkjema>>()
+        while (gjenstaaende.isNotEmpty()) {
+            val gruppe = mutableListOf(gjenstaaende.removeFirst())
+            var vokste = true
+            while (vokste) {
+                vokste = false
+                val iterator = gjenstaaende.iterator()
+                while (iterator.hasNext()) {
+                    val kandidat = iterator.next()
+                    if (gruppe.any { it.matcher(kandidat) }) {
+                        gruppe += kandidat
+                        iterator.remove()
+                        vokste = true
+                    }
+                }
             }
-            .sortedByDescending { it.antallInnsendinger }
+            grupper += gruppe
+        }
+        return grupper
+    }
+
+    /** Én virksomhet (juridisk enhet) i topplisten med de gjeldende delene som ligger bak tallene. */
+    private data class Virksomhet(val juridiskEnhet: String, val deler: List<InnsendtSkjema>)
+
+    /**
+     * Grupperer kohorten på juridisk enhet – samme nøkkel som saksdekningen bruker, så underenheter
+     * ikke splitter en sak i to rader. Sorteringen er deterministisk (antall, deretter enhet) slik at
+     * rang-oppslaget i [hentVirksomhetSaksnumre] treffer samme rad som topplisten.
+     */
+    private fun grupperVirksomheter(kohort: List<InnsendtSkjema>): List<Virksomhet> =
+        kohort.filter { !it.erstattet }
+            .groupBy { it.juridiskEnhet }
+            .map { (enhet, deler) -> Virksomhet(enhet, deler) }
+            .sortedWith(compareByDescending<Virksomhet> { it.deler.size }.thenBy { it.juridiskEnhet })
+
+    private fun Virksomhet.tilDto(indeks: SaksIndeks) = VirksomhetStatistikkDto(
+        antallInnsendinger = deler.size.toLong(),
+        antallUnikeInnsendere = deler.mapTo(mutableSetOf()) { it.innsenderFnr }.size.toLong(),
+        antallArbeidstakerDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.toLong(),
+        antallArbeidsgiverDel = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.toLong(),
+        antallKomplett = deler.count { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }.toLong(),
+        antallSakerMedBeggeDeler = deler.mapTo(mutableSetOf()) { it.sakNokkel() }.count { indeks.erDekket(it) }.toLong(),
+        antallMottatt = deler.count { it.saksstatus == Saksstatus.MOTTATT }.toLong(),
+        antallAvsluttet = deler.count { it.saksstatus == Saksstatus.AVSLUTTET }.toLong(),
+        antallUkjent = deler.count { it.saksstatus == null }.toLong()
+    )
+
+    /**
+     * Oppslag på hele den innsendte populasjonen, bygget av gjeldende (ikke erstattede) deler. Alle
+     * egenskaps-spørsmål i statistikken stilles hit, slik at et periodefilter aldri bryter et par.
+     */
+    private inner class SaksIndeks(populasjon: List<InnsendtSkjema>) {
+        private val gjeldende = populasjon.filter { !it.erstattet }
+        val komplettePerSak = gjeldende.filter { it.skjemadel == Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL }
+            .groupBy { it.sakNokkel() }
+        val arbeidstakerePerSak = gjeldende.filter { it.skjemadel == Skjemadel.ARBEIDSTAKERS_DEL }.groupBy { it.sakNokkel() }
+        val arbeidsgiverePerSak = gjeldende.filter { it.skjemadel == Skjemadel.ARBEIDSGIVERS_DEL }.groupBy { it.sakNokkel() }
+
+        /** Grupper av gjeldende deler av samme type/sak med overlappende perioder (mulige dobbeltinnsendinger). */
+        val dobbeltinnsendinger: List<List<InnsendtSkjema>> =
+            (arbeidstakerePerSak.values + arbeidsgiverePerSak.values)
+                .flatMap { overlappendeGrupper(it) }
+                .filter { it.size > 1 }
+
+        fun harKomplett(nokkel: Pair<String, String>): Boolean = komplettePerSak.containsKey(nokkel)
+
+        fun harMatchendeSeparateDeler(nokkel: Pair<String, String>): Boolean {
+            val arbeidstakere = arbeidstakerePerSak[nokkel] ?: return false
+            val arbeidsgivere = arbeidsgiverePerSak[nokkel] ?: return false
+            return arbeidstakere.any { at -> arbeidsgivere.any { at.matcher(it) } }
+        }
+
+        fun erDekket(nokkel: Pair<String, String>): Boolean = harKomplett(nokkel) || harMatchendeSeparateDeler(nokkel)
+    }
 
     private interface SakDel {
         val fnr: String
@@ -310,7 +493,12 @@ class AdminService(
         override val periode: PeriodeDto?,
         val erstattet: Boolean,
         val saksstatus: Saksstatus?,
-        val opprettetVia: OpprettetVia?
+        val saksnummer: String?,
+        val opprettetVia: OpprettetVia?,
+        /** Da skjemaet ble opprettet (utkastet startet) – brukes til å avgjøre hvem som initierte et par. */
+        val skjemaOpprettetDato: Instant,
+        /** Da skjemaet ble sendt inn – styrer periodefilteret. */
+        val innsendtDato: Instant
     ) : SakDel
 
     private data class UtkastSkjema(

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -735,6 +735,61 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
+        fun `initiativ - tidligere versjon av en matchende del teller med, men bare i sin egen utsendelse`() {
+            // Sak A: arbeidsgiveren sendte inn tidlig, korrigerte senere. Uten versjonskjeden ville den
+            // korrigerte versjonens tidspunkter gjort arbeidstakeren til initiativtaker.
+            val aFnr = "50000000001"
+            val aV1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-03-31"))
+            val aParPeriode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-04-30"))
+            val aV1 = lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = aFnr, periode = aV1Periode,
+                utkastStartet = Instant.parse("2026-01-01T08:00:00Z"), innsendtDato = Instant.parse("2026-01-02T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = aFnr, periode = aParPeriode,
+                utkastStartet = Instant.parse("2026-01-03T08:00:00Z"), innsendtDato = Instant.parse("2026-01-04T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = aFnr, periode = aParPeriode, erstatterSkjemaId = aV1.id,
+                utkastStartet = Instant.parse("2026-01-05T08:00:00Z"), innsendtDato = Instant.parse("2026-01-06T08:00:00Z")
+            )
+
+            // Sak B: samme tidsbilde, men den erstattede AG-versjonen ble korrigert inn i en ANNEN
+            // utsendelse – da skal den ikke telle i den valgte klyngen
+            val bFnr = "50000000002"
+            val bGammelPeriode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-03-31"))
+            val bParPeriode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-04-30"))
+            val bSenAgPeriode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val bSenAtPeriode = PeriodeDto(LocalDate.parse("2026-11-01"), LocalDate.parse("2026-12-31"))
+            val bGammel = lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = bFnr, periode = bGammelPeriode,
+                utkastStartet = Instant.parse("2026-01-01T08:00:00Z"), innsendtDato = Instant.parse("2026-01-02T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = bFnr, periode = bParPeriode,
+                utkastStartet = Instant.parse("2026-01-03T08:00:00Z"), innsendtDato = Instant.parse("2026-01-04T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = bFnr, periode = bParPeriode,
+                utkastStartet = Instant.parse("2026-01-05T08:00:00Z"), innsendtDato = Instant.parse("2026-01-06T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = bFnr, periode = bSenAgPeriode, erstatterSkjemaId = bGammel.id,
+                utkastStartet = Instant.parse("2026-01-07T08:00:00Z"), innsendtDato = Instant.parse("2026-01-08T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = bFnr, periode = bSenAtPeriode,
+                utkastStartet = Instant.parse("2026-01-09T08:00:00Z"), innsendtDato = Instant.parse("2026-01-10T08:00:00Z")
+            )
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 2
+            s.parInitiertAvArbeidsgiver shouldBe 1 // sak A: den erstattede versjonen hører til paret
+            s.parInitiertAvArbeidstaker shouldBe 1 // sak B: den erstattede versjonen hører til en annen utsendelse
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
         fun `initiativ - erstattet versjon fra en annen utsendelse forgifter ikke tidsstemplene`() {
             val fnr = "49000000001"
             val at1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -710,7 +710,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag1Periode,
                 utkastStartet = Instant.parse("2026-01-04T08:00:00Z"), innsendtDato = Instant.parse("2026-01-05T08:00:00Z")
             )
-            // Utsendelse 2: arbeidsgiverens utkast ble startet tidlig, men sendt inn sist
+            // Utsendelse 2: arbeidsgiverens utkast ble startet tidlig, men sendt inn sist. Erstatterens
+            // utkast-start kan godt ligge før originalens – koblingen settes ved innsending, ikke ved
+            // utkast-opprettelse.
             val gammelAg = lagInnsendt(
                 Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = feilPeriode,
                 utkastStartet = Instant.parse("2026-01-06T08:00:00Z"), innsendtDato = Instant.parse("2026-01-07T08:00:00Z")
@@ -727,6 +729,49 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             val s = hentBruk().saksdekning
             s.antallSakerMedMatchendeSeparateDeler shouldBe 1
             // Utsendelse 1 er den tidligste gjeldende utsendelsen, og der startet arbeidstakeren
+            s.parInitiertAvArbeidstaker shouldBe 1
+            s.parInitiertAvArbeidsgiver shouldBe 0
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
+        fun `initiativ - erstattet versjon fra en annen utsendelse forgifter ikke tidsstemplene`() {
+            val fnr = "49000000001"
+            val at1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
+            val ag1Periode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-03-31"))
+            val ag2Periode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val at2Periode = PeriodeDto(LocalDate.parse("2026-11-01"), LocalDate.parse("2026-12-31"))
+            val feilPeriode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-12-31"))
+
+            // Utsendelse 2 sin ERSTATTEDE AG-versjon bærer de tidligste tidsstemplene, og perioden dekker
+            // hele året – den overlapper dermed utsendelse 1 sin AT-del uten å høre til den utsendelsen
+            val gammelAg = lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = feilPeriode,
+                utkastStartet = Instant.parse("2026-01-01T08:00:00Z"), innsendtDato = Instant.parse("2026-01-02T08:00:00Z")
+            )
+            // Utsendelse 1 (innsendt først av de gjeldende): arbeidstaker sendte inn før arbeidsgiver startet
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at1Periode,
+                utkastStartet = Instant.parse("2026-01-05T08:00:00Z"), innsendtDato = Instant.parse("2026-01-06T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag1Periode,
+                utkastStartet = Instant.parse("2026-01-07T08:00:00Z"), innsendtDato = Instant.parse("2026-01-08T08:00:00Z")
+            )
+            // Utsendelse 2, gjeldende versjoner
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag2Periode, erstatterSkjemaId = gammelAg.id,
+                utkastStartet = Instant.parse("2026-01-03T08:00:00Z"), innsendtDato = Instant.parse("2026-01-09T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at2Periode,
+                utkastStartet = Instant.parse("2026-01-10T08:00:00Z"), innsendtDato = Instant.parse("2026-01-11T08:00:00Z")
+            )
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+            // Den erstattede versjonen følger sin etterfølger til utsendelse 2, og trekker ikke
+            // arbeidsgiversiden i utsendelse 1 bakover i tid
             s.parInitiertAvArbeidstaker shouldBe 1
             s.parInitiertAvArbeidsgiver shouldBe 0
             s.parUavhengigStartet shouldBe 0

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -635,12 +635,14 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         @Test
         fun `initiativ - flere utsendelser paa samme sak klassifiseres etter den tidligste klyngen`() {
             val fnr = "45000000001"
-            // Utsendelse 1 (tidligst innsendt): arbeidsgiver sendte inn før arbeidstaker startet utkastet
-            val ag1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
-            val at1Periode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-03-31"))
-            // Utsendelse 2: eget par, med et arbeidstaker-utkast som ble startet lenge før alt annet
-            val at2Periode = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-10-31"))
-            val ag2Periode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            // Utsendelse 1 (tidligst INNSENDT, men senest i periode): arbeidsgiver sendte inn før
+            // arbeidstaker startet utkastet
+            val ag1Periode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val at1Periode = PeriodeDto(LocalDate.parse("2026-11-01"), LocalDate.parse("2026-12-31"))
+            // Utsendelse 2 (tidligst i periode, men sist innsendt): eget par, med et arbeidstaker-utkast
+            // som ble startet lenge før alt annet
+            val at2Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
+            val ag2Periode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-03-31"))
             val t0 = Instant.parse("2026-01-01T08:00:00Z")
             val t1 = Instant.parse("2026-01-02T08:00:00Z")
             val t2 = Instant.parse("2026-01-03T08:00:00Z")
@@ -657,8 +659,76 @@ class AdminControllerIntegrationTest : ApiTestBase() {
 
             val s = hentBruk().saksdekning
             s.antallSakerMedMatchendeSeparateDeler shouldBe 1
-            s.parInitiertAvArbeidsgiver shouldBe 1 // fra utsendelse 1, ikke blandet med utsendelse 2
+            // Utsendelse 1 vinner fordi den ble innsendt først – ikke fordi perioden starter først
+            s.parInitiertAvArbeidsgiver shouldBe 1
             s.parInitiertAvArbeidstaker shouldBe 0
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
+        fun `initiativ - del uten motpart som henger paa klyngen paavirker ikke klassifiseringen`() {
+            val fnr = "47000000001"
+            // AT0 overlapper AT1, men ikke AG1 – den kobles transitivt inn i klyngen uten å ha en motpart
+            val at0Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-03-31"))
+            val at1Periode = PeriodeDto(LocalDate.parse("2026-03-01"), LocalDate.parse("2026-04-30"))
+            val ag1Periode = PeriodeDto(LocalDate.parse("2026-04-01"), LocalDate.parse("2026-05-31"))
+            val t0 = Instant.parse("2026-01-01T08:00:00Z")
+            val t1 = Instant.parse("2026-01-02T08:00:00Z")
+            val t2 = Instant.parse("2026-01-03T08:00:00Z")
+            val t3 = Instant.parse("2026-01-04T08:00:00Z")
+            val t4 = Instant.parse("2026-01-05T08:00:00Z")
+            val t5 = Instant.parse("2026-01-06T08:00:00Z")
+
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at0Periode, utkastStartet = t0, innsendtDato = t1)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag1Periode, utkastStartet = t2, innsendtDato = t3)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at1Periode, utkastStartet = t4, innsendtDato = t5)
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+            // Kun AT1/AG1 utgjør paret: AT1 ble startet etter at AG1 var innsendt
+            s.parInitiertAvArbeidsgiver shouldBe 1
+            s.parInitiertAvArbeidstaker shouldBe 0
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
+        fun `initiativ - erstattet versjon med bred periode limer ikke sammen to utsendelser`() {
+            val fnr = "48000000001"
+            val at1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
+            val ag1Periode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-03-31"))
+            val ag2Periode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val at2Periode = PeriodeDto(LocalDate.parse("2026-11-01"), LocalDate.parse("2026-12-31"))
+            // Erstattet versjon av utsendelse 2 sin AG-del, med tastefeil-periode som dekker hele året
+            val feilPeriode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-12-31"))
+
+            // Utsendelse 1 (innsendt først): arbeidstaker sendte inn før arbeidsgiver startet utkastet
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at1Periode,
+                utkastStartet = Instant.parse("2026-01-01T08:00:00Z"), innsendtDato = Instant.parse("2026-01-03T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag1Periode,
+                utkastStartet = Instant.parse("2026-01-04T08:00:00Z"), innsendtDato = Instant.parse("2026-01-05T08:00:00Z")
+            )
+            // Utsendelse 2: arbeidsgiverens utkast ble startet tidlig, men sendt inn sist
+            val gammelAg = lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = feilPeriode,
+                utkastStartet = Instant.parse("2026-01-06T08:00:00Z"), innsendtDato = Instant.parse("2026-01-07T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag2Periode, erstatterSkjemaId = gammelAg.id,
+                utkastStartet = Instant.parse("2026-01-02T08:00:00Z"), innsendtDato = Instant.parse("2026-01-08T08:00:00Z")
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at2Periode,
+                utkastStartet = Instant.parse("2026-01-09T08:00:00Z"), innsendtDato = Instant.parse("2026-01-10T08:00:00Z")
+            )
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+            // Utsendelse 1 er den tidligste gjeldende utsendelsen, og der startet arbeidstakeren
+            s.parInitiertAvArbeidstaker shouldBe 1
+            s.parInitiertAvArbeidsgiver shouldBe 0
             s.parUavhengigStartet shouldBe 0
         }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -633,6 +633,58 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
+        fun `initiativ - flere utsendelser paa samme sak klassifiseres etter den tidligste klyngen`() {
+            val fnr = "45000000001"
+            // Utsendelse 1 (tidligst innsendt): arbeidsgiver sendte inn før arbeidstaker startet utkastet
+            val ag1Periode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
+            val at1Periode = PeriodeDto(LocalDate.parse("2026-02-01"), LocalDate.parse("2026-03-31"))
+            // Utsendelse 2: eget par, med et arbeidstaker-utkast som ble startet lenge før alt annet
+            val at2Periode = PeriodeDto(LocalDate.parse("2026-09-01"), LocalDate.parse("2026-10-31"))
+            val ag2Periode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val t0 = Instant.parse("2026-01-01T08:00:00Z")
+            val t1 = Instant.parse("2026-01-02T08:00:00Z")
+            val t2 = Instant.parse("2026-01-03T08:00:00Z")
+            val t3 = Instant.parse("2026-01-04T08:00:00Z")
+            val t4 = Instant.parse("2026-01-05T08:00:00Z")
+            val t5 = Instant.parse("2026-01-06T08:00:00Z")
+            val t6 = Instant.parse("2026-01-07T08:00:00Z")
+            val t7 = Instant.parse("2026-01-08T08:00:00Z")
+
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag1Periode, utkastStartet = t2, innsendtDato = t3)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at1Periode, utkastStartet = t4, innsendtDato = t5)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = at2Periode, utkastStartet = t0, innsendtDato = t6)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = ag2Periode, utkastStartet = t1, innsendtDato = t7)
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+            s.parInitiertAvArbeidsgiver shouldBe 1 // fra utsendelse 1, ikke blandet med utsendelse 2
+            s.parInitiertAvArbeidstaker shouldBe 0
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
+        fun `flere versjoner telles selv om bare den erstattede raden er i vinduet`() {
+            val iVinduet = Instant.parse("2026-03-15T10:00:00Z")
+            val utenforVinduet = Instant.parse("2026-06-15T10:00:00Z")
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "46000000001", periode = periodeA, innsendtDato = iVinduet)
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVERS_DEL,
+                fnr = "46000000001",
+                periode = periodeOverlapp,
+                innsendtDato = utenforVinduet,
+                erstatterSkjemaId = gammel.id
+            )
+
+            val body = hentBruk(fraOgMed = "2026-03-01", tilOgMed = "2026-03-31")
+            body.saksdekning.antallSakerMedFlereVersjoner shouldBe 1
+            with(body.saksdekning.arbeidsgiverDeler) {
+                totalt shouldBe 0
+                antallErstattedeVersjoner shouldBe 1
+                totalt + antallErstattedeVersjoner shouldBe body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVERS_DEL]
+            }
+        }
+
+        @Test
         fun `erstattet komplett holdes utenfor antallKomplette og kan avstemmes`() {
             val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "44000000001", periode = periodeA)
             lagInnsendt(

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -603,6 +603,57 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
+        fun `initiativ - maales paa det matchende paret, ikke paa et tidligere par som aldri matchet`() {
+            val fnr = "43000000001"
+            // Første utsendelse: AT og AG har perioder som verken overlapper hverandre eller den senere utsendelsen
+            val tidligAtPeriode = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-02-28"))
+            val tidligAgPeriode = PeriodeDto(LocalDate.parse("2026-04-01"), LocalDate.parse("2026-05-31"))
+            // Andre utsendelse: AT og AG overlapper hverandre – det eneste faktiske paret
+            val senAgPeriode = PeriodeDto(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-12-31"))
+            val senAtPeriode = PeriodeDto(LocalDate.parse("2026-11-01"), LocalDate.parse("2026-12-31"))
+            val t0 = Instant.parse("2026-02-01T08:00:00Z")
+            val t1 = Instant.parse("2026-02-02T08:00:00Z")
+            val t2 = Instant.parse("2026-02-03T08:00:00Z")
+            val t3 = Instant.parse("2026-02-04T08:00:00Z")
+            val t4 = Instant.parse("2026-02-05T08:00:00Z")
+            val t5 = Instant.parse("2026-02-06T08:00:00Z")
+
+            // Ikke-matchende par, tidligst i tid: begge startet før noen innsending (ville gitt "uavhengig")
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = tidligAtPeriode, utkastStartet = t0, innsendtDato = t1)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = tidligAgPeriode, utkastStartet = t0, innsendtDato = t1)
+            // Matchende par, senere: arbeidsgiver sendte inn før arbeidstakers utkast ble startet
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, periode = senAgPeriode, utkastStartet = t2, innsendtDato = t3)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = fnr, periode = senAtPeriode, utkastStartet = t4, innsendtDato = t5)
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+            s.parInitiertAvArbeidsgiver shouldBe 1
+            s.parInitiertAvArbeidstaker shouldBe 0
+            s.parUavhengigStartet shouldBe 0
+        }
+
+        @Test
+        fun `erstattet komplett holdes utenfor antallKomplette og kan avstemmes`() {
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "44000000001", periode = periodeA)
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+                fnr = "44000000001",
+                periode = periodeOverlapp,
+                erstatterSkjemaId = gammel.id
+            )
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "44000000002", periode = periodeA)
+
+            val body = hentBruk()
+            body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL] shouldBe 3
+            with(body.saksdekning) {
+                antallKomplette shouldBe 2
+                antallErstattedeKomplette shouldBe 1
+                antallKomplette + antallErstattedeKomplette shouldBe
+                    body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL]
+            }
+        }
+
+        @Test
         fun `komplette fordeles paa fullmaktstype`() {
             lagInnsendt(
                 Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
@@ -647,7 +698,12 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "41000000002", orgnr = "910000012", juridiskEnhet = juridiskEnhet)
             lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "41000000003", orgnr = "910000020", juridiskEnhet = "910000020")
 
-            val topp = hentBruk().topplisteVirksomheter
+            val body = hentBruk()
+            // Underenheter telles hver for seg på topp-nivå, mens topplisten grupperer på juridisk enhet
+            body.antallUnikeVirksomheter shouldBe 3
+            body.antallUnikeJuridiskeEnheter shouldBe 2
+
+            val topp = body.topplisteVirksomheter
             topp shouldHaveSize 2
             with(topp[0]) {
                 antallInnsendinger shouldBe 3 // begge underenhetene slått sammen
@@ -707,11 +763,9 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 s.antallSakerMedKomplett + s.antallSakerMedMatchendeSeparateDeler - s.antallSakerMedBaadeKomplettOgSeparate
             s.parInitiertAvArbeidsgiver + s.parInitiertAvArbeidstaker + s.parUavhengigStartet shouldBe
                 s.antallSakerMedMatchendeSeparateDeler
-            s.antallMuligeDobbeltinnsendinger shouldBe s.muligeDobbeltinnsendinger.size.toLong()
             s.komplettPerFlyt.values.sum() shouldBe s.antallKomplette
-            s.antallVentendeMedAvsluttetSak shouldBe listOf(s.arbeidstakerDeler, s.arbeidsgiverDeler).sumOf {
-                it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
-            }
+            // Kun AG-delen uten periode (42000000005) venter med avsluttet sak
+            s.antallVentendeMedAvsluttetSak shouldBe 1
             body.topplisteVirksomheter.sumOf { it.antallInnsendinger } shouldBe
                 s.antallKomplette + s.arbeidstakerDeler.totalt + s.arbeidsgiverDeler.totalt
 
@@ -719,6 +773,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             s.antallKomplette shouldBe 1
             s.antallDelerUtenPeriode shouldBe 1
             s.antallMuligeDobbeltinnsendinger shouldBe 1
+            s.muligeDobbeltinnsendinger shouldHaveSize 1
             s.arbeidsgiverDeler.antallErstattedeVersjoner shouldBe 1
             s.arbeidsgiverDeler.dekketAvKomplettSkjema shouldBe 1
             s.arbeidsgiverDeler.venterMotpartHarUtkast shouldBe 1
@@ -918,11 +973,37 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             )
         }
 
-        private fun hentSaksnumre(rang: Int) =
-            adminClient.get().uri("/admin/statistikk/bruk/virksomheter/$rang/saksnumre")
+        private fun hentSaksnumre(rang: Int, fraOgMed: String? = null, tilOgMed: String? = null) =
+            adminClient.get().uri { b ->
+                b.path("/admin/statistikk/bruk/virksomheter/$rang/saksnumre")
+                fraOgMed?.let { b.queryParam("fraOgMed", it) }
+                tilOgMed?.let { b.queryParam("tilOgMed", it) }
+                b.build()
+            }
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
+
+        private fun hentSaksnumreDto(rang: Int, fraOgMed: String? = null, tilOgMed: String? = null): VirksomhetSaksnumreDto =
+            hentSaksnumre(rang, fraOgMed, tilOgMed)
+                .expectStatus().isOk
+                .expectBody<VirksomhetSaksnumreDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+        private fun hentToppliste(fraOgMed: String? = null, tilOgMed: String? = null): List<VirksomhetStatistikkDto> =
+            adminClient.get().uri { b ->
+                b.path("/admin/statistikk/bruk")
+                fraOgMed?.let { b.queryParam("fraOgMed", it) }
+                tilOgMed?.let { b.queryParam("tilOgMed", it) }
+                b.build()
+            }
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BrukStatistikkDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+                .topplisteVirksomheter
 
         @Test
         fun `skal returnere saksnumrene for virksomheten paa oppgitt rang, uten personopplysninger`() {
@@ -959,23 +1040,44 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             lagInnsendt(fnr = "81000000002", juridiskEnhet = "921000010")
             lagInnsendt(fnr = "81000000003", juridiskEnhet = "921000020")
 
-            val toppliste = adminClient.get().uri("/admin/statistikk/bruk")
-                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk
-                .expectBody<BrukStatistikkDto>()
-                .returnResult().responseBody.shouldNotBeNull()
-                .topplisteVirksomheter
-
-            toppliste.forEachIndexed { indeks, virksomhet ->
-                val saksnumre = hentSaksnumre(indeks + 1)
-                    .expectStatus().isOk
-                    .expectBody<VirksomhetSaksnumreDto>()
-                    .returnResult().responseBody.shouldNotBeNull()
+            hentToppliste().forEachIndexed { indeks, virksomhet ->
+                val saksnumre = hentSaksnumreDto(indeks + 1)
                 saksnumre.antallInnsendinger shouldBe virksomhet.antallInnsendinger
                 saksnumre.saksnumre shouldHaveSize virksomhet.antallInnsendinger.toInt()
             }
+        }
+
+        @Test
+        fun `skal bruke samme periodevindu som topplisten`() {
+            val iVinduet = Instant.parse("2026-03-15T10:00:00Z")
+            val utenforVinduet = Instant.parse("2026-06-15T10:00:00Z")
+            lagInnsendt(fnr = "83000000001", juridiskEnhet = "923000010", saksnummer = "SAK-V1", innsendtDato = iVinduet)
+            lagInnsendt(fnr = "83000000002", juridiskEnhet = "923000010", saksnummer = "SAK-V2", innsendtDato = iVinduet)
+            lagInnsendt(fnr = "83000000003", juridiskEnhet = "923000010", saksnummer = "SAK-UTENFOR", innsendtDato = utenforVinduet)
+            lagInnsendt(fnr = "83000000004", juridiskEnhet = "923000020", saksnummer = "SAK-W1", innsendtDato = iVinduet)
+
+            val toppRad1 = hentToppliste(fraOgMed = "2026-03-01", tilOgMed = "2026-03-31").first()
+            val saksnumre = hentSaksnumreDto(1, fraOgMed = "2026-03-01", tilOgMed = "2026-03-31")
+
+            saksnumre.antallInnsendinger shouldBe toppRad1.antallInnsendinger
+            saksnumre.antallInnsendinger shouldBe 2
+            saksnumre.saksnumre shouldContainExactlyInAnyOrder listOf("SAK-V1", "SAK-V2")
+
+            // Uten periodefilter er den tredje innsendingen med igjen
+            hentSaksnumreDto(1).saksnumre shouldContainExactlyInAnyOrder listOf("SAK-V1", "SAK-V2", "SAK-UTENFOR")
+        }
+
+        @Test
+        fun `skal skille virksomheter med likt antall innsendinger paa juridisk enhet`() {
+            lagInnsendt(fnr = "84000000001", juridiskEnhet = "924000020", saksnummer = "SAK-B1")
+            lagInnsendt(fnr = "84000000002", juridiskEnhet = "924000020", saksnummer = "SAK-B2")
+            lagInnsendt(fnr = "84000000003", juridiskEnhet = "924000010", saksnummer = "SAK-A1")
+            lagInnsendt(fnr = "84000000004", juridiskEnhet = "924000010", saksnummer = "SAK-A2")
+
+            hentToppliste().map { it.antallInnsendinger } shouldBe listOf(2L, 2L)
+            // Ved likt antall sorteres laveste juridiske enhet først
+            hentSaksnumreDto(1).saksnumre shouldContainExactlyInAnyOrder listOf("SAK-A1", "SAK-A2")
+            hentSaksnumreDto(2).saksnumre shouldContainExactlyInAnyOrder listOf("SAK-B1", "SAK-B2")
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -297,13 +297,15 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             fnr: String = "10000000001",
             orgnr: String = korrektSyntetiskOrgnr,
             juridiskEnhet: String = orgnr,
-            periode: PeriodeDto = periodeA,
+            periode: PeriodeDto? = periodeA,
             representasjonstype: Representasjonstype = Representasjonstype.DEG_SELV,
             sprak: Språk = Språk.NORSK_BOKMAL,
             erstatterSkjemaId: UUID? = null,
             innsendtDato: Instant = Instant.now(),
+            utkastStartet: Instant = innsendtDato,
             innsenderFnr: String = "12345678901",
             saksstatus: Saksstatus? = null,
+            saksnummer: String? = null,
             opprettetVia: OpprettetVia? = null
         ): Skjema = skjemaRepository.save(
             skjemaMedDefaultVerdier(
@@ -311,7 +313,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                 orgnr = orgnr,
                 status = SkjemaStatus.SENDT,
                 data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(
-                    utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = periode)
+                    utsendingsperiodeOgLand = periode?.let { utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = it) }
                 ),
                 metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
                     representasjonstype = representasjonstype,
@@ -319,7 +321,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                     juridiskEnhetOrgnr = juridiskEnhet,
                     erstatterSkjemaId = erstatterSkjemaId
                 ),
-                opprettetVia = opprettetVia
+                opprettetVia = opprettetVia,
+                opprettetDato = utkastStartet
             )
         ).also { skjema ->
             innsendingRepository.save(
@@ -328,7 +331,8 @@ class AdminControllerIntegrationTest : ApiTestBase() {
                     innsendtSprak = sprak,
                     opprettetDato = innsendtDato,
                     innsenderFnr = innsenderFnr,
-                    saksstatus = saksstatus
+                    saksstatus = saksstatus,
+                    saksnummer = saksnummer
                 )
             )
         }
@@ -453,7 +457,7 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `saksdekning - mulige dobbeltinnsendinger, men ikke versjon-erstatninger`() {
+        fun `saksdekning - mulige dobbeltinnsendinger telles per tilfelle, ikke per rad`() {
             // Ekte dobbeltinnsending: samme person sender arbeidsgivers del to ganger, overlappende periode
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "30000000001", periode = periodeA)
             lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "30000000001", periode = periodeOverlapp)
@@ -462,7 +466,263 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             val gammel = lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "30000000002", periode = periodeA)
             lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "30000000002", periode = periodeOverlapp, erstatterSkjemaId = gammel.id)
 
-            hentBruk().saksdekning.antallMuligeDobbeltinnsendinger shouldBe 2
+            val s = hentBruk().saksdekning
+            s.antallMuligeDobbeltinnsendinger shouldBe 1 // ett tilfelle (to rader)
+            s.muligeDobbeltinnsendinger.single().antallInnsendinger shouldBe 2
+        }
+
+        @Test
+        fun `duplikat-tilfeller lister saksnumre, og skjema-id naar saksnummer mangler`() {
+            // Tre overlappende arbeidsgiver-deler for samme sak = ETT tilfelle med tre innsendinger
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "31000000001", periode = periodeA, saksnummer = "SAK-D1")
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "31000000001", periode = periodeOverlapp, saksnummer = "SAK-D2")
+            val utenSaksnummer = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "31000000001", periode = periodeA)
+            // Et eget tilfelle for en annen sak – to arbeidstaker-deler
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "31000000002", periode = periodeA, saksnummer = "SAK-E1")
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "31000000002", periode = periodeOverlapp, saksnummer = "SAK-E2")
+
+            val s = hentBruk().saksdekning
+            s.antallMuligeDobbeltinnsendinger shouldBe 2
+            s.muligeDobbeltinnsendinger shouldHaveSize 2
+            val treer = s.muligeDobbeltinnsendinger.single { it.antallInnsendinger == 3 }
+            treer.saksnumre shouldContainExactlyInAnyOrder listOf("SAK-D1", "SAK-D2", utenSaksnummer.id.toString())
+            s.muligeDobbeltinnsendinger.single { it.antallInnsendinger == 2 }
+                .saksnumre shouldContainExactlyInAnyOrder listOf("SAK-E1", "SAK-E2")
+        }
+
+        @Test
+        fun `kohort - del i vinduet matcher motpart utenfor vinduet`() {
+            val iVinduet = Instant.parse("2026-03-15T10:00:00Z")
+            val utenforVinduet = Instant.parse("2026-06-15T10:00:00Z")
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "33000000001", periode = periodeA, innsendtDato = iVinduet)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "33000000001", periode = periodeOverlapp, innsendtDato = utenforVinduet)
+
+            val s = hentBruk(fraOgMed = "2026-03-01", tilOgMed = "2026-03-31").saksdekning
+            with(s.arbeidstakerDeler) {
+                totalt shouldBe 1
+                medMotpart shouldBe 1
+                venterIngenMotpart shouldBe 0
+                venterMotpartHarUtkast shouldBe 0
+            }
+            s.arbeidsgiverDeler.totalt shouldBe 0
+            s.antallSakerMedBeggeDeler shouldBe 1
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 1
+        }
+
+        @Test
+        fun `erstattede versjoner holdes utenfor totalt og avstemmes mot innsendtPerSkjemadel`() {
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "34000000001", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "34000000001", periode = periodeOverlapp, erstatterSkjemaId = gammel.id)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "34000000002", periode = periodeA)
+
+            val body = hentBruk()
+            body.totaltInnsendt shouldBe 3 // fordelingene beholder alle innsendinger
+            with(body.saksdekning.arbeidsgiverDeler) {
+                totalt shouldBe 1
+                antallErstattedeVersjoner shouldBe 1
+                totalt + antallErstattedeVersjoner shouldBe body.innsendtPerSkjemadel[Skjemadel.ARBEIDSGIVERS_DEL]
+            }
+            with(body.saksdekning.arbeidstakerDeler) {
+                antallErstattedeVersjoner shouldBe 0
+                totalt + antallErstattedeVersjoner shouldBe body.innsendtPerSkjemadel[Skjemadel.ARBEIDSTAKERS_DEL]
+            }
+        }
+
+        @Test
+        fun `separat del dekkes av komplett skjema og venter dermed ikke`() {
+            // Arbeidsgiver sendte sin del, mens arbeidstakerens del kom via et komplett skjema
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "35000000001", periode = periodeA, saksstatus = Saksstatus.MOTTATT)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "35000000001", periode = periodeOverlapp)
+            // Samme, men saken er avsluttet
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "35000000002", periode = periodeA, saksstatus = Saksstatus.AVSLUTTET)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "35000000002", periode = periodeOverlapp)
+            // Komplett skjema uten overlappende periode dekker ikke delen
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "35000000003", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "35000000003", periode = periodeSenere)
+
+            val s = hentBruk().saksdekning
+            with(s.arbeidsgiverDeler) {
+                totalt shouldBe 3
+                medMotpart shouldBe 0
+                dekketAvKomplettSkjema shouldBe 2
+                dekketAvKomplettSkjemaAktivSak shouldBe 1
+                dekketAvKomplettSkjemaAvsluttetSak shouldBe 1
+                venterIngenMotpart shouldBe 1
+                totalt shouldBe medMotpart + dekketAvKomplettSkjema + venterMotpartHarUtkast + venterIngenMotpart
+            }
+        }
+
+        @Test
+        fun `dekomponering av saker med begge deler gaar opp`() {
+            // Kun komplett
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "36000000001")
+            // Kun matchende separate deler
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "36000000002", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "36000000002", periode = periodeOverlapp)
+            // Både komplett og matchende separate deler
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "36000000003")
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "36000000003", periode = periodeA)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "36000000003", periode = periodeOverlapp)
+            // Udekket sak
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "36000000004", periode = periodeA)
+
+            val s = hentBruk().saksdekning
+            s.antallSakerMedKomplett shouldBe 2
+            s.antallSakerMedMatchendeSeparateDeler shouldBe 2
+            s.antallSakerMedBaadeKomplettOgSeparate shouldBe 1
+            s.antallSakerMedBeggeDeler shouldBe 3
+            s.antallSakerMedBeggeDeler shouldBe
+                s.antallSakerMedKomplett + s.antallSakerMedMatchendeSeparateDeler - s.antallSakerMedBaadeKomplettOgSeparate
+        }
+
+        @Test
+        fun `initiativ - arbeidsgiver foerst, arbeidstaker foerst og uavhengig`() {
+            val t0 = Instant.parse("2026-02-01T08:00:00Z")
+            val t1 = Instant.parse("2026-02-02T08:00:00Z")
+            val t2 = Instant.parse("2026-02-03T08:00:00Z")
+            val t3 = Instant.parse("2026-02-04T08:00:00Z")
+
+            // Arbeidsgiver sendte inn først; arbeidstakerens utkast ble startet etterpå
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "37000000001", periode = periodeA, utkastStartet = t0, innsendtDato = t1)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "37000000001", periode = periodeOverlapp, utkastStartet = t2, innsendtDato = t3)
+
+            // Arbeidstaker sendte inn først; arbeidsgiverens utkast ble startet etterpå
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "37000000002", periode = periodeA, utkastStartet = t0, innsendtDato = t1)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "37000000002", periode = periodeOverlapp, utkastStartet = t2, innsendtDato = t3)
+
+            // Begge startet utkastet før noen av delene ble sendt inn
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "37000000003", periode = periodeA, utkastStartet = t0, innsendtDato = t3)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "37000000003", periode = periodeOverlapp, utkastStartet = t1, innsendtDato = t3)
+
+            val s = hentBruk().saksdekning
+            s.parInitiertAvArbeidsgiver shouldBe 1
+            s.parInitiertAvArbeidstaker shouldBe 1
+            s.parUavhengigStartet shouldBe 1
+            s.parInitiertAvArbeidsgiver + s.parInitiertAvArbeidstaker + s.parUavhengigStartet shouldBe
+                s.antallSakerMedMatchendeSeparateDeler
+        }
+
+        @Test
+        fun `komplette fordeles paa fullmaktstype`() {
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+                fnr = "38000000001",
+                representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+                fnr = "38000000002",
+                representasjonstype = Representasjonstype.RADGIVER_MED_FULLMAKT
+            )
+            lagInnsendt(
+                Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+                fnr = "38000000003",
+                representasjonstype = Representasjonstype.RADGIVER_MED_FULLMAKT
+            )
+
+            val s = hentBruk().saksdekning
+            s.antallKomplette shouldBe 3
+            s.komplettPerFlyt[Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT] shouldBe 1
+            s.komplettPerFlyt[Representasjonstype.RADGIVER_MED_FULLMAKT] shouldBe 2
+            s.komplettPerFlyt[Representasjonstype.DEG_SELV] shouldBe 0
+            s.komplettPerFlyt.values.sum() shouldBe s.antallKomplette
+        }
+
+        @Test
+        fun `deler uten utsendingsperiode telles som kvalitetsmaal`() {
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "39000000001", periode = null)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "39000000002", periode = null)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "39000000003", periode = periodeA)
+
+            val s = hentBruk().saksdekning
+            s.antallDelerUtenPeriode shouldBe 2
+            s.arbeidstakerDeler.venterIngenMotpart shouldBe 2
+        }
+
+        @Test
+        fun `toppliste grupperer paa juridisk enhet paa tvers av underenheter og viser saksstatus`() {
+            val juridiskEnhet = "910000010"
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "41000000001", orgnr = "910000011", juridiskEnhet = juridiskEnhet, saksstatus = Saksstatus.MOTTATT)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "41000000001", orgnr = "910000012", juridiskEnhet = juridiskEnhet, periode = periodeOverlapp, saksstatus = Saksstatus.AVSLUTTET)
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "41000000002", orgnr = "910000012", juridiskEnhet = juridiskEnhet)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "41000000003", orgnr = "910000020", juridiskEnhet = "910000020")
+
+            val topp = hentBruk().topplisteVirksomheter
+            topp shouldHaveSize 2
+            with(topp[0]) {
+                antallInnsendinger shouldBe 3 // begge underenhetene slått sammen
+                antallArbeidstakerDel shouldBe 2
+                antallArbeidsgiverDel shouldBe 1
+                antallSakerMedBeggeDeler shouldBe 1
+                antallMottatt shouldBe 1
+                antallAvsluttet shouldBe 1
+                antallUkjent shouldBe 1
+            }
+            topp[1].antallInnsendinger shouldBe 1
+            topp[1].antallKomplett shouldBe 1
+        }
+
+        @Test
+        fun `alle kontrollsummer gaar opp for en sammensatt populasjon`() {
+            val iVinduet = Instant.parse("2026-03-15T10:00:00Z")
+            val utenforVinduet = Instant.parse("2026-06-15T10:00:00Z")
+            // Komplett skjema
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "42000000001", innsendtDato = iVinduet, representasjonstype = Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT)
+            // Matchende separat par, arbeidsgiver-delen sendt utenfor vinduet
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "42000000002", periode = periodeA, innsendtDato = iVinduet)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000002", periode = periodeOverlapp, innsendtDato = utenforVinduet)
+            // Versjonert arbeidsgiver-del
+            val gammel = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000003", periode = periodeA, innsendtDato = iVinduet)
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000003", periode = periodeOverlapp, innsendtDato = iVinduet, erstatterSkjemaId = gammel.id)
+            // Duplikat-tilfelle
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "42000000004", periode = periodeA, innsendtDato = iVinduet, saksnummer = "SAK-X1")
+            lagInnsendt(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "42000000004", periode = periodeOverlapp, innsendtDato = iVinduet, saksnummer = "SAK-X2")
+            // Del uten periode
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000005", periode = null, innsendtDato = iVinduet, saksstatus = Saksstatus.AVSLUTTET)
+            // Separat del dekket av komplett skjema
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000006", periode = periodeA, innsendtDato = iVinduet)
+            lagInnsendt(Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL, fnr = "42000000006", periode = periodeOverlapp, innsendtDato = utenforVinduet)
+            // Ventende del der motparten har påbegynt utkast
+            lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = "42000000007", periode = periodeA, innsendtDato = iVinduet)
+            lagUtkast(Skjemadel.ARBEIDSTAKERS_DEL, fnr = "42000000007")
+
+            val body = hentBruk(fraOgMed = "2026-03-01", tilOgMed = "2026-03-31")
+            val s = body.saksdekning
+
+            Skjemadel.entries.forEach { del ->
+                val status = when (del) {
+                    Skjemadel.ARBEIDSTAKERS_DEL -> s.arbeidstakerDeler
+                    Skjemadel.ARBEIDSGIVERS_DEL -> s.arbeidsgiverDeler
+                    Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL -> null
+                }
+                status?.let {
+                    it.totalt + it.antallErstattedeVersjoner shouldBe body.innsendtPerSkjemadel[del]
+                    it.totalt shouldBe it.medMotpart + it.dekketAvKomplettSkjema + it.venterMotpartHarUtkast + it.venterIngenMotpart
+                    it.medMotpart shouldBe it.medMotpartAktivSak + it.medMotpartAvsluttetSak
+                    it.dekketAvKomplettSkjema shouldBe it.dekketAvKomplettSkjemaAktivSak + it.dekketAvKomplettSkjemaAvsluttetSak
+                }
+            }
+
+            s.antallSakerMedBeggeDeler shouldBe
+                s.antallSakerMedKomplett + s.antallSakerMedMatchendeSeparateDeler - s.antallSakerMedBaadeKomplettOgSeparate
+            s.parInitiertAvArbeidsgiver + s.parInitiertAvArbeidstaker + s.parUavhengigStartet shouldBe
+                s.antallSakerMedMatchendeSeparateDeler
+            s.antallMuligeDobbeltinnsendinger shouldBe s.muligeDobbeltinnsendinger.size.toLong()
+            s.komplettPerFlyt.values.sum() shouldBe s.antallKomplette
+            s.antallVentendeMedAvsluttetSak shouldBe listOf(s.arbeidstakerDeler, s.arbeidsgiverDeler).sumOf {
+                it.venterMotpartHarUtkastAvsluttetSak + it.venterIngenMotpartAvsluttetSak
+            }
+            body.topplisteVirksomheter.sumOf { it.antallInnsendinger } shouldBe
+                s.antallKomplette + s.arbeidstakerDeler.totalt + s.arbeidsgiverDeler.totalt
+
+            // Konkrete tall for den sammensatte populasjonen
+            s.antallKomplette shouldBe 1
+            s.antallDelerUtenPeriode shouldBe 1
+            s.antallMuligeDobbeltinnsendinger shouldBe 1
+            s.arbeidsgiverDeler.antallErstattedeVersjoner shouldBe 1
+            s.arbeidsgiverDeler.dekketAvKomplettSkjema shouldBe 1
+            s.arbeidsgiverDeler.venterMotpartHarUtkast shouldBe 1
+            s.arbeidstakerDeler.medMotpart shouldBe 1
         }
 
         @Test
@@ -621,6 +881,114 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         @Test
         fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
             adminClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
+                .exchange()
+                .expectStatus().isForbidden
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/statistikk/bruk/virksomheter/{rang}/saksnumre")
+    inner class VirksomhetSaksnumre {
+
+        private val periodeA = PeriodeDto(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-06-30"))
+
+        private fun lagInnsendt(
+            fnr: String,
+            juridiskEnhet: String,
+            orgnr: String = juridiskEnhet,
+            saksnummer: String? = null,
+            innsendtDato: Instant = Instant.now()
+        ): Skjema = skjemaRepository.save(
+            skjemaMedDefaultVerdier(
+                fnr = fnr,
+                orgnr = orgnr,
+                status = SkjemaStatus.SENDT,
+                data = UtsendtArbeidstakerArbeidstakersSkjemaDataDto(
+                    utsendingsperiodeOgLand = utsendingsperiodeOgLandDtoMedDefaultVerdier().copy(utsendelsePeriode = periodeA)
+                ),
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL,
+                    juridiskEnhetOrgnr = juridiskEnhet
+                )
+            )
+        ).also { skjema ->
+            innsendingRepository.save(
+                innsendingMedDefaultVerdier(skjema = skjema, opprettetDato = innsendtDato, saksnummer = saksnummer)
+            )
+        }
+
+        private fun hentSaksnumre(rang: Int) =
+            adminClient.get().uri("/admin/statistikk/bruk/virksomheter/$rang/saksnumre")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+
+        @Test
+        fun `skal returnere saksnumrene for virksomheten paa oppgitt rang, uten personopplysninger`() {
+            val utenSaksnummer = lagInnsendt(fnr = "80000000001", juridiskEnhet = "920000010", orgnr = "920000011", saksnummer = null)
+            lagInnsendt(fnr = "80000000002", juridiskEnhet = "920000010", orgnr = "920000012", saksnummer = "SAK-A2")
+            lagInnsendt(fnr = "80000000003", juridiskEnhet = "920000010", saksnummer = "SAK-A3")
+            lagInnsendt(fnr = "80000000004", juridiskEnhet = "920000020", saksnummer = "SAK-B1")
+
+            val topp1 = hentSaksnumre(1)
+                .expectStatus().isOk
+                .expectBody<VirksomhetSaksnumreDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+            topp1.rang shouldBe 1
+            topp1.antallInnsendinger shouldBe 3
+            topp1.saksnumre shouldContainExactlyInAnyOrder listOf("SAK-A2", "SAK-A3", utenSaksnummer.id.toString())
+
+            val topp2 = hentSaksnumre(2)
+                .expectStatus().isOk
+                .expectBody<VirksomhetSaksnumreDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+            topp2.antallInnsendinger shouldBe 1
+            topp2.saksnumre shouldBe listOf("SAK-B1")
+
+            val json = hentSaksnumre(1).expectStatus().isOk
+                .expectBody(String::class.java).returnResult().responseBody!!
+            json shouldNotContain "80000000001"
+            json shouldNotContain "920000010"
+            json shouldNotContain "Test Testesen"
+        }
+
+        @Test
+        fun `antallInnsendinger skal stemme med samme rad i topplisten`() {
+            lagInnsendt(fnr = "81000000001", juridiskEnhet = "921000010")
+            lagInnsendt(fnr = "81000000002", juridiskEnhet = "921000010")
+            lagInnsendt(fnr = "81000000003", juridiskEnhet = "921000020")
+
+            val toppliste = adminClient.get().uri("/admin/statistikk/bruk")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<BrukStatistikkDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+                .topplisteVirksomheter
+
+            toppliste.forEachIndexed { indeks, virksomhet ->
+                val saksnumre = hentSaksnumre(indeks + 1)
+                    .expectStatus().isOk
+                    .expectBody<VirksomhetSaksnumreDto>()
+                    .returnResult().responseBody.shouldNotBeNull()
+                saksnumre.antallInnsendinger shouldBe virksomhet.antallInnsendinger
+                saksnumre.saksnumre shouldHaveSize virksomhet.antallInnsendinger.toInt()
+            }
+        }
+
+        @Test
+        fun `skal returnere 404 naar rang er utenfor topplisten`() {
+            lagInnsendt(fnr = "82000000001", juridiskEnhet = "922000010")
+
+            hentSaksnumre(2).expectStatus().isNotFound
+            hentSaksnumre(0).expectStatus().isNotFound
+        }
+
+        @Test
+        fun `skal returnere 403 naar azp ikke matcher tillatt klient`() {
+            adminClient.get().uri("/admin/statistikk/bruk/virksomheter/1/saksnumre")
                 .header("Authorization", "Bearer ${mockOAuth2Server.m2mTokenWithoutAccess()}")
                 .exchange()
                 .expectStatus().isForbidden


### PR DESCRIPTION
Kvalitetssikring av bruksstatistikken:

- **Kohort-semantikk:** periodefilteret avgrenser hvilke deler som telles; motpart/dekning/erstattet måles alltid mot hele populasjonen — par brytes ikke lenger av periodevinduet, og perioder kan sammenlignes som stabile kohorter
- **Gjeldende deler:** erstattede versjoner holdes utenfor tellingene, med synlig avstemming (`innsendtPerSkjemadel[del] = totalt + antallErstattedeVersjoner`, tilsvarende for komplette)
- **Dekket av komplett skjema** som egen gjensidig utelukkende kategori, aktiv/avsluttet-split på alle kategorier
- **Dekomponering** av `antallSakerMedBeggeDeler` (komplett + separate − begge) så tallet kan regnes for hånd
- **Duplikater per tilfelle** med saksnummer-kontekst
- **Initiativ-innsikt:** hvem tok initiativet per matchet par (arbeidsgiver/arbeidstaker/uavhengig), målt på faktisk matchende deler i tidligste utsendelse, med versjonskjede-korrekt tidsgrunnlag
- **Komplette per fullmaktstype** (`komplettPerFlyt`)
- **Toppliste på juridisk enhet** med saksstatus-tall, og nytt endepunkt `GET /admin/statistikk/bruk/virksomheter/{rang}/saksnumre` for stikkprøver
- Kvalitetstellere: `antallDelerUtenPeriode`, `antallUnikeJuridiskeEnheter`

Alle kontrollsummer er testverifisert (33 statistikk-tester, 781 totalt). Review-sløyfe kjørt til ren runde.