### PR TITLE
Vis alle endepunkter i Swagger UI

### DIFF
--- a/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/melosys/skjema/config/SwaggerConfig.kt
@@ -27,6 +27,13 @@ class SwaggerConfig {
      * /v3/api-docs er uendret og brukes fortsatt til frontend-typegenerering.
      */
     @Bean
+    fun allApi(): GroupedOpenApi = GroupedOpenApi.builder()
+        .group("all")
+        .displayName("Alle endepunkter")
+        .pathsToMatch("/**")
+        .build()
+
+    @Bean
     fun adminApi(): GroupedOpenApi = GroupedOpenApi.builder()
         .group("admin")
         .displayName("Melosys Skjema Admin API")


### PR DESCRIPTION
Legger til en «Alle endepunkter»-gruppe i Swagger UI slik at alle ruter vises, ikke bare admin.

Swagger UI viste kun admin-gruppen fordi det var den eneste GroupedOpenApi-beanen.
Uten en eksplisitt «all»-gruppe ble øvrige controllere usynlige i dropdown-menyen.

- Ny `allApi()` GroupedOpenApi-bean som matcher `/**`