### PR TITLE
MELOSYS-8209 Ikke varsle arbeidstaker som allerede har sendt inn sin del

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingService.kt
@@ -68,6 +68,11 @@ class ArbeidstakerVarslingService(
     }
 
     private fun varsleUtenFullmakt(fnr: String, orgnr: String, metadata: UtsendtArbeidstakerMetadata) {
+        if (metadata.kobletSkjemaId != null) {
+            log.info { "Arbeidstaker har allerede sendt inn sin del (koblet motpart), sender ikke varsel" }
+            return
+        }
+
         if (harEksisterendeArbeidstakerUtkast(fnr, metadata.juridiskEnhetOrgnr)) {
             log.info { "Arbeidstaker har eksisterende utkast, sender ikke varsel" }
             return

--- a/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/skjema/service/ArbeidstakerVarslingServiceTest.kt
@@ -85,6 +85,44 @@ class ArbeidstakerVarslingServiceTest {
     }
 
     @Test
+    fun `AG uten fullmakt der AT allerede har sendt inn sin del skal IKKE sende varsel`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.ARBEIDSGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+                kobletSkjemaId = UUID.randomUUID()
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns emptyList()
+
+        service.varsleArbeidstakerHvisAktuelt(skjema.id!!)
+
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
+    fun `Radgiver uten fullmakt der AT allerede har sendt inn sin del skal IKKE sende varsel`() {
+        val skjema = skjemaMedDefaultVerdier(
+            id = UUID.randomUUID(),
+            status = SkjemaStatus.SENDT,
+            metadata = utsendtArbeidstakerMetadataMedDefaultVerdier(
+                representasjonstype = Representasjonstype.RADGIVER,
+                skjemadel = Skjemadel.ARBEIDSGIVERS_DEL,
+                kobletSkjemaId = UUID.randomUUID()
+            )
+        )
+        every { skjemaRepository.findById(skjema.id!!) } returns Optional.of(skjema)
+        every { skjemaRepository.findByFnrAndTypeAndStatus(any(), any(), any()) } returns emptyList()
+
+        service.varsleArbeidstakerHvisAktuelt(skjema.id!!)
+
+        verify(exactly = 0) { brukervarselProducer.sendBrukervarsel(any()) }
+    }
+
+    @Test
     fun `Radgiver uten fullmakt og ingen AT-utkast skal sende varsel med link`() {
         val skjema = skjemaMedDefaultVerdier(
             id = UUID.randomUUID(),


### PR DESCRIPTION
## Problem

Når arbeidsgiver (eller rådgiver) uten fullmakt sendte inn sin del, fikk arbeidstaker et varsel om at de måtte sende inn sin del — også når arbeidstaker allerede hadde sendt inn.

Guarden i `ArbeidstakerVarslingService` sjekket kun etter et eksisterende **UTKAST** av arbeidstakers del. Når arbeidstaker sender inn, settes skjemaet til `SENDT`, og utkastet forsvinner fra spørringen — guarden slo derfor aldri til.

## Løsning

Legger til en sjekk på `metadata.kobletSkjemaId`. Motpart-koblingen utføres i `UtsendtArbeidstakerSkjemaKoblingService.finnOgKobl` i samme transaksjon som innsendingen, før varslingen kjører (varslingen trigges etter commit via `InnsendingOpprettetEvent`). Er skjemaet koblet til en motpart, har arbeidstaker allerede sendt inn sin del, og varselet droppes.

Dette gjenbruker koblingslogikkens kriterier (samme fnr, samme juridiske enhet, motsatt skjemadel, overlappende periode) i stedet for å duplisere dem i varslingen.

## Tester

To nye tester som dekker arbeidsgiver og rådgiver uten fullmakt der arbeidstakers del allerede er sendt inn.