### PR TITLE
NOJIRA: Grupper minor og patch dependabot-oppdateringer for gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7


### PR DESCRIPTION
Konfigurerer dependabot til å samle minor- og patch-oppdateringer for gradle i én felles PR, i stedet for separate PRer per avhengighet.