### PR TITLE
NOJIRA: Kun kjør tester når relevante filer endres

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,13 @@
 name: Gradle Test
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'src/**'
+      - '.github/*/pull-request.yaml'
+      - '*gradle*'
+      - 'melosys-skjema-api-types/**'
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
Legger til path-filter på pull-request workflow slik at tester kun kjøres når relevante filer endres (src, gradle, types).