### PR TITLE
MELOSYS-8168 Ekskluder manuelt gjennomgåtte saksnumre ved resending av varsel

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -12,6 +12,7 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -134,13 +135,20 @@ class AdminController(
         description = "Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til arbeidstakere " +
             "som fikk et varsel med feil lenke før lenken ble fikset. Kandidatene finnes i koden: alle " +
             "handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn før " +
-            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Med dryRun=true (default) " +
-            "sendes ingenting — responsen viser hvem som VILLE fått varsel. Kjør med dryRun=false for å sende."
+            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Valgfri request-body kan " +
+            "inneholde `ekskluderteSaksnumre` – saker der saksbehandler har verifisert at motparten " +
+            "allerede er mottatt via en annen kanal, og som derfor ikke skal varsles på nytt. Med " +
+            "dryRun=true (default) sendes ingenting — responsen viser hvem som VILLE fått varsel. " +
+            "Kjør med dryRun=false for å sende."
     )
     @ApiResponse(responseCode = "200", description = "Resending utført (eller opptalt ved dry-run)")
-    fun resendVarsler(@RequestParam(defaultValue = "true") dryRun: Boolean): ResendVarslerResultatDto {
-        log.info { "Admin: Resend varsler (dryRun=$dryRun) til arbeidstakere som fikk varsel med feil lenke" }
-        return adminService.resendVarsler(dryRun)
+    fun resendVarsler(
+        @RequestParam(defaultValue = "true") dryRun: Boolean,
+        @RequestBody(required = false) request: ResendVarslerRequestDto?
+    ): ResendVarslerResultatDto {
+        val ekskluderte = request?.ekskluderteSaksnumre.orEmpty()
+        log.info { "Admin: Resend varsler (dryRun=$dryRun, ${ekskluderte.size} ekskludert(e) saksnummer) til arbeidstakere som fikk varsel med feil lenke" }
+        return adminService.resendVarsler(dryRun, ekskluderte)
     }
 
 }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminController.kt
@@ -135,18 +135,27 @@ class AdminController(
         description = "Resender det handlingspliktige varselet (nå med korrekt skjema-lenke) til arbeidstakere " +
             "som fikk et varsel med feil lenke før lenken ble fikset. Kandidatene finnes i koden: alle " +
             "handlingspliktige AG-deler (arbeidsgiver/rådgiver uten fullmakt) som ble sendt inn før " +
-            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Valgfri request-body kan " +
-            "inneholde `ekskluderteSaksnumre` – saker der saksbehandler har verifisert at motparten " +
-            "allerede er mottatt via en annen kanal, og som derfor ikke skal varsles på nytt. Med " +
-            "dryRun=true (default) sendes ingenting — responsen viser hvem som VILLE fått varsel. " +
+            "2026-07-03 12:11:38 UTC og fortsatt venter på arbeidstakers del. Valgfri request-body " +
+            "(Content-Type: application/json) kan inneholde `ekskluderteSaksnumre` – saker der " +
+            "saksbehandler har verifisert at motparten allerede er mottatt via en annen kanal, og som " +
+            "derfor ikke skal varsles på nytt. Treffer en oppgitt verdi ingen kandidat, avvises kjøringen " +
+            "med 400 når dryRun=false. Med dryRun=true (default) sendes ingenting — responsen viser hvem " +
+            "som VILLE fått varsel, hvem som ble ekskludert, og hvilke verdier som ikke traff. " +
             "Kjør med dryRun=false for å sende."
     )
     @ApiResponse(responseCode = "200", description = "Resending utført (eller opptalt ved dry-run)")
+    @ApiResponse(responseCode = "400", description = "Ugyldig eksklusjonsliste, eller verdier som ikke traff noen kandidat ved dryRun=false")
     fun resendVarsler(
         @RequestParam(defaultValue = "true") dryRun: Boolean,
         @RequestBody(required = false) request: ResendVarslerRequestDto?
     ): ResendVarslerResultatDto {
         val ekskluderte = request?.ekskluderteSaksnumre.orEmpty()
+        // Ukjente felt ignoreres av Jackson-oppsettet vårt, så en feilstavet nøkkel ville ellers gitt en
+        // tom liste – og en full utsending – uten at kaller merket det. Sendte du en body, må den bety noe.
+        require(request == null || ekskluderte.isNotEmpty()) {
+            "Tom eksklusjonsliste. Utelat request-bodyen hvis du ikke vil ekskludere noe – ellers er " +
+                "feltnavnet trolig feilstavet (forventet: ekskluderteSaksnumre)."
+        }
         log.info { "Admin: Resend varsler (dryRun=$dryRun, ${ekskluderte.size} ekskludert(e) saksnummer) til arbeidstakere som fikk varsel med feil lenke" }
         return adminService.resendVarsler(dryRun, ekskluderte)
     }

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -55,11 +55,38 @@ data class RetryResultatDto(
  * [ekskluderteSaksnumre] er saker en saksbehandler har gjennomgått manuelt og sett at motparten
  * allerede er mottatt via en annen kanal – de skal ikke varsles på nytt. Saker uten saksnummer kan
  * ekskluderes ved å oppgi skjema-id-en (samme representasjon som i responsen). Whitespace trimmes,
- * og tomme verdier ignoreres.
+ * og matchingen er ikke case-sensitiv.
+ *
+ * Valideres i [init] framfor med bean validation-annotasjoner, siden container element-constraints
+ * (`List<@NotBlank String>`) ikke slår inn her. Blanke og for lange verdier avvises: en verdi som ikke
+ * er et gyldig saksnummer (maks 99 tegn, jf. `innsending.saksnummer`) eller en skjema-id kan uansett
+ * ikke treffe en kandidat, og skal ikke havne i logger og responser.
+ *
+ * NB: sendingen er irreversibel, så en oppgitt verdi som ikke treffer noen kandidat avvises med 400
+ * ved ekte kjøring (`dryRun=false`) – se [ResendVarslerResultatDto.ikkeFunnetEkskluderte].
  */
 data class ResendVarslerRequestDto(
     val ekskluderteSaksnumre: List<String> = emptyList()
-)
+) {
+    init {
+        require(ekskluderteSaksnumre.size <= MAKS_ANTALL_EKSKLUDERTE) {
+            "Eksklusjonslisten kan ikke ha mer enn $MAKS_ANTALL_EKSKLUDERTE elementer"
+        }
+        // isNullOrBlank framfor isNotBlank: Jackson kan legge null i lista selv om typen er String.
+        require(ekskluderteSaksnumre.none { it.isNullOrBlank() }) {
+            "Eksklusjonslisten kan ikke inneholde tomme verdier"
+        }
+        require(ekskluderteSaksnumre.all { it.orEmpty().trim().length <= MAKS_LENGDE_SAKSNUMMER }) {
+            "En verdi i eksklusjonslisten er lengre enn $MAKS_LENGDE_SAKSNUMMER tegn og kan ikke være et saksnummer"
+        }
+    }
+
+    private companion object {
+        const val MAKS_ANTALL_EKSKLUDERTE = 2000
+        /** Matcher kolonnen innsending.saksnummer (VARCHAR(99)), jf. `GyldigSaksnummer`. */
+        const val MAKS_LENGDE_SAKSNUMMER = 99
+    }
+}
 
 /**
  * MELOSYS-8168 (midlertidig): Resultat av resending. Kandidatene finnes i koden (AG-del innsendt før
@@ -70,15 +97,21 @@ data class ResendVarslerRequestDto(
  * sendes. [antallSendt] er antallet i listen. Saker som mangler saksnummer representeres med
  * skjema-id-en sin.
  *
- * [antallEkskludert] er kandidatene som ble filtrert bort av eksklusjonslisten, og [ikkeFunnetEkskluderte]
- * er oppgitte saksnumre som ikke traff noen kandidat (typisk allerede ute av kandidatsettet, eller en
- * skrivefeil) – ta med som kontroll på at listen ble tolket som forventet.
+ * [ekskluderte] er kandidatene som ble filtrert bort av eksklusjonslisten, og [antallEkskludert] er
+ * antallet i den listen. NB: dette er KANDIDATER, ikke listeoppføringer – treffer én oppføring flere
+ * kandidater (samme saksnummer på flere handlingspliktige AG-deler), kan tallet være høyere enn
+ * antall oppgitte verdier. Sjekk listen mot din egen ved dry-run.
+ *
+ * [ikkeFunnetEkskluderte] er oppgitte verdier som ikke traff noen kandidat (typisk allerede ute av
+ * kandidatsettet, eller en skrivefeil). Ved `dryRun=false` er den alltid tom, siden kjøringen da
+ * avvises med 400 i stedet – en skrivefeil skal ikke føre til at saken varsles likevel.
  */
 data class ResendVarslerResultatDto(
     val dryRun: Boolean,
     val antallSendt: Int,
     val saksnumre: List<String>,
     val antallEkskludert: Int = 0,
+    val ekskluderte: List<String> = emptyList(),
     val ikkeFunnetEkskluderte: List<String> = emptyList()
 )
 

--- a/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/controller/admin/AdminDtos.kt
@@ -49,17 +49,37 @@ data class RetryResultatDto(
 )
 
 /**
+ * MELOSYS-8168 (midlertidig): Valgfri request-body til resending. Kandidatene finnes fortsatt i koden;
+ * dette er kun en manuell eksklusjonsliste.
+ *
+ * [ekskluderteSaksnumre] er saker en saksbehandler har gjennomgått manuelt og sett at motparten
+ * allerede er mottatt via en annen kanal – de skal ikke varsles på nytt. Saker uten saksnummer kan
+ * ekskluderes ved å oppgi skjema-id-en (samme representasjon som i responsen). Whitespace trimmes,
+ * og tomme verdier ignoreres.
+ */
+data class ResendVarslerRequestDto(
+    val ekskluderteSaksnumre: List<String> = emptyList()
+)
+
+/**
  * MELOSYS-8168 (midlertidig): Resultat av resending. Kandidatene finnes i koden (AG-del innsendt før
- * SMS ble aktivert, som fortsatt venter på AT-del), så endepunktet trenger ingen request-body.
+ * SMS ble aktivert, som fortsatt venter på AT-del), så endepunktet trenger ingen request-body utover
+ * en eventuell eksklusjonsliste ([ResendVarslerRequestDto]).
  *
  * [saksnumre] lister sakene som fikk et nytt varsel — eller ved [dryRun] ville fått, uten at noe
  * sendes. [antallSendt] er antallet i listen. Saker som mangler saksnummer representeres med
  * skjema-id-en sin.
+ *
+ * [antallEkskludert] er kandidatene som ble filtrert bort av eksklusjonslisten, og [ikkeFunnetEkskluderte]
+ * er oppgitte saksnumre som ikke traff noen kandidat (typisk allerede ute av kandidatsettet, eller en
+ * skrivefeil) – ta med som kontroll på at listen ble tolket som forventet.
  */
 data class ResendVarslerResultatDto(
     val dryRun: Boolean,
     val antallSendt: Int,
-    val saksnumre: List<String>
+    val saksnumre: List<String>,
+    val antallEkskludert: Int = 0,
+    val ikkeFunnetEkskluderte: List<String> = emptyList()
 )
 
 /**

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -729,16 +729,33 @@ class AdminService(
      *
      * [ekskluderteSaksnumre] er en manuell liste fra fagsiden: saker der saksbehandler har verifisert at
      * motparten allerede er mottatt via en annen kanal, og som derfor ikke skal varsles på nytt. Listen
-     * matches på samme nøkkel som responsen bruker (saksnummer, eller skjema-id for saker uten saksnummer).
+     * matches (case-insensitivt, trimmet) på samme nøkkel som responsen bruker – saksnummer, eller
+     * skjema-id for saker uten saksnummer.
+     *
+     * Sendingen kan ikke angres, så en ekte kjøring feiler med [IllegalArgumentException] hvis en oppgitt
+     * verdi ikke traff noen kandidat: da er listen misforstått (skrivefeil, feil felt i bodyen, eller feil
+     * datagrunnlag), og alternativet ville vært å varsle en sak saksbehandler eksplisitt ba oss droppe.
+     * Ved [dryRun] rapporteres avviket i stedet, så listen kan rettes før ekte kjøring.
      */
     fun resendVarsler(dryRun: Boolean, ekskluderteSaksnumre: List<String> = emptyList()): ResendVarslerResultatDto {
         val alleKandidater = finnResendKandidater()
-        val ekskluderte = ekskluderteSaksnumre.map { it.trim() }.filter { it.isNotEmpty() }.toSet()
-        val (utelatt, kandidater) = alleKandidater.partition { it.nøkkel() in ekskluderte }
-        val ikkeFunnet = (ekskluderte - utelatt.map { it.nøkkel() }.toSet()).sorted()
+        // Slås opp normalisert (trimmet + lowercase), men rapporteres tilbake slik kaller skrev det.
+        val oppgitt: Map<String, String> = ekskluderteSaksnumre
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .associateBy { it.lowercase() }
+        val (utelatt, kandidater) = alleKandidater.partition { it.nøkkel().lowercase() in oppgitt }
+        val truffet = utelatt.map { it.nøkkel().lowercase() }.toSet()
+        val ikkeFunnet = (oppgitt - truffet).values.sorted()
         log.info { "Admin: Resend (dryRun=$dryRun) – fant ${alleKandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del), ${utelatt.size} ekskludert manuelt" }
+        advarOmFlertydigeEksklusjoner(utelatt)
         if (ikkeFunnet.isNotEmpty()) {
-            log.warn { "Admin: Resend – ${ikkeFunnet.size} oppgitt(e) saksnummer i eksklusjonslisten traff ingen kandidat: $ikkeFunnet" }
+            // Verdiene selv holdes utenfor loggen (fritekst fra kaller) – de returneres i responsen.
+            val melding = "${ikkeFunnet.size} av ${oppgitt.size} oppgitte verdier i eksklusjonslisten traff ingen kandidat"
+            require(dryRun) {
+                "Resend avbrutt: $melding. Kjør med dryRun=true for å se hvilke (ikkeFunnetEkskluderte), og rett listen."
+            }
+            log.warn { "Admin: Resend (dry-run) – $melding. Se ikkeFunnetEkskluderte i responsen." }
         }
 
         val sendteSaksnumre = mutableListOf<String>()
@@ -758,8 +775,26 @@ class AdminService(
             antallSendt = sendteSaksnumre.size,
             saksnumre = sendteSaksnumre,
             antallEkskludert = utelatt.size,
+            ekskluderte = utelatt.map { it.nøkkel() }.sorted(),
             ikkeFunnetEkskluderte = ikkeFunnet
         )
+    }
+
+    /**
+     * Nøkkelen er ikke unik: samme saksnummer kan ligge på flere handlingspliktige AG-deler (ulike personer
+     * eller perioder på samme sak). Da ekskluderer én oppføring flere kandidater, og noen kan miste varselet
+     * sitt uten at saksbehandler har vurdert dem. Vi stopper ikke kjøringen – over-eksklusjon er den trygge
+     * retningen – men det skal ikke skje ubemerket.
+     */
+    private fun advarOmFlertydigeEksklusjoner(utelatt: List<ResendKandidat>) {
+        utelatt.groupBy { it.nøkkel().lowercase() }
+            .filter { (_, kandidater) -> kandidater.size > 1 }
+            .forEach { (_, kandidater) ->
+                log.warn {
+                    "Admin: Resend – én oppføring i eksklusjonslisten traff ${kandidater.size} kandidater " +
+                        "(skjema ${kandidater.map { it.skjemaId }}). Alle er utelatt; verifiser at det er ønsket."
+                }
+            }
     }
 
     /** Finner resend-kandidatene med skjema-id og saksnummer (se [resendVarsler] for kriteriene). */

--- a/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/AdminService.kt
@@ -46,7 +46,10 @@ private val OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 data class ResendKandidat(
     val skjemaId: UUID,
     val saksnummer: String?
-)
+) {
+    /** Identifikatoren kandidaten kjennes på utad (rapportering og eksklusjon): saksnummer, ellers skjema-id. */
+    fun nøkkel(): String = saksnummer ?: skjemaId.toString()
+}
 
 /**
  * Administrative operasjoner som eksponeres via [no.nav.melosys.skjema.controller.admin.AdminController]
@@ -723,24 +726,40 @@ class AdminService(
      * hopper over arbeidstakere med påbegynt utkast. Sendingen skjer utenfor lese-transaksjonen (jf.
      * [retryAlleFeilede]) så vi ikke holder en DB-connection åpen gjennom Kafka-sendingen. Returnerer antall
      * sendte varsler og saksnumrene som faktisk fikk et nytt varsel (for sporbarhet på fagsiden).
+     *
+     * [ekskluderteSaksnumre] er en manuell liste fra fagsiden: saker der saksbehandler har verifisert at
+     * motparten allerede er mottatt via en annen kanal, og som derfor ikke skal varsles på nytt. Listen
+     * matches på samme nøkkel som responsen bruker (saksnummer, eller skjema-id for saker uten saksnummer).
      */
-    fun resendVarsler(dryRun: Boolean): ResendVarslerResultatDto {
-        val kandidater = finnResendKandidater()
-        log.info { "Admin: Resend (dryRun=$dryRun) – fant ${kandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del)" }
+    fun resendVarsler(dryRun: Boolean, ekskluderteSaksnumre: List<String> = emptyList()): ResendVarslerResultatDto {
+        val alleKandidater = finnResendKandidater()
+        val ekskluderte = ekskluderteSaksnumre.map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        val (utelatt, kandidater) = alleKandidater.partition { it.nøkkel() in ekskluderte }
+        val ikkeFunnet = (ekskluderte - utelatt.map { it.nøkkel() }.toSet()).sorted()
+        log.info { "Admin: Resend (dryRun=$dryRun) – fant ${alleKandidater.size} kandidat(er) (handlingspliktig AG-del før $VARSEL_LENKE_FIKSET_TIDSPUNKT som venter på AT-del), ${utelatt.size} ekskludert manuelt" }
+        if (ikkeFunnet.isNotEmpty()) {
+            log.warn { "Admin: Resend – ${ikkeFunnet.size} oppgitt(e) saksnummer i eksklusjonslisten traff ingen kandidat: $ikkeFunnet" }
+        }
 
         val sendteSaksnumre = mutableListOf<String>()
         kandidater.forEach { kandidat ->
             try {
                 if (arbeidstakerVarslingService.resendVarselTilArbeidstaker(kandidat.skjemaId, dryRun)) {
                     // Saker uten saksnummer representeres med skjema-id-en, så ingen sending blir usynlig.
-                    sendteSaksnumre += kandidat.saksnummer ?: kandidat.skjemaId.toString()
+                    sendteSaksnumre += kandidat.nøkkel()
                 }
             } catch (e: Exception) {
                 log.error(e) { "Admin: Resend feilet for skjema ${kandidat.skjemaId}" }
             }
         }
         log.info { "Admin: Resend ferdig (dryRun=$dryRun) – ${sendteSaksnumre.size} varsler ${if (dryRun) "ville blitt sendt" else "sendt"}" }
-        return ResendVarslerResultatDto(dryRun = dryRun, antallSendt = sendteSaksnumre.size, saksnumre = sendteSaksnumre)
+        return ResendVarslerResultatDto(
+            dryRun = dryRun,
+            antallSendt = sendteSaksnumre.size,
+            saksnumre = sendteSaksnumre,
+            antallEkskludert = utelatt.size,
+            ikkeFunnetEkskluderte = ikkeFunnet
+        )
     }
 
     /** Finner resend-kandidatene med skjema-id og saksnummer (se [resendVarsler] for kriteriene). */

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.skjema.controller.admin
 
 import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -1372,29 +1373,108 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
             lagInnsendtDel(Skjemadel.ARBEIDSTAKERS_DEL, Representasjonstype.DEG_SELV, fnr, periode, foerCutoff, juridiskEnhet)
 
-        private fun resend(dryRun: Boolean = false, ekskluderteSaksnumre: List<String>? = null): ResendVarslerResultatDto {
+        private fun resend(dryRun: Boolean = false, ekskluderteSaksnumre: List<String>? = null): ResendVarslerResultatDto =
+            resendRespons(dryRun, ekskluderteSaksnumre)
+                .expectStatus().isOk
+                .expectBody<ResendVarslerResultatDto>()
+                .returnResult().responseBody.shouldNotBeNull()
+
+        private fun resendRespons(dryRun: Boolean = false, ekskluderteSaksnumre: List<String>? = null): WebTestClient.ResponseSpec {
             val request = adminClient.post().uri("/admin/varsler/resend?dryRun=$dryRun")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
             val medBody = ekskluderteSaksnumre?.let { request.bodyValue(ResendVarslerRequestDto(it)) } ?: request
             return medBody.exchange()
-                .expectStatus().isOk
-                .expectBody<ResendVarslerResultatDto>()
-                .returnResult().responseBody.shouldNotBeNull()
         }
 
         @Test
-        fun `skal hoppe over saker i eksklusjonslisten og rapportere ukjente saksnumre`() {
+        fun `skal hoppe over saker i eksklusjonslisten, uavhengig av whitespace og store bokstaver`() {
             lagAgDel(fnr = "10000000040", saksnummer = "SAK-EKSKLUDERT")
             lagAgDel(fnr = "10000000041", saksnummer = "SAK-BEHOLDES")
 
-            val resultat = resend(ekskluderteSaksnumre = listOf("  SAK-EKSKLUDERT  ", "", "SAK-FINNES-IKKE"))
+            val resultat = resend(ekskluderteSaksnumre = listOf("  sak-Ekskludert  "))
 
             resultat.antallSendt shouldBe 1
             resultat.saksnumre shouldBe listOf("SAK-BEHOLDES")
             resultat.antallEkskludert shouldBe 1
-            resultat.ikkeFunnetEkskluderte shouldBe listOf("SAK-FINNES-IKKE")
+            resultat.ekskluderte shouldBe listOf("SAK-EKSKLUDERT")
+            resultat.ikkeFunnetEkskluderte.shouldBeEmpty()
             verify(exactly = 1) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `dry-run skal rapportere verdier som ikke traff noen kandidat, uten aa sende noe`() {
+            lagAgDel(fnr = "10000000042", saksnummer = "SAK-EKSKLUDERT")
+            lagAgDel(fnr = "10000000043", saksnummer = "SAK-BEHOLDES")
+
+            // Duplikat i lista skal telles én gang, ikke rapporteres som ikke-funnet
+            val resultat = resend(dryRun = true, ekskluderteSaksnumre = listOf("SAK-EKSKLUDERT", "SAK-EKSKLUDERT", "SAK-FINNES-IKKE"))
+
+            resultat.dryRun shouldBe true
+            resultat.antallSendt shouldBe 1
+            resultat.saksnumre shouldBe listOf("SAK-BEHOLDES")
+            resultat.antallEkskludert shouldBe 1
+            resultat.ikkeFunnetEkskluderte shouldBe listOf("SAK-FINNES-IKKE")
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `ekte kjoering skal avvises naar en oppgitt verdi ikke traff noen kandidat`() {
+            lagAgDel(fnr = "10000000044", saksnummer = "SAK-BEHOLDES")
+
+            resendRespons(dryRun = false, ekskluderteSaksnumre = listOf("SAK-FINNES-IKKE")).expectStatus().isBadRequest
+
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        @Test
+        fun `skal kunne ekskludere sak uten saksnummer via skjema-id`() {
+            val utenSaksnummer = lagAgDel(fnr = "10000000045")
+            lagAgDel(fnr = "10000000046", saksnummer = "SAK-BEHOLDES")
+
+            val resultat = resend(ekskluderteSaksnumre = listOf(utenSaksnummer.id.toString().uppercase()))
+
+            resultat.saksnumre shouldBe listOf("SAK-BEHOLDES")
+            resultat.ekskluderte shouldBe listOf(utenSaksnummer.id.toString())
+            resultat.ikkeFunnetEkskluderte.shouldBeEmpty()
+        }
+
+        @Test
+        fun `en oppfoering skal ekskludere alle kandidater med samme saksnummer`() {
+            lagAgDel(fnr = "10000000047", saksnummer = "SAK-DELT")
+            lagAgDel(fnr = "10000000048", saksnummer = "SAK-DELT")
+
+            val resultat = resend(ekskluderteSaksnumre = listOf("SAK-DELT"))
+
+            // antallEkskludert teller KANDIDATER, ikke listeoppføringer – her 2 fra én oppføring
+            resultat.antallEkskludert shouldBe 2
+            resultat.antallSendt shouldBe 0
+            resultat.ikkeFunnetEkskluderte.shouldBeEmpty()
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
+
+        /** Rå JSON-body, for tilfeller der [ResendVarslerRequestDto] ikke lar seg konstruere klientside. */
+        private fun resendRaaBody(json: String, dryRun: Boolean = false): WebTestClient.ResponseSpec =
+            adminClient.post().uri("/admin/varsler/resend?dryRun=$dryRun")
+                .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(json)
+                .exchange()
+
+        @Test
+        fun `skal avvise tom eller ugyldig eksklusjonsliste, slik at feilstavet felt ikke gir full utsending`() {
+            lagAgDel(fnr = "10000000049", saksnummer = "SAK-BEHOLDES")
+
+            // Tom liste = trolig feilstavet feltnavn (ukjente felt ignoreres av Jackson-oppsettet)
+            resendRespons(ekskluderteSaksnumre = emptyList()).expectStatus().isBadRequest
+            resendRaaBody("""{"ekskluderteSaksnummer": ["SAK-BEHOLDES"]}""").expectStatus().isBadRequest
+            // Blanke, for lange og null-verdier er ikke gyldige saksnumre – og skal ikke gi 500
+            resendRaaBody("""{"ekskluderteSaksnumre": ["   "]}""").expectStatus().isBadRequest
+            resendRaaBody("""{"ekskluderteSaksnumre": ["${"S".repeat(100)}"]}""").expectStatus().isBadRequest
+            resendRaaBody("""{"ekskluderteSaksnumre": ["SAK-BEHOLDES", null]}""").expectStatus().isBadRequest
+
+            verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
         }
 
         @Test

--- a/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/controller/admin/AdminControllerIntegrationTest.kt
@@ -1372,14 +1372,30 @@ class AdminControllerIntegrationTest : ApiTestBase() {
         private fun lagAtDel(fnr: String, periode: PeriodeDto = periodeA, juridiskEnhet: String = korrektSyntetiskOrgnr): Skjema =
             lagInnsendtDel(Skjemadel.ARBEIDSTAKERS_DEL, Representasjonstype.DEG_SELV, fnr, periode, foerCutoff, juridiskEnhet)
 
-        private fun resend(dryRun: Boolean = false): ResendVarslerResultatDto =
-            adminClient.post().uri("/admin/varsler/resend?dryRun=$dryRun")
+        private fun resend(dryRun: Boolean = false, ekskluderteSaksnumre: List<String>? = null): ResendVarslerResultatDto {
+            val request = adminClient.post().uri("/admin/varsler/resend?dryRun=$dryRun")
                 .header("Authorization", "Bearer ${mockOAuth2Server.adminTokenMedTilgang()}")
                 .accept(MediaType.APPLICATION_JSON)
-                .exchange()
+            val medBody = ekskluderteSaksnumre?.let { request.bodyValue(ResendVarslerRequestDto(it)) } ?: request
+            return medBody.exchange()
                 .expectStatus().isOk
                 .expectBody<ResendVarslerResultatDto>()
                 .returnResult().responseBody.shouldNotBeNull()
+        }
+
+        @Test
+        fun `skal hoppe over saker i eksklusjonslisten og rapportere ukjente saksnumre`() {
+            lagAgDel(fnr = "10000000040", saksnummer = "SAK-EKSKLUDERT")
+            lagAgDel(fnr = "10000000041", saksnummer = "SAK-BEHOLDES")
+
+            val resultat = resend(ekskluderteSaksnumre = listOf("  SAK-EKSKLUDERT  ", "", "SAK-FINNES-IKKE"))
+
+            resultat.antallSendt shouldBe 1
+            resultat.saksnumre shouldBe listOf("SAK-BEHOLDES")
+            resultat.antallEkskludert shouldBe 1
+            resultat.ikkeFunnetEkskluderte shouldBe listOf("SAK-FINNES-IKKE")
+            verify(exactly = 1) { brukervarselProducer.sendBrukervarsel(any()) }
+        }
 
         @Test
         fun `dry-run teller kandidatene uten aa sende noe, og er default`() {


### PR DESCRIPTION
## Hva
`POST /admin/varsler/resend` tar nå en valgfri request-body med `ekskluderteSaksnumre`. Kandidatene i listen hoppes over.

## Hvorfor
En saksbehandler har gått gjennom alle aktive saker uten motpart manuelt i produksjon, og sett at motparten for mange av dem allerede er mottatt via en annen kanal. Disse skal ikke varsles på nytt.

## Detaljer
- Body er valgfri, så eksisterende kall uten body fungerer som før.
- Listen matches på samme nøkkel som responsen bruker (`ResendKandidat.nøkkel()`): saksnummer, eller skjema-id for saker uten saksnummer. Da kan også saker uten saksnummer ekskluderes. Matchingen trimmer og er ikke case-sensitiv.
- Responsen er utvidet med `ekskluderte`, `antallEkskludert` og `ikkeFunnetEkskluderte`.

## Fail-loud (etter kodegjennomgang)
Sendingen er irreversibel og listen er manuelt sammensatt, så de stille feilmodusene er lukket:
- **Feilstavet feltnavn** ga før tom liste og full utsending med 200 OK (ukjente felt ignoreres av Jackson-oppsettet vårt). Nå avvises en body med tom liste med 400.
- **Verdi som ikke traff** (skrivefeil, case-mismatch) ble før bare logget, mens saken ble varslet likevel. Nå avvises `dryRun=false` med 400; ved dry-run rapporteres avviket i `ikkeFunnetEkskluderte` så listen kan rettes først.
- **Én oppføring som treffer flere kandidater** (samme saksnummer på flere handlingspliktige AG-deler) logges som warning. Over-eksklusjon er den trygge retningen, så kjøringen stoppes ikke, men det skjer ikke ubemerket.
- **Input valideres** (antall, blanke, for lange og null-verdier), og ikke-funnede verdier logges kun som antall – fritekst fra kaller skal ikke persisteres i Kibana.

## Bruk
```
POST /admin/varsler/resend?dryRun=true
Content-Type: application/json
{ "ekskluderteSaksnumre": ["SAK-1", "SAK-2"] }
```
Kjør dry-run først og verifiser `ekskluderte` mot din egen liste og at `ikkeFunnetEkskluderte` er tom, før `dryRun=false`.

## Test
Integrasjonstester dekker eksklusjon (whitespace/case), dry-run med ikke-funnede verdier, 400 ved ekte kjøring med ikke-funnet verdi, eksklusjon via skjema-id, duplikater, én oppføring som treffer flere kandidater, og avvisning av tom/ugyldig/feilstavet body. Full `./gradlew clean build` er grønn.