### PR TITLE
MELOSYS-8084 Sett saksstatus MOTTATT når saksnummer registreres

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -40,16 +40,16 @@ class AdminController(
         return adminService.hentStatistikk()
     }
 
-    @GetMapping("/saksstatus/uttrekk")
+    @GetMapping("/saksstatus/eksport")
     @Operation(
-        summary = "Backup-uttrekk av saksnummer/saksstatus per skjema-id",
-        description = "Feltene massesynken kan endre, uten personopplysninger. Ta uttrekket FØR " +
-            "massesynk kjøres, som gjenopprettings- og diff-grunnlag."
+        summary = "Eksporter saksnummer og saksstatus per skjema-id",
+        description = "Synk-tilstanden per skjema, uten personopplysninger – til avstemming mot " +
+            "Melosys, feilsøking av synken, eller som diff-grunnlag før en eventuell migrering."
     )
-    @ApiResponse(responseCode = "200", description = "Uttrekk hentet")
-    fun hentSaksstatusUttrekk(): SaksstatusUttrekkDto {
-        log.info { "Admin: Henter saksstatus-uttrekk" }
-        return adminService.hentSaksstatusUttrekk()
+    @ApiResponse(responseCode = "200", description = "Eksport hentet")
+    fun hentSaksstatusEksport(): SaksstatusEksportDto {
+        log.info { "Admin: Henter saksstatus-eksport" }
+        return adminService.hentSaksstatusEksport()
     }
 
     @GetMapping("/statistikk/bruk")

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -249,17 +249,17 @@ data class DobbeltinnsendingDto(
 )
 
 /**
- * Backup-uttrekk av synk-tilstanden FØR massesynk/migrering: nøyaktig feltene synken kan endre,
- * per skjema-id. Inneholder bevisst ingen personopplysninger (ingen fnr, navn eller skjemadata) —
- * kan lastes ned fra melosys-console og brukes til gjenoppretting eller diff.
+ * Synk-tilstanden per skjema-id: nøyaktig feltene saksstatus-synken kan endre. Brukes til
+ * avstemming mot Melosys, feilsøking av synken, og som diff-grunnlag før en eventuell migrering.
+ * Inneholder bevisst ingen personopplysninger (ingen fnr, navn eller skjemadata).
  */
-data class SaksstatusUttrekkDto(
+data class SaksstatusEksportDto(
     val tidspunkt: Instant,
     val antall: Int,
-    val rader: List<SaksstatusUttrekkRadDto>
+    val rader: List<SaksstatusEksportRadDto>
 )
 
-data class SaksstatusUttrekkRadDto(
+data class SaksstatusEksportRadDto(
     val skjemaId: UUID,
     val referanseId: String,
     val saksnummer: String?,

--- a/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/repository/InnsendingRepository.kt
@@ -65,7 +65,7 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
 
     /**
      * Synk-feltene per innsendt skjema, uten å materialisere skjemaets JSONB-data —
-     * uttrekket trenger kun radene på innsending-tabellen pluss skjema-id-en (FK).
+     * eksporten trenger kun radene på innsending-tabellen pluss skjema-id-en (FK).
      */
     @Query(
         "SELECT i.skjema.id AS skjemaId, i.referanseId AS referanseId, i.saksnummer AS saksnummer, " +
@@ -74,10 +74,10 @@ interface InnsendingRepository : JpaRepository<Innsending, UUID> {
             "WHERE i.skjema.status = no.nav.melosys.skjema.types.common.SkjemaStatus.SENDT " +
             "AND i.skjema.type = no.nav.melosys.skjema.types.SkjemaType.UTSENDT_ARBEIDSTAKER"
     )
-    fun finnSaksstatusUttrekk(): List<SaksstatusUttrekkProjeksjon>
+    fun finnSaksstatusEksport(): List<SaksstatusEksportProjeksjon>
 }
 
-interface SaksstatusUttrekkProjeksjon {
+interface SaksstatusEksportProjeksjon {
     val skjemaId: UUID
     val referanseId: String
     val saksnummer: String?

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -12,8 +12,8 @@ import no.nav.melosys.skjema.controller.admin.DelStatusDto
 import no.nav.melosys.skjema.controller.admin.DobbeltinnsendingDto
 import no.nav.melosys.skjema.controller.admin.MotpartCtaStatistikkDto
 import no.nav.melosys.skjema.controller.admin.SaksstatusFordelingDto
-import no.nav.melosys.skjema.controller.admin.SaksstatusUttrekkDto
-import no.nav.melosys.skjema.controller.admin.SaksstatusUttrekkRadDto
+import no.nav.melosys.skjema.controller.admin.SaksstatusEksportDto
+import no.nav.melosys.skjema.controller.admin.SaksstatusEksportRadDto
 import no.nav.melosys.skjema.controller.admin.InnsendingAdminDto
 import no.nav.melosys.skjema.controller.admin.ResendVarslerResultatDto
 import no.nav.melosys.skjema.controller.admin.RetryResultatDto
@@ -214,13 +214,13 @@ class AdminService(
     }
 
     /**
-     * Backup-uttrekk av synk-tilstanden før massesynk: feltene synken kan endre, per skjema-id.
-     * Ingen personopplysninger — se [SaksstatusUttrekkDto].
+     * Synk-tilstanden per skjema-id: feltene saksstatus-synken kan endre.
+     * Ingen personopplysninger — se [SaksstatusEksportDto].
      */
     @Transactional(readOnly = true)
-    fun hentSaksstatusUttrekk(): SaksstatusUttrekkDto {
-        val rader = innsendingRepository.finnSaksstatusUttrekk().map { rad ->
-            SaksstatusUttrekkRadDto(
+    fun hentSaksstatusEksport(): SaksstatusEksportDto {
+        val rader = innsendingRepository.finnSaksstatusEksport().map { rad ->
+            SaksstatusEksportRadDto(
                 skjemaId = rad.skjemaId,
                 referanseId = rad.referanseId,
                 saksnummer = rad.saksnummer,
@@ -228,7 +228,7 @@ class AdminService(
                 saksstatusOppdatert = rad.saksstatusOppdatert
             )
         }
-        return SaksstatusUttrekkDto(tidspunkt = Instant.now(), antall = rader.size, rader = rader)
+        return SaksstatusEksportDto(tidspunkt = Instant.now(), antall = rader.size, rader = rader)
     }
 
     private fun innenfor(tidspunkt: Instant, fra: Instant?, tilEksklusiv: Instant?): Boolean =

--- a/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/M2MSkjemaService.kt
@@ -103,15 +103,21 @@ class M2MSkjemaService(
      * først er satt: samme verdi på nytt er idempotent OK, en annen verdi gir
      * [SaksnummerKonfliktException] (409). Backfill (null → verdi) er alltid OK.
      *
-     * Den nye innsendingen beholder `saksstatus = null` (vises som Mottatt) uavhengig av andre
-     * innsendinger på samme sak: Melosys oppretter ny behandling for den, så den er per
-     * definisjon under behandling.
+     * Saksnummeret er beviset på at Melosys har opprettet sak og behandling for innsendingen, så
+     * statusen settes samtidig til [Saksstatus.MOTTATT]. Melosys publiserer bare status*endringer*,
+     * og en nyopprettet sak har ingen – uten dette ville innsendingen stått uten status til saken
+     * en gang ble avsluttet. En innsending som allerede har status beholder den (ingen nedgradering
+     * av avsluttede saker, og [Innsending.saksstatusOppdatert] bevares ved gjentatte kall).
      */
     @Transactional
     fun registrerSaksnummer(skjemaId: UUID, saksnummer: String) {
         val innsending = hentInnsending(skjemaId)
         validerSaksnummerUendret(innsending, saksnummer)
         innsending.saksnummer = saksnummer
+        if (innsending.saksstatus == null) {
+            innsending.saksstatus = Saksstatus.MOTTATT
+            innsending.saksstatusOppdatert = Instant.now()
+        }
         log.info { "Registrert saksnummer $saksnummer for skjema $skjemaId" }
     }
 

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/M2MSkjemaControllerIntegrationTest.kt
@@ -289,9 +289,9 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `skal ikke arve saksstatus fra soesken - ny innsending forblir null (Mottatt)`() {
+        fun `skal ikke arve saksstatus fra soesken - ny innsending blir MOTTATT`() {
             // Søsken på samme sak er AVSLUTTET, men Melosys oppretter ny behandling for den nye
-            // innsendingen – den skal derfor stå som null (Mottatt), ikke arve søskenens status.
+            // innsendingen – den skal derfor bli MOTTATT, ikke arve søskenens status.
             lagInnsendtSkjemaMedInnsending(saksnummer = "MEL-600", saksstatus = Saksstatus.AVSLUTTET)
             val nyttSkjema = lagInnsendtSkjemaMedInnsending(saksnummer = null)
 
@@ -306,7 +306,7 @@ class M2MSkjemaControllerIntegrationTest : ApiTestBase() {
 
             val oppdatert = innsendingRepository.findBySkjemaId(nyttSkjema.id!!)!!
             oppdatert.saksnummer shouldBe "MEL-600"
-            oppdatert.saksstatus.shouldBeNull()
+            oppdatert.saksstatus shouldBe Saksstatus.MOTTATT
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -1010,14 +1010,14 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         }
 
         @Test
-        fun `saksstatus-uttrekk returnerer synk-feltene uten personopplysninger`() {
+        fun `saksstatus-eksport returnerer synk-feltene uten personopplysninger`() {
             val fnr = "63000000001"
             val skjema = lagInnsendt(Skjemadel.ARBEIDSGIVERS_DEL, fnr = fnr, saksstatus = Saksstatus.MOTTATT)
             val innsending = innsendingRepository.findBySkjemaId(skjema.id!!)!!
             innsending.saksnummer = "MEL-123456"
             innsendingRepository.save(innsending)
 
-            val json = adminClient.get().uri("/admin/saksstatus/uttrekk")
+            val json = adminClient.get().uri("/admin/saksstatus/eksport")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .exchange()
                 .expectStatus().isOk
@@ -1028,15 +1028,15 @@ class AdminControllerIntegrationTest : ApiTestBase() {
             json shouldNotContain innsending.innsenderFnr
             json shouldNotContain "Test Testesen"
 
-            val uttrekk = adminClient.get().uri("/admin/saksstatus/uttrekk")
+            val eksport = adminClient.get().uri("/admin/saksstatus/eksport")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .exchange()
                 .expectStatus().isOk
-                .expectBody<SaksstatusUttrekkDto>()
+                .expectBody<SaksstatusEksportDto>()
                 .returnResult()
                 .responseBody!!
-            uttrekk.antall shouldBe 1
-            with(uttrekk.rader.single()) {
+            eksport.antall shouldBe 1
+            with(eksport.rader.single()) {
                 skjemaId shouldBe skjema.id
                 saksnummer shouldBe "MEL-123456"
                 saksstatus shouldBe Saksstatus.MOTTATT

--- a/src/test/kotlin/no/nav/melosys/skjema/service/M2MSkjemaServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/M2MSkjemaServiceIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 import no.nav.melosys.skjema.ApiTestBase
@@ -19,6 +20,7 @@ import no.nav.melosys.skjema.skjemaMedDefaultVerdier
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Representasjonstype
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.Skjemadel
 import no.nav.melosys.skjema.types.utsendtarbeidstaker.UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
+import no.nav.melosys.skjema.types.common.Saksstatus
 import no.nav.melosys.skjema.types.common.SkjemaStatus
 import no.nav.melosys.skjema.types.felles.PeriodeDto
 import no.nav.melosys.skjema.utsendtArbeidstakerMetadataMedDefaultVerdier
@@ -403,6 +405,63 @@ class M2MSkjemaServiceIntegrationTest : ApiTestBase() {
 
             val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
             oppdatert.saksnummer shouldBe "12345"
+        }
+
+        @Test
+        fun `registrerSaksnummer setter saksstatus MOTTATT naar status mangler`() {
+            val skjema = skjemaRepository.save(skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidstakersDataMedOverlappendePeriode,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            ))
+
+            innsendingRepository.save(innsendingMedDefaultVerdier(
+                skjema = skjema,
+                status = InnsendingStatus.FERDIG,
+                referanseId = "TEST11"
+            ))
+
+            m2mSkjemaService.registrerSaksnummer(skjema.id!!, "MEL-1")
+
+            val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            oppdatert.saksstatus shouldBe Saksstatus.MOTTATT
+            oppdatert.saksstatusOppdatert.shouldNotBeNull()
+        }
+
+        @Test
+        fun `registrerSaksnummer nedgraderer ikke en avsluttet sak`() {
+            val skjema = skjemaRepository.save(skjemaMedDefaultVerdier(
+                fnr = korrektSyntetiskFnr,
+                orgnr = korrektSyntetiskOrgnr,
+                status = SkjemaStatus.SENDT,
+                data = arbeidstakersDataMedOverlappendePeriode,
+                metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                    representasjonstype = Representasjonstype.DEG_SELV,
+                    skjemadel = Skjemadel.ARBEIDSTAKERS_DEL
+                )
+            ))
+
+            val avsluttetTidspunkt = Instant.parse("2026-01-01T00:00:00Z")
+            innsendingRepository.save(innsendingMedDefaultVerdier(
+                skjema = skjema,
+                status = InnsendingStatus.FERDIG,
+                referanseId = "TEST12"
+            ).apply {
+                saksnummer = "MEL-2"
+                saksstatus = Saksstatus.AVSLUTTET
+                saksstatusOppdatert = avsluttetTidspunkt
+            })
+
+            m2mSkjemaService.registrerSaksnummer(skjema.id!!, "MEL-2")
+
+            val oppdatert = innsendingRepository.findBySkjemaId(skjema.id!!)!!
+            oppdatert.saksstatus shouldBe Saksstatus.AVSLUTTET
+            oppdatert.saksstatusOppdatert shouldBe avsluttetTidspunkt
         }
 
         @Test


### PR DESCRIPTION
Melosys publiserer bare status*endringer*, og en nyopprettet sak har ingen. Derfor sto innsendinger uten saksstatus helt til saken en gang ble avsluttet — selv om saken var opprettet og under behandling (`MELOSYS_MOTTAK_DIGITAL_SØKNAD` → `OPPRETT_SAK_OG_BEHANDLING_DIGITAL_SØKNAD` → `SEND_SAKSNUMMER_TIL_MELOSYS_SKJEMA_API`, uten noe statusendring-event).

Saksnummeret er beviset på at saken finnes, så `registrerSaksnummer` setter nå `MOTTATT` samtidig. Dette gjør eksplisitt det brukervisningen allerede antok (null ble vist som «Mottatt»).

- Innsendinger som allerede har status beholder den: ingen nedgradering av avsluttede saker, og `saksstatusOppdatert` bevares ved gjentatte kall (idempotent)
- Etter dette betyr manglende saksstatus noe langt mer presist: Melosys har ikke registrert sak for innsendingen ennå

I tillegg: saksstatus-uttrekket er døpt om til **eksport** (`GET /admin/saksstatus/eksport`, `hentSaksstatusEksport`). Massesynken er kjørt, så «backup før massesynk» er ikke lenger dekkende — endepunktet er nå et avstemmings- og feilsøkingsverktøy. Knappen fjernes fra bruksstatistikk-siden i melosys-console#226; endepunktet består som admin-verktøy.

778 tester grønne (verifisert via XML-parsing).